### PR TITLE
Add screen_capture to terminal_testg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1097,8 +1097,13 @@ genwaveg: $(GLIBSD) sound_programs/genwave.c
 terminal_test: $(CLIBSD) tests/terminal_test.c
 	$(CC) $(CFLAGS) tests/terminal_test.c $(CLIBS) -o bin/terminal_test
 
-terminal_testg: $(GLIBSD) tests/terminal_test.c
-	$(CC) $(CFLAGS) tests/terminal_test.c $(GLIBS) -o bin/terminal_testg
+ifeq ($(OSTYPE),Darwin)
+terminal_testg: $(GLIBSD) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(GLIBS) -o bin/terminal_testg
+else
+terminal_testg: $(GLIBSD) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(GLIBS) -lpng -lz -o bin/terminal_testg
+endif
 	
 #
 # Test graph model compliant output

--- a/Makefile
+++ b/Makefile
@@ -1094,8 +1094,13 @@ genwaveg: $(GLIBSD) sound_programs/genwave.c
 #
 # Test console model compliant output
 #	
-terminal_test: $(CLIBSD) tests/terminal_test.c
-	$(CC) $(CFLAGS) tests/terminal_test.c $(CLIBS) -o bin/terminal_test
+ifeq ($(OSTYPE),Darwin)
+terminal_test: $(CLIBSD) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(CLIBS) -o bin/terminal_test
+else
+terminal_test: $(CLIBSD) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(CLIBS) -lX11 -lpng -lz -o bin/terminal_test
+endif
 
 ifeq ($(OSTYPE),Darwin)
 terminal_testg: $(GLIBSD) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)

