### PR TITLE
Move BSDGames to curses/, add canfield, fix sslerrorqueue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "BSDGames"]
-	path = BSDGames
+[submodule "curses/BSDGames"]
+	path = curses/BSDGames
 	url = https://github.com/vattam/BSDGames

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "BSDGames"]
+	path = BSDGames
+	url = https://github.com/vattam/BSDGames

--- a/apis/bsdcompat/sys/endian.h
+++ b/apis/bsdcompat/sys/endian.h
@@ -1,0 +1,1 @@
+#include <endian.h>

--- a/apis/curses.c
+++ b/apis/curses.c
@@ -522,6 +522,13 @@ int beep(void) { return OK; }
 int baudrate(void) { return 38400; }
 int scrollok(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
 int touchwin(WINDOW* win) { (void)win; return OK; }
+int leaveok(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+int standout(void) { return attron(A_STANDOUT); }
+int standend(void) { return attrset(A_NORMAL); }
+int nl(void) { return OK; }
+int nonl(void) { return OK; }
+char erasechar(void) { return '\b'; }
+char killchar(void) { return 0x15; /* Ctrl-U */ }
 
 int winch(WINDOW* win) {
 

--- a/apis/curses.c
+++ b/apis/curses.c
@@ -41,6 +41,17 @@ static int   cur_ungetch = -1;  /* ungetch buffer */
 /* color pair table: fg/bg for each pair */
 static struct { short fg; short bg; } color_pairs[COLOR_PAIRS];
 
+/* screen content buffer for mvinch/winch readback */
+static int  scrbuf_inited = 0;
+static char scrbuf[256][256];
+
+static void scrbuf_init(void) {
+
+    memset(scrbuf, ' ', sizeof(scrbuf));
+    scrbuf_inited = 1;
+
+}
+
 /* the single window */
 static WINDOW stdscr_data;
 WINDOW* stdscr = &stdscr_data;
@@ -175,6 +186,8 @@ int refresh(void) {
 
 int clear(void) {
 
+    if (!scrbuf_inited) scrbuf_init();
+    else memset(scrbuf, ' ', sizeof(scrbuf));
     putchar('\f');
     return OK;
 
@@ -227,6 +240,14 @@ int move(int y, int x) {
 
 int addch(int ch) {
 
+    if (!scrbuf_inited) scrbuf_init();
+    /* track screen contents for mvinch/winch readback */
+    {
+        int cx = ami_curx(stdout) - 1;
+        int cy = ami_cury(stdout) - 1;
+        if (cy >= 0 && cy < 256 && cx >= 0 && cx < 256)
+            scrbuf[cy][cx] = (char)(ch & 0x7F);
+    }
     if (ch > 0x7F) put_utf8(ch); /* ACS/Unicode character */
     else putchar(ch);
     return OK;
@@ -475,15 +496,6 @@ int getmaxy(WINDOW* win) { (void)win; return LINES; }
    Ami doesn't have a "read character at position" function, so we
    return ' ' as a fallback. The snake game uses this to check if a
    position is empty — we track the screen content in a simple buffer. */
-static int scrbuf_inited = 0;
-static char scrbuf[256][256]; /* max 256x256 screen */
-
-static void scrbuf_init(void) {
-
-    memset(scrbuf, ' ', sizeof(scrbuf));
-    scrbuf_inited = 1;
-
-}
 
 int mvinch(int y, int x) {
 
@@ -507,6 +519,21 @@ int napms(int ms) {
 }
 
 int beep(void) { return OK; }
+int baudrate(void) { return 38400; }
+int scrollok(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+int touchwin(WINDOW* win) { (void)win; return OK; }
+
+int winch(WINDOW* win) {
+
+    int cx, cy;
+    (void)win;
+    if (!scrbuf_inited) scrbuf_init();
+    cx = ami_curx(stdout) - 1;
+    cy = ami_cury(stdout) - 1;
+    if (cy < 0 || cy >= 256 || cx < 0 || cx >= 256) return ' ';
+    return (unsigned char)scrbuf[cy][cx];
+
+}
 
 /*******************************************************************************
 
@@ -573,3 +600,108 @@ int vline(int ch, int n) {
 
 int mvhline(int y, int x, int ch, int n) { move(y, x); return hline(ch, n); }
 int mvvline(int y, int x, int ch, int n) { move(y, x); return vline(ch, n); }
+
+/*******************************************************************************
+
+Window functions (minimal — all map to stdscr with an origin offset)
+
+Curses windows are mapped to stdscr with a stored origin. Drawing calls
+offset by the window's begin_y/begin_x. This is sufficient for programs
+that use a small number of non-overlapping windows (like worm's status
+bar + game area).
+
+*******************************************************************************/
+
+#define MAX_WINS 16
+static struct { int used; int by; int bx; int ny; int nx; } wins[MAX_WINS];
+
+WINDOW* newwin(int nlines, int ncols, int begin_y, int begin_x) {
+
+    int i;
+    for (i = 1; i < MAX_WINS; i++) {
+
+        if (!wins[i].used) {
+
+            wins[i].used = 1;
+            wins[i].by = begin_y;
+            wins[i].bx = begin_x;
+            wins[i].ny = nlines;
+            wins[i].nx = ncols;
+            return (WINDOW*)((long)i);
+
+        }
+
+    }
+    return stdscr;
+
+}
+
+static void win_origin(WINDOW* win, int* oy, int* ox) {
+
+    long idx = (long)win;
+    if (idx > 0 && idx < MAX_WINS && wins[idx].used) {
+
+        *oy = wins[idx].by;
+        *ox = wins[idx].bx;
+
+    } else {
+
+        *oy = 0;
+        *ox = 0;
+
+    }
+
+}
+
+int wrefresh(WINDOW* win) { (void)win; return refresh(); }
+
+int wmove(WINDOW* win, int y, int x) {
+
+    int oy, ox;
+    win_origin(win, &oy, &ox);
+    return move(oy + y, ox + x);
+
+}
+
+int waddch(WINDOW* win, int ch) { (void)win; return addch(ch); }
+int waddstr(WINDOW* win, const char* str) { (void)win; return addstr(str); }
+
+int mvwaddch(WINDOW* win, int y, int x, int ch) {
+
+    wmove(win, y, x);
+    return addch(ch);
+
+}
+
+int mvwaddstr(WINDOW* win, int y, int x, const char* str) {
+
+    wmove(win, y, x);
+    return addstr(str);
+
+}
+
+int wprintw(WINDOW* win, const char* fmt, ...) {
+
+    va_list ap;
+    (void)win;
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    return OK;
+
+}
+
+int mvwprintw(WINDOW* win, int y, int x, const char* fmt, ...) {
+
+    va_list ap;
+    wmove(win, y, x);
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    return OK;
+
+}
+
+int wclear(WINDOW* win) { (void)win; return clear(); }
+int wclrtoeol(WINDOW* win) { (void)win; return clrtoeol(); }
+int wgetch(WINDOW* win) { (void)win; return getch(); }

--- a/apis/curses.h
+++ b/apis/curses.h
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 
 /* boolean */
+#include <stdbool.h>
 #ifndef TRUE
 #define TRUE  1
 #endif
@@ -38,6 +39,7 @@
 /* window type (we only support stdscr — this is a dummy struct) */
 typedef struct _win_st { int dummy; } WINDOW;
 extern WINDOW* stdscr;
+#define curscr stdscr
 extern int LINES;
 extern int COLS;
 
@@ -143,6 +145,13 @@ int baudrate(void);
 int scrollok(WINDOW* win, int bf);
 int touchwin(WINDOW* win);
 int winch(WINDOW* win);
+int leaveok(WINDOW* win, int bf);
+int standout(void);
+int standend(void);
+int nl(void);
+int nonl(void);
+char erasechar(void);
+char killchar(void);
 
 /* box drawing */
 int box(WINDOW* win, int verch, int horch);

--- a/apis/curses.h
+++ b/apis/curses.h
@@ -18,6 +18,7 @@
 #ifndef _AMI_CURSES_H
 #define _AMI_CURSES_H
 
+#include <stdio.h>
 #include <stdarg.h>
 
 /* boolean */
@@ -121,9 +122,27 @@ int getmaxy(WINDOW* win);
 /* screen reading */
 int mvinch(int y, int x);
 
+/* windows (minimal — all map to stdscr) */
+WINDOW* newwin(int nlines, int ncols, int begin_y, int begin_x);
+int     wrefresh(WINDOW* win);
+int     wmove(WINDOW* win, int y, int x);
+int     waddch(WINDOW* win, int ch);
+int     waddstr(WINDOW* win, const char* str);
+int     mvwaddch(WINDOW* win, int y, int x, int ch);
+int     mvwaddstr(WINDOW* win, int y, int x, const char* str);
+int     wprintw(WINDOW* win, const char* fmt, ...);
+int     mvwprintw(WINDOW* win, int y, int x, const char* fmt, ...);
+int     wclear(WINDOW* win);
+int     wclrtoeol(WINDOW* win);
+int     wgetch(WINDOW* win);
+
 /* misc */
 int napms(int ms);
 int beep(void);
+int baudrate(void);
+int scrollok(WINDOW* win, int bf);
+int touchwin(WINDOW* win);
+int winch(WINDOW* win);
 
 /* box drawing */
 int box(WINDOW* win, int verch, int horch);

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -21,18 +21,32 @@ CFLAGS  = -g3 -I$(ROOT)/apis -D'__COPYRIGHT(x)=' -D'__RCSID(x)='
 
 CURSES_OBJ = $(ROOT)/apis/curses.o
 
-TLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(ROOT)/lib/petit_ami_term.so \
+# Static link against Petit-Ami .o files directly.
+TOBJ    = $(ROOT)/linux/stdio.o $(ROOT)/linux/services.o \
+          $(ROOT)/linux/network.o $(ROOT)/linux/terminal.o \
+          $(ROOT)/linux/system_event.o \
+          $(ROOT)/utils/config.o $(ROOT)/utils/option.o \
+          $(ROOT)/cpp/terminal.o
+
+GOBJ    = $(ROOT)/linux/stdio.o $(ROOT)/linux/services.o \
+          $(ROOT)/linux/network.o $(ROOT)/linux/graphics.o \
+          $(ROOT)/linux/system_event.o \
+          $(ROOT)/portable/gnome_widgets.o \
+          $(ROOT)/utils/config.o $(ROOT)/utils/option.o \
+          $(ROOT)/cpp/terminal.o
+
+TLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(TOBJ) \
           $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
           $(ROOT)/linux/dumpsynthplug.o \
-          -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd
+          -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd -lstdc++
 
-GLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(ROOT)/lib/petit_ami_graph.so \
+GLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(GOBJ) \
           $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
           $(ROOT)/linux/dumpsynthplug.o \
           -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto \
-          -lX11 -lfreetype -lfontconfig -lbsd
+          -lX11 -lXext -lfreetype -lfontconfig -lbsd -lstdc++
 
-GAMES   = snake rain worm worms
+GAMES   = snake rain worm worms canfield
 
 all: $(CURSES_OBJ) $(foreach g,$(GAMES),$(g)_term $(g)_gfx)
 
@@ -40,13 +54,15 @@ snake: snake_term snake_gfx
 rain: rain_term rain_gfx
 worm: worm_term worm_gfx
 worms: worms_term worms_gfx
+canfield: canfield_term canfield_gfx
+gomoku: gomoku_term gomoku_gfx
 
 $(CURSES_OBJ): $(ROOT)/apis/curses.c $(ROOT)/apis/curses.h
 	$(CC) $(AMIFLAGS) -c $(ROOT)/apis/curses.c -o $(CURSES_OBJ)
 
 # Snake
-SNAKE_SRC   = $(ROOT)/BSDGames/snake/snake/snake.c
-SNAKE_FLAGS = -I$(ROOT)/BSDGames/snake/snake
+SNAKE_SRC   = BSDGames/snake/snake/snake.c
+SNAKE_FLAGS = -IBSDGames/snake/snake
 
 snake_term: $(CURSES_OBJ) $(SNAKE_SRC)
 	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(TLIBS) -lm
@@ -55,7 +71,7 @@ snake_gfx: $(CURSES_OBJ) $(SNAKE_SRC)
 	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(GLIBS) -lm
 
 # Rain
-RAIN_SRC = $(ROOT)/BSDGames/rain/rain.c
+RAIN_SRC = BSDGames/rain/rain.c
 
 rain_term: $(CURSES_OBJ) $(RAIN_SRC)
 	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(TLIBS)
@@ -64,7 +80,7 @@ rain_gfx: $(CURSES_OBJ) $(RAIN_SRC)
 	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(GLIBS)
 
 # Worm
-WORM_SRC = $(ROOT)/BSDGames/worm/worm.c
+WORM_SRC = BSDGames/worm/worm.c
 
 worm_term: $(CURSES_OBJ) $(WORM_SRC)
 	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(TLIBS)
@@ -73,13 +89,35 @@ worm_gfx: $(CURSES_OBJ) $(WORM_SRC)
 	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(GLIBS)
 
 # Worms
-WORMS_SRC = $(ROOT)/BSDGames/worms/worms.c
+WORMS_SRC = BSDGames/worms/worms.c
 
 worms_term: $(CURSES_OBJ) $(WORMS_SRC)
 	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(TLIBS)
 
 worms_gfx: $(CURSES_OBJ) $(WORMS_SRC)
 	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(GLIBS)
+
+# Canfield
+CANFIELD_SRC   = BSDGames/canfield/canfield/canfield.c
+CANFIELD_FLAGS = -IBSDGames/canfield/canfield
+
+canfield_term: $(CURSES_OBJ) $(CANFIELD_SRC)
+	$(CC) $(CFLAGS) $(CANFIELD_FLAGS) -o $@ $(CANFIELD_SRC) $(TLIBS)
+
+canfield_gfx: $(CURSES_OBJ) $(CANFIELD_SRC)
+	$(CC) $(CFLAGS) $(CANFIELD_FLAGS) -o $@ $(CANFIELD_SRC) $(GLIBS)
+
+# Gomoku
+GOMOKU_SRC   = BSDGames/gomoku/main.c BSDGames/gomoku/bdisp.c \
+               BSDGames/gomoku/stoc.c BSDGames/gomoku/makemove.c \
+               BSDGames/gomoku/pickmove.c BSDGames/gomoku/bdinit.c
+GOMOKU_FLAGS = -IBSDGames/gomoku -I$(ROOT)/apis/bsdcompat -Dgetline=gomoku_getline
+
+gomoku_term: $(CURSES_OBJ) $(GOMOKU_SRC)
+	$(CC) $(CFLAGS) $(GOMOKU_FLAGS) -o $@ $(GOMOKU_SRC) $(TLIBS)
+
+gomoku_gfx: $(CURSES_OBJ) $(GOMOKU_SRC)
+	$(CC) $(CFLAGS) $(GOMOKU_FLAGS) -o $@ $(GOMOKU_SRC) $(GLIBS)
 
 clean:
 	rm -f $(CURSES_OBJ) *_term *_gfx

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -1,0 +1,87 @@
+#
+# Makefile for BSD curses games on Petit-Ami
+#
+# Builds each game in both terminal and graphics versions using the
+# curses compatibility layer in apis/curses.c.
+#
+# Usage: make          (builds all)
+#        make snake     (builds snake_term and snake_gfx)
+#        make clean
+#
+
+ROOT    = ..
+CC      = gcc
+
+# flags for building the curses adapter (needs Ami stdio interception)
+AMIFLAGS = -g3 -I$(ROOT)/apis -I$(ROOT)/include -I$(ROOT)/libc \
+           -I/usr/include/freetype2 -I/usr/include/libpng16 -DSTDIO_BYPASS
+
+# flags for building game source (standard libc, no Ami stdio override)
+CFLAGS  = -g3 -I$(ROOT)/apis -D'__COPYRIGHT(x)=' -D'__RCSID(x)='
+
+CURSES_OBJ = $(ROOT)/apis/curses.o
+
+TLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(ROOT)/lib/petit_ami_term.so \
+          $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
+          $(ROOT)/linux/dumpsynthplug.o \
+          -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd
+
+GLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(ROOT)/lib/petit_ami_graph.so \
+          $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
+          $(ROOT)/linux/dumpsynthplug.o \
+          -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto \
+          -lX11 -lfreetype -lfontconfig -lbsd
+
+GAMES   = snake rain worm worms
+
+all: $(CURSES_OBJ) $(foreach g,$(GAMES),$(g)_term $(g)_gfx)
+
+snake: snake_term snake_gfx
+rain: rain_term rain_gfx
+worm: worm_term worm_gfx
+worms: worms_term worms_gfx
+
+$(CURSES_OBJ): $(ROOT)/apis/curses.c $(ROOT)/apis/curses.h
+	$(CC) $(AMIFLAGS) -c $(ROOT)/apis/curses.c -o $(CURSES_OBJ)
+
+# Snake
+SNAKE_SRC   = $(ROOT)/BSDGames/snake/snake/snake.c
+SNAKE_FLAGS = -I$(ROOT)/BSDGames/snake/snake
+
+snake_term: $(CURSES_OBJ) $(SNAKE_SRC)
+	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(TLIBS) -lm
+
+snake_gfx: $(CURSES_OBJ) $(SNAKE_SRC)
+	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(GLIBS) -lm
+
+# Rain
+RAIN_SRC = $(ROOT)/BSDGames/rain/rain.c
+
+rain_term: $(CURSES_OBJ) $(RAIN_SRC)
+	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(TLIBS)
+
+rain_gfx: $(CURSES_OBJ) $(RAIN_SRC)
+	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(GLIBS)
+
+# Worm
+WORM_SRC = $(ROOT)/BSDGames/worm/worm.c
+
+worm_term: $(CURSES_OBJ) $(WORM_SRC)
+	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(TLIBS)
+
+worm_gfx: $(CURSES_OBJ) $(WORM_SRC)
+	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(GLIBS)
+
+# Worms
+WORMS_SRC = $(ROOT)/BSDGames/worms/worms.c
+
+worms_term: $(CURSES_OBJ) $(WORMS_SRC)
+	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(TLIBS)
+
+worms_gfx: $(CURSES_OBJ) $(WORMS_SRC)
+	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(GLIBS)
+
+clean:
+	rm -f $(CURSES_OBJ) *_term *_gfx
+
+.PHONY: all clean snake rain worm worms

--- a/linux/network.c
+++ b/linux/network.c
@@ -231,7 +231,8 @@ static filptr opnfil[MAXFIL];  /* open files table */
 static pthread_mutex_t oflock; /* lock for this structure */
 static filptr frefil;          /* free file entries list */
 static pthread_mutex_t fflock; /* lock for this structure */
-static ami_certptr frecert;     /* free certificate name/value entries list */
+static ami_certptr frecert;    /* free certificate name/value entries list */
+static int in_condes;          /* executing in constructor or destructor */
 
 /*
  * openSSL variables
@@ -250,6 +251,26 @@ int cookie_initialized;
 
 /*******************************************************************************
 
+Process abort
+
+Processes a program abort. If the constructor/destructor flag is active, meaning
+inside a constructor or destructor, we do an immediate abort. Otherwise we do
+a planned abort. The difference is in if the constructor/destructor stacking is
+performed.
+
+*******************************************************************************/
+
+static void net_abort(void)
+
+{
+
+    if (in_condes) _exit(1); /* slam abort */
+    else exit(1); /* planned abort */
+
+}
+
+/*******************************************************************************
+
 Process network library error
 
 Outputs an error message using the special syslib function, then halts.
@@ -262,7 +283,7 @@ static void netwrterr(const char* s)
 
     fprintf(stderr, "\nError: Network: %s\n", s);
 
-    exit(1);
+    net_abort();
 
 }
 
@@ -340,7 +361,7 @@ static void linuxerror(void)
 
     fprintf(stderr, "\nLinux Error: %s\n", strerror(errno));
 
-    exit(1);
+    net_abort();
 
 }
 /*******************************************************************************
@@ -352,12 +373,22 @@ SSL errors at this time.
 
 *******************************************************************************/
 
+static int sslerrcb(const char *str, size_t len, void *u)
+
+{
+
+    (void)u;
+    fprintf(stderr, "%.*s", (int)len, str);
+    return 1;
+
+}
+
 static void sslerrorqueue(void)
 
 {
 
-    ERR_print_errors_fp(stderr);
-    exit(1);
+    ERR_print_errors_cb(sslerrcb, NULL);
+    net_abort();
 
 }
 
@@ -407,7 +438,7 @@ static void sslerror(SSL* ssl, int r)
 
     }
 
-    exit(1);
+    net_abort();
 
 }
 
@@ -2663,6 +2694,8 @@ static void ami_init_network()
     int fi;
     int r;
 
+    in_condes = 1; /* set in constructor */
+
     frefil = NULL; /* clear free files list */
     /* clear open files table */
     for (fi = 0; fi < MAXFIL; fi++) opnfil[fi] = NULL;
@@ -2724,6 +2757,8 @@ static void ami_init_network()
     /* set cookie uninitialized */
     cookie_initialized = FALSE;
 
+    in_condes = 0; /* set clear constructor */
+
 }
 
 /*******************************************************************************
@@ -2738,6 +2773,8 @@ static void ami_deinit_network()
 {
 
     int fi;
+
+    in_condes = 1; /* set in destructor */
 
     /* holding copies of system vectors */
     pread_t cppread;
@@ -2784,5 +2821,7 @@ static void ami_deinit_network()
     pthread_mutex_destroy(&oflock);
     /* release the free files lock */
     pthread_mutex_destroy(&fflock);
+
+    in_condes = 0; /* clear the destructor */
 
 }


### PR DESCRIPTION
## Summary

- Move BSDGames submodule from project root into \`curses/\` directory (where it belongs)
- Add canfield solitaire card game (5 BSD games total)
- Static linking against Petit-Ami \`.o\` files instead of shared libs
- Fix \`sslerrorqueue\` crash and network constructor exit handling

## Games built (all from unmodified BSD source)

| Game | Terminal | Graphics |
|------|----------|----------|
| snake | snake_term | snake_gfx |
| rain | rain_term | rain_gfx |
| worm | worm_term | worm_gfx |
| worms | worms_term | worms_gfx |
| canfield | canfield_term | canfield_gfx |

## Curses layer additions

\`standout\`/\`standend\`, \`leaveok\`, \`nl\`/\`nonl\`, \`erasechar\`/\`killchar\`, window functions (\`newwin\`, \`wrefresh\`, \`wmove\`, \`waddch\`, etc.), \`baudrate\`, \`scrollok\`, \`touchwin\`, \`winch\`, \`curscr\`, \`bool\` type, screen buffer tracking for \`mvinch\`/\`winch\` readback

## Network fixes

- \`sslerrorqueue\`: use \`ERR_print_errors_cb\` with a callback instead of \`ERR_print_errors_fp(stderr)\` — avoids passing Petit-Ami's fake FILE pointer to OpenSSL
- Constructor/destructor context: use \`_exit()\` instead of \`exit()\` to avoid destructor chain crashes on partially-initialized state

🤖 Generated with [Claude Code](https://claude.com/claude-code)