### PR TITLE
Fix ami_elapsed to use ami_clock instead of clock()

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -843,9 +843,9 @@ long ami_elapsed(long r)
 {
 
     /* reference time */
-    int t;
+    long t;
 
-    t = clock();   /* get the current time */
+    t = ami_clock();   /* get the current time */
     if (t >= r) t -= r; /* time has not wrapped */
     else t += INT_MAX-r; /* time has wrapped */
 


### PR DESCRIPTION
## Summary

`ami_elapsed()` was calling `clock()` (CPU time in `CLOCKS_PER_SEC` ticks) instead of `ami_clock()` (wall time in 100µs units). Since the reference time passed to `ami_elapsed()` comes from `ami_clock()`, the two time bases were incompatible, producing nonsensical elapsed times.

This caused the `graphics_test` benchmark calibration loop to exit almost immediately and compute far too few iterations — each benchmark pattern ran for a fraction of a second instead of the intended 15 seconds.

## Fix
- `ami_elapsed()`: call `ami_clock()` instead of `clock()`
- Change local `int t` to `long t` to match `ami_clock()`'s return type

## Test plan
- [x] `graphics_test` benchmark patterns now run for ~15 seconds each
- [x] `make graphics_test` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)