--- a/linux/screen_capture.c
+++ b/linux/screen_capture.c
@@ -233,9 +233,10 @@ void screen_capture(void) {
 
     /* Flush Petit-Ami's Xlib output buffer FIRST (its display is a separate
        connection from ours, so our XSync can't do it). Then XSync ours to
-       make sure the grab doesn't race the server. */
-    extern void pa_xflush(void);
-    pa_xflush();
+       make sure the grab doesn't race the server. pa_xflush lives in
+       graphics.c; weak link so the terminal build (no graphics.c) is a no-op. */
+    extern void pa_xflush(void) __attribute__((weak));
+    if (pa_xflush) pa_xflush();
     XSync(cap_display, False);
 
     XWindowAttributes a;

--- a/linux/screen_capture.c
+++ b/linux/screen_capture.c
@@ -78,34 +78,54 @@ static int window_pid_matches(Display *d, Window w, pid_t our_pid) {
 /*
  * Locate the Petit-Ami window on this display. Strategy:
  *   1. Walk _NET_CLIENT_LIST, return first window with _NET_WM_PID == getpid().
- *   2. If nothing matches, walk root's direct children and return the largest
+ *   2. Query _NET_ACTIVE_WINDOW — the currently focused window. In terminal
+ *      mode the test program is interactive, so its terminal emulator window
+ *      will be focused when screen_capture() is called.
+ *   3. If nothing matches, walk root's direct children and return the largest
  *      mapped InputOutput window.
  * Returns 0 if nothing found.
  */
 static Window find_pa_window(Display *d) {
     Window root = DefaultRootWindow(d);
     pid_t  our_pid = getpid();
+    Atom actual_type;
+    int actual_format;
+    unsigned long nitems, bytes_after;
+    unsigned char *prop = NULL;
 
+    /* pass 1: match by PID (graphics mode — we own the window) */
     Atom client_list = XInternAtom(d, "_NET_CLIENT_LIST", True);
-    if (client_list != None) {
-        Atom actual_type;
-        int actual_format;
-        unsigned long nitems, bytes_after;
-        unsigned char *prop = NULL;
-        if (XGetWindowProperty(d, root, client_list, 0, 4096, False,
+    if (client_list != None &&
+        XGetWindowProperty(d, root, client_list, 0, 4096, False,
+                           XA_WINDOW, &actual_type, &actual_format,
+                           &nitems, &bytes_after, &prop) == Success
+        && prop != NULL) {
+        Window *wlist = (Window *)prop;
+        for (unsigned long i = 0; i < nitems; i++) {
+            if (window_pid_matches(d, wlist[i], our_pid) == 1) {
+                Window found = wlist[i];
+                XFree(prop);
+                return found;
+            }
+        }
+        XFree(prop);
+    }
+
+    /* pass 2: grab the currently focused window (terminal mode — the terminal
+       emulator owns the window, but it has focus because the user is
+       interacting with our test program) */
+    Atom active_win = XInternAtom(d, "_NET_ACTIVE_WINDOW", True);
+    if (active_win != None) {
+        prop = NULL;
+        if (XGetWindowProperty(d, root, active_win, 0, 1, False,
                                XA_WINDOW, &actual_type, &actual_format,
                                &nitems, &bytes_after, &prop) == Success
-            && prop != NULL) {
-            Window *wlist = (Window *)prop;
-            for (unsigned long i = 0; i < nitems; i++) {
-                if (window_pid_matches(d, wlist[i], our_pid) == 1) {
-                    Window found = wlist[i];
-                    XFree(prop);
-                    return found;
-                }
-            }
+            && prop != NULL && nitems == 1) {
+            Window found = *(Window *)prop;
             XFree(prop);
+            if (found) return found;
         }
+        if (prop) XFree(prop);
     }
 
     /* fallback: scan root children for a large mapped IO window */

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -197,7 +197,10 @@ static void waittime(int n, int t)
 }
 
 
-extern void screen_capture(void);
+/* screen_capture is linked in the graphics build (terminal_testg) but not the
+   plain terminal build (terminal_test). Provide a weak stub so the terminal
+   build links cleanly; the real screen_capture.o overrides it. */
+void __attribute__((weak)) screen_capture(void) { }
 
 /* wait return to be pressed, or handle terminate */
 static void waitnext(void)

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -197,11 +197,15 @@ static void waittime(int n, int t)
 }
 
 
+extern void screen_capture(void);
+
 /* wait return to be pressed, or handle terminate */
 static void waitnext(void)
 {
 
     ami_evtrec er; /* event record */
+
+    screen_capture();
 
     do { ami_event(stdin, &er);
     } while (er.etype != ami_etenter);

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -197,10 +197,7 @@ static void waittime(int n, int t)
 }
 
 
-/* screen_capture is linked in the graphics build (terminal_testg) but not the
-   plain terminal build (terminal_test). Provide a weak stub so the terminal
-   build links cleanly; the real screen_capture.o overrides it. */
-void __attribute__((weak)) screen_capture(void) { }
+extern void screen_capture(void);
 
 /* wait return to be pressed, or handle terminate */
 static void waitnext(void)


### PR DESCRIPTION
## Summary
- Call `screen_capture()` in `waitnext()` so each test page is captured to `test_images`, matching what `graphics_test` already does
- Link `screen_capture.o` and `-lX11 -lpng -lz` into both `terminal_test` and `terminal_testg` Makefile targets
- Make `pa_xflush` a weak extern in `screen_capture.c` so the terminal build (no `graphics.c`) links cleanly
- Fix window discovery for terminal mode: add `_NET_ACTIVE_WINDOW` pass so screen_capture grabs the focused terminal window instead of the largest window (which was VSCode)

## Window discovery strategy (updated)
1. **PID match** — walk `_NET_CLIENT_LIST`, match `_NET_WM_PID == getpid()` (works in graphics mode)
2. **Active window** — query `_NET_ACTIVE_WINDOW` (works in terminal mode since the terminal has focus during interaction)
3. **Fallback** — largest mapped InputOutput child of root

## Test plan
- [x] `make terminal_test` builds cleanly
- [x] `make terminal_testg` builds cleanly
- [ ] Run `terminal_test`, verify `test_images` captures the terminal window (not VSCode)
- [ ] Run `terminal_testg`, verify captures still work
- [ ] View with `testviewer` to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)