### PR TITLE
Fix linespace, iauto grid check, exit crash, and mouse test state

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -6470,9 +6470,11 @@ static void iauto(winptr win, int e)
     /* check we are transitioning to auto mode */
     if (e) {
 
-        /* check display is on grid and in bounds */
-        if (sc->curxg-1%win->charspace) error(eatoofg);
-        if (sc->curxg-1%win->charspace) error(eatoofg);
+        /* check display is on grid and in bounds. Note: parentheses are
+           required because % binds tighter than -. The cursor graphical
+           position must land on a character cell boundary for x and y. */
+        if ((sc->curxg-1) % win->charspace) error(eatoofg);
+        if ((sc->curyg-1) % win->linespace) error(eatoofg);
         if (sc->angle != INT_MAX/4) error(eatoang);
         if (!icurbnd(sc)) error(eatoecb);
 
@@ -16126,6 +16128,14 @@ static void ami_deinit_graphics()
     int    fn;
 
     ami_evtrec er;
+    ami_evtcod e; /* event index */
+
+    /* Reset all event vectors back to the default handler. The client program
+       may have installed overrides (e.g. longjmp-based terminate handlers)
+       that are no longer safe to call now that main() has returned — the
+       stack frame they longjmp into is gone. */
+    evtshan = defaultevent;
+    for (e = ami_etchar; e <= ami_ettabbar; e++) evthan[e] = defaultevent;
 
     /* try to get window from stdout */
     win = NULL; /* set no window */

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -3078,7 +3078,20 @@ void setfnt(winptr win)
 
     /* extract metrics */
     win->charspace = (int)(win->ftface->size->metrics.max_advance >> 6);
-    win->linespace = win->gfhigh;
+    {
+        /* Line height must accommodate the full font: ascender + descender.
+           If we use only gfhigh, tall glyphs can extend above the cell and
+           leave trails when cells are overwritten. */
+        int ascender  = (int)(win->ftface->size->metrics.ascender  >> 6);
+        int descender = (int)(win->ftface->size->metrics.descender >> 6);
+        if (descender < 0) descender = -descender;
+        int line_h    = (int)(win->ftface->size->metrics.height >> 6);
+        int full_h    = ascender + descender;
+        /* take the larger of the font's declared line height and
+           ascender+descender to be safe against clipping */
+        win->linespace = line_h > full_h ? line_h : full_h;
+        if (win->linespace < win->gfhigh) win->linespace = win->gfhigh;
+    }
     win->chrspcx = 0;
     win->chrspcy = 0;
     win->baseoff = (int)(win->ftface->size->metrics.ascender >> 6);

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -1520,6 +1520,8 @@ int main(int argc, char *argv[])
 
     if (ami_mouse(stdin) > 0) {  /* mouse test */
 
+        x = 1;
+        y = 1;
         printf("\f");
         ami_auto(stdout, FALSE);
         ami_curvis(stdout, FALSE);
@@ -1564,6 +1566,7 @@ int main(int argc, char *argv[])
             }
 
         } while (er.etype != ami_etenter);
+        ami_home(stdout);
         ami_auto(stdout, TRUE);
         ami_curvis(stdout, TRUE);
 


### PR DESCRIPTION
## Summary

Four related fixes, bundled since they were all uncovered while chasing the same `terminal_testg` mouse test failure.

### 1. `linespace` font-height fix (original PR content)

When text is overwritten (e.g. `\r` then spaces), small fragments of the previous text remained at the top/bottom of characters on screen. The cause was `linespace` being set to `gfhigh` (the requested pixel size) while glyphs could actually extend beyond that height.

`drwchr90` clears each character cell with `XFillRectangle(..., cs, win->linespace)`. If `linespace` is smaller than the glyph's actual vertical footprint, the fill doesn't cover everything the old glyph drew. Fix: set `linespace` to the larger of the font's declared line height, ascender+|descender|, and `gfhigh`.

### 2. `iauto()` grid-check operator precedence

The on-grid test was:
```c
if (sc->curxg-1%win->charspace) error(eatoofg);
if (sc->curxg-1%win->charspace) error(eatoofg);
```
which parses as `curxg - (1 % charspace)` = `curxg - 1`, so the check tripped almost always. Also the line was duplicated; one of them should be the Y check. Fixed to:
```c
if ((sc->curxg-1) % win->charspace) error(eatoofg);
if ((sc->curyg-1) % win->linespace) error(eatoofg);
```

### 3. `ami_deinit_graphics` exit crash

`terminal_testg` segfaulted on exit. Root cause: `tests/terminal_test.c` installs a `termevent` handler that does `longjmp(terminate_buf, 1)` back into `main`. When libc runs destructors, `ami_deinit_graphics` enters its autohold wait loop; any `etterm` delivered there still dispatches through `evthan[ami_etterm] = termevent`, and the longjmp target — `main`'s stack frame — is gone. Undefined behavior, crash.

Fix: at the top of `ami_deinit_graphics`, reset `evtshan` and every `evthan[]` slot back to `defaultevent`. Any client-installed override is now invisible during teardown. This protects all Petit-Ami programs, not just this one test.

### 4. `terminal_test.c` mouse test state

Two small issues in the mouse test block, both only exposed once fix #2 made the grid check actually work:
- `x` and `y` were uninitialized on entry
- after the mouse loop exits, the cursor is left off the character grid, so `ami_auto(stdout, TRUE)` tripped the (now-working) grid check

Fix: initialize `x = y = 1` on entry and call `ami_home(stdout)` before re-enabling auto mode.

## Test plan
- [x] `terminal_testg` runs all pages to completion without the "Cannot reenable auto outside screen" error
- [x] `terminal_testg` exits cleanly (no segfault) after the Finished window is closed
- [x] Text overwrite (`\r` + blank) leaves no fragment trails
- [x] `graphics_test` text rendering unchanged
