### PR TITLE
Enable STDIO_BYPASS for FreeBSD to fix X11 display auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,10 +328,8 @@ ifeq ($(STDIO_SOURCE),stdio)
     CFLAGS +=-Ilibc
     ifneq ($(OSTYPE),Windows_NT)
     ifneq ($(OSTYPE),Darwin)
-    ifneq ($(OSTYPE),FreeBSD)
-        # Linux needs bypass to coexist with system glibc
+        # Linux and FreeBSD need bypass to coexist with system libc
         CFLAGS += -DSTDIO_BYPASS
-    endif
     endif
     endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,11 @@ ifeq ($(STDIO_SOURCE),stdio)
     CFLAGS +=-Ilibc
     ifneq ($(OSTYPE),Windows_NT)
     ifneq ($(OSTYPE),Darwin)
-        # Linux and FreeBSD need bypass to coexist with system libc
+        # Linux and FreeBSD use X11/libXau which accesses FILE* internals
+        # directly (backdoor access). STDIO_BYPASS prevents petit_ami from
+        # exporting fopen/fclose etc. as global symbols, so libXau always
+        # uses the real system fopen and a proper FILE*. Mac OS X is exempt
+        # because it uses Cocoa/CoreGraphics and does not involve libXau.
         CFLAGS += -DSTDIO_BYPASS
     endif
     endif


### PR DESCRIPTION
## Summary

- Enable `STDIO_BYPASS` for FreeBSD builds, the same as Linux
- Without this, petit_ami exports `fopen`/`fclose`/`fread`/`fwrite` as global symbols, hijacking calls from system libraries like libXau
- FreeBSD system libc accesses `FILE*` struct fields directly via macros (`_flags`, `_r`, `_w`, `_bf`, etc.) — passing a petit_ami `FILE*` with an incompatible layout caused `XOpenDisplay` to fail with "Authorization required, but no authorization protocol specified"
- `STDIO_BYPASS` renames petit_ami stdio functions to `stdio_fopen` etc. via macros, so system libraries always use the real system `fopen` and a proper `FILE*`

## Test plan

- [ ] Run `gmake clean && gmake` on GhostBSD/FreeBSD
- [ ] Verify graphical programs open an X window without auth errors
- [ ] Verify Linux build is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)