### PR TITLE
Add screen_capture to management_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1154,8 +1154,13 @@ endif
 #
 # Test windows management model compliant output
 #
-management_test: $(GLIBSD) tests/management_test.c
-	$(CC) $(CFLAGS) tests/management_test.c $(GLIBS) -o bin/management_test 
+ifeq ($(OSTYPE),Darwin)
+management_test: $(GLIBSD) tests/management_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/management_test.c $(SCREEN_CAPTURE_OBJ) $(GLIBS) -o bin/management_test
+else
+management_test: $(GLIBSD) tests/management_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/management_test.c $(SCREEN_CAPTURE_OBJ) $(GLIBS) -lpng -lz -o bin/management_test
+endif
 
 #
 # Test windows widget compliant output

--- a/tests/management_test.c
+++ b/tests/management_test.c
@@ -72,6 +72,8 @@ static enum { /* debug levels */
                                 __func__, __LINE__, ##__VA_ARGS__); \
                                 fflush(stderr); } while (0)
 
+extern void screen_capture(void);
+
 /* wait return to be pressed, or handle terminate */
 
 static void waitnext(void)
@@ -79,6 +81,8 @@ static void waitnext(void)
 {
 
     ami_evtrec er; /* event record */
+
+    screen_capture();
 
     do { ami_event(stdin, &er); }
     while (er.etype != ami_etenter && er.etype != ami_etterm);


### PR DESCRIPTION
## Summary
- Call `screen_capture()` in `waitnext()` so each test page is captured to `test_images`, matching `graphics_test` and `terminal_test`
- Link `screen_capture.o` and `-lpng -lz` into the `management_test` Makefile target

## Test plan
- [x] `make management_test` builds cleanly
- [ ] Run `management_test`, verify `test_images` is produced
- [ ] View with `testviewer` to confirm captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)