### PR TITLE
Fix child window frame off leaving rounded corners

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -4568,6 +4568,7 @@ static void childfrm_draw(winptr win)
     int corner_r;     /* outer corner radius */
 
     if (!win->childfrm || !win->frmgc || !win->linespace) return;
+    if (!win->frame) return; /* frame is turned off — nothing to draw */
 
     /* Query actual geometry from the X server. XSync ensures any pending
        resize requests have been processed before we query. We cannot rely
@@ -14737,9 +14738,26 @@ static void frame_ivf(FILE* f, int e)
             XMoveResizeWindow(padisplay, win->xwhan,
                               win->cwox, win->cwoy,
                               win->gmaxxg, win->gmaxyg);
+            /* when frame is turned off, clear the rounded-corner shape
+               mask so the client window presents as a plain rectangle */
+            if (!e) {
+
+                XRectangle r;
+                r.x = 0;
+                r.y = 0;
+                r.width  = win->xmwr.w;
+                r.height = win->xmwr.h;
+                XShapeCombineRectangles(padisplay, win->xmwhan,
+                                        ShapeBounding, 0, 0, &r, 1,
+                                        ShapeSet, Unsorted);
+
+            }
             XWUNLOCK();
 
             restore(win);
+            /* redraw the frame (and re-apply the shape mask) when frame
+               is turned back on */
+            if (e) childfrm_draw(win);
 
         }
 


### PR DESCRIPTION
## Summary

When \`ami_frame(f, FALSE)\` was called on a child window, the rounded-corner XShape mask applied by \`childfrm_draw\` stayed on \`xmwhan\`, so the client window's top corners were still clipped round — visible as rounded colored areas where there should be square windows.

## Root cause

Two issues:

1. \`frame_ivf\` did not reset the bounding shape when turning the frame off. The shape mask from when the frame was on persisted.
2. Even after fixing #1, \`childfrm_draw\` was being called from Expose event handlers regardless of whether the frame was currently on. It unconditionally re-applied the rounded shape mask, undoing the fix on the next Expose.

## Fix

- \`frame_ivf\` now calls \`XShapeCombineRectangles\` with a full-window rectangle when the frame is turned off, restoring the plain rectangular shape.
- \`childfrm_draw\` now early-returns when \`!win->frame\`, so subsequent Expose events don't re-apply the mask.
- Also re-applies the rounded frame (via \`childfrm_draw\`) when the frame is turned back on, in case Expose doesn't fire.

## Test plan
- [x] \`management_test\` frame 2 (child windows without frames): top corners are square
- [x] Turning frame back on restores the rounded corners
- [x] Existing rounded-corner behavior on framed child windows still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)