### PR TITLE
Fix MAXFIL overflow, fluidsynth warning, non-Latin font filter

### DIFF
--- a/linux/fluidsynthplug.c
+++ b/linux/fluidsynthplug.c
@@ -265,6 +265,8 @@ static void fluidsynth_plug_init()
         devtbl[i]->synth = new_fluid_synth(devtbl[i]->settings);
         /* create the audio driver as alsa type */
         fluid_settings_setstr(devtbl[i]->settings, "audio.driver", "alsa");
+        /* disable realtime priority to suppress warning when not running as root */
+        fluid_settings_setint(devtbl[i]->settings, "audio.realtime-prio", 0);
         devtbl[i]->adriver = new_fluid_audio_driver(devtbl[i]->settings, devtbl[i]->synth);
         /* load a SoundFont and reset presets */
         devtbl[i]->sfont_id = fluid_synth_sfload(devtbl[i]->synth, "/usr/share/sounds/sf2/FluidR3_GM.sf2", 1);

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -174,7 +174,7 @@ static enum { /* debug levels */
 #define MAXTAB 50  /* total number of tabs possible per screen */
 #define MAXPIC 50  /* total number of loadable pictures */
 #define MAXLIN 250 /* maximum length of input bufferred line */
-#define MAXFIL 100 /* maximum open files */
+#define MAXFIL 1000 /* maximum open files */
 #define MINJST 1   /* minimum pixels for space in justification */
 #define MAXFNM 250 /* number of filename characters in buffer */
 #define MAXJOY 10  /* number of joysticks possible */
@@ -2662,13 +2662,14 @@ void getfonts(void)
     FcChar8*     fcfile;
     int          fcweight, fcslant, fcwidth, fcspacing, fcindex;
     FcBool       fcscalable;
+    FcCharSet*   fccs;
 
     /* query fontconfig for all scalable fonts */
     pat = FcPatternCreate();
     FcPatternAddBool(pat, FC_SCALABLE, FcTrue);
     os = FcObjectSetBuild(FC_FAMILY, FC_FOUNDRY, FC_STYLE, FC_WEIGHT,
                           FC_SLANT, FC_WIDTH, FC_SPACING, FC_FILE, FC_INDEX,
-                          NULL);
+                          FC_CHARSET, NULL);
     fs = FcFontList(NULL, pat, os);
     FcObjectSetDestroy(os);
     FcPatternDestroy(pat);
@@ -2685,6 +2686,14 @@ void getfonts(void)
             continue;
         if (FcPatternGetString(font, FC_FILE, 0, &fcfile) != FcResultMatch)
             continue;
+
+        /* skip fonts that don't cover basic Latin (A-Z, a-z) */
+        if (FcPatternGetCharSet(font, FC_CHARSET, 0, &fccs) == FcResultMatch) {
+
+            if (!FcCharSetHasChar(fccs, 'A') || !FcCharSetHasChar(fccs, 'z'))
+                continue;
+
+        }
 
         /* get foundry, default to empty */
         if (FcPatternGetString(font, FC_FOUNDRY, 0, &fcfoundry) != FcResultMatch)

--- a/linux/network.c
+++ b/linux/network.c
@@ -99,7 +99,7 @@
 #define NOCANCEL /* include nocancel overrides */
 #endif
 
-#define MAXFIL 100 /* maximum number of open files */
+#define MAXFIL 1000 /* maximum number of open files */
 #define COOKIE_SECRET_LENGTH 16 /* length of secret cookie */
 #define CVBUFSIZ 4096 /* certificate value buffer size */
 

--- a/tests/graphics_test.c
+++ b/tests/graphics_test.c
@@ -332,7 +332,7 @@ static void waitnext(void)
     ami_title(stdout, titlebuf);
 
     /* capture test screens */
-    /* screen_capture(); */
+    screen_capture();
 
     do { ami_event(stdin, &er); }
     while (er.etype != ami_etenter && er.etype != ami_etterm);

--- a/tests/graphics_test.c
+++ b/tests/graphics_test.c
@@ -332,7 +332,7 @@ static void waitnext(void)
     ami_title(stdout, titlebuf);
 
     /* capture test screens */
-    screen_capture();
+    /* screen_capture(); */
 
     do { ami_event(stdin, &er); }
     while (er.etype != ami_etenter && er.etype != ami_etterm);


### PR DESCRIPTION
## Summary
- Increase `MAXFIL` from 100 to 1000 in `linux/graphics.c` and `linux/network.c` — X11 + fontconfig initialization consumes 100+ file descriptors, causing "Invalid file number" errors at startup
- Suppress fluidsynth "Failed to set thread to high priority" warning by disabling realtime priority (requires root, not needed for playback)
- Filter out script-specific fonts (e.g. Noto Sans Khojki) that lack basic Latin glyphs — these rendered as `.notdef` boxes when displaying ASCII text

## Test plan
- [ ] `make clean && make` builds without errors
- [ ] `bin/graphics_test` starts without "Invalid file number" error
- [ ] No "Failed to set thread to high priority" warning on startup
- [ ] Font list in graphics_test shows only fonts with Latin character support
- [ ] All graphical programs (backgammon, clock, etc.) launch cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)