### PR TITLE
Fix child window frame off leaving visible artifacts

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -14623,8 +14623,10 @@ static void frame_ivf(FILE* f, int e)
             XWLOCK();
             XResizeWindow(padisplay, win->xmwhan,
                           win->xmwr.w, win->xmwr.h);
-            /* reposition subclient within master */
-            XMoveWindow(padisplay, win->xwhan, win->cwox, win->cwoy);
+            /* reposition and resize subclient within master */
+            XMoveResizeWindow(padisplay, win->xwhan,
+                              win->cwox, win->cwoy,
+                              win->gmaxxg, win->gmaxyg);
             XWUNLOCK();
 
             restore(win);


### PR DESCRIPTION
## Summary

When `ami_frame(f, FALSE)` was called on a child window, dark gray borders and a bottom bar remained visible. The `xmwhan` (master window) was resized correctly to match the client area, but `xwhan` (subclient) was only repositioned via `XMoveWindow`, not resized. If `xwhan` had been resized during the frame-on phase, it would be smaller than `xmwhan`, leaving the master window's background visible.

## Fix

Use `XMoveResizeWindow` instead of `XMoveWindow` to both reposition and resize `xwhan` to `gmaxxg × gmaxyg` when toggling frame on/off. This ensures the subclient always fills the master window exactly — no gaps for the background to show through.

## Test plan
- [x] `management_test` frame 19: child windows without frames show no dark borders or shadows
- [x] Child windows with frames on still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)