### PR TITLE
Scale FreeType pixel size to fit within gfhigh

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -3073,25 +3073,26 @@ void setfnt(winptr win)
     if (FT_New_Face(ftlibrary, best->path, best->index, &win->ftface))
         error(esystem);
 
-    /* set pixel size */
-    FT_Set_Pixel_Sizes(win->ftface, 0, win->gfhigh);
+    /* Set pixel size, scaling down if needed so that the font's actual
+       ascender + |descender| fits within gfhigh. FreeType's pixel size
+       request is the em-square height, but the actual glyph extent
+       (ascender + descender) can exceed it. We reduce the pixel size
+       until all glyphs fit within the requested cell height. */
+    {
+        int pixsiz = win->gfhigh;
+        int ascender, descender;
+        do {
+            FT_Set_Pixel_Sizes(win->ftface, 0, pixsiz);
+            ascender  = (int)( win->ftface->size->metrics.ascender  >> 6);
+            descender = (int)(-win->ftface->size->metrics.descender >> 6);
+            if (ascender + descender <= win->gfhigh) break;
+            pixsiz--;
+        } while (pixsiz > 1);
+    }
 
     /* extract metrics */
     win->charspace = (int)(win->ftface->size->metrics.max_advance >> 6);
-    {
-        /* Line height must accommodate the full font: ascender + descender.
-           If we use only gfhigh, tall glyphs can extend above the cell and
-           leave trails when cells are overwritten. */
-        int ascender  = (int)(win->ftface->size->metrics.ascender  >> 6);
-        int descender = (int)(win->ftface->size->metrics.descender >> 6);
-        if (descender < 0) descender = -descender;
-        int line_h    = (int)(win->ftface->size->metrics.height >> 6);
-        int full_h    = ascender + descender;
-        /* take the larger of the font's declared line height and
-           ascender+descender to be safe against clipping */
-        win->linespace = line_h > full_h ? line_h : full_h;
-        if (win->linespace < win->gfhigh) win->linespace = win->gfhigh;
-    }
+    win->linespace = win->gfhigh;
     win->chrspcx = 0;
     win->chrspcy = 0;
     win->baseoff = (int)(win->ftface->size->metrics.ascender >> 6);


### PR DESCRIPTION
## Summary

FreeType's pixel size request sets the em-square height, but the actual glyph extent (ascender + descender) can exceed it. The previous linespace fix (PR #54) set `linespace` to the full font height to prevent text trails, but this broke `chrsizy()` — the save/restore cycle in `graphtest()` inflated the font size on each call, causing the graphics figures pattern to march downward and the bottom caption to disappear off screen.

### Fix

- Keep `linespace = gfhigh` always, so `chrsizy()` returns the requested size and the character grid stays stable
- Scale down the FreeType pixel size request until `ascender + |descender| <= gfhigh`, ensuring all glyphs render within their cell
- Removes the `clrspace` field added during debugging — no longer needed

### Why this is correct

In Petit-Ami's model, `chrsizy()` is the canonical cell height. Every glyph must fit within it, backgrounds abut from line to line, and the grid is defined by it. The font rendering must conform to this, not the other way around.

## Test plan
- [x] `graphics_test` figures pattern no longer marches down across frames
- [x] Bottom caption ("Graphical figures test, linewidth == N") visible
- [x] Text overwrite leaves no fragment trails
- [x] `terminal_testg` runs and exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)