### PR TITLE
Add .adp adapter layer + menu hooks + hint bar to curses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "curses/BSDGames"]
 	path = curses/BSDGames
 	url = https://github.com/vattam/BSDGames
+[submodule "curses/nano"]
+	path = curses/nano
+	url = https://git.savannah.gnu.org/git/nano.git

--- a/apis/curses.c
+++ b/apis/curses.c
@@ -7,7 +7,7 @@
 * Key mappings:                                                                *
 *   curses          Petit-Ami                                                  *
 *   ------          ---------                                                  *
-*   initscr()       ami_auto(off), ami_curvis(off)                             *
+*   initscr()       ami_auto(off)  (cursor left visible, as in ncurses)        *
 *   endwin()        ami_auto(on), ami_curvis(on)                               *
 *   move(y,x)       ami_cursor(stdout, x+1, y+1)   (0-based to 1-based)       *
 *   addch(c)        putchar(c)                                                 *
@@ -24,9 +24,28 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <terminal.h>
+#include <services.h>
 #include "curses.h"
+
+#define ADP_MAXSTR    1024  /* path buffer size */
+#define ADP_MAXKEYSTR 64    /* max chars per mapped key string */
+#define ADP_MAXLABEL  48    /* max chars per hint label */
+#define ADP_MAXHINT   4096  /* max chars for the full hint string */
+#define ADP_MAXFKEY   24    /* highest supported function key number */
+#define ADP_EVT_COUNT (ami_etmenus + 1) /* size of indexed event table */
+
+/* Program invocation name (glibc/MinGW provides this). Used to derive the
+   .adp file name — ami_getpgm() returns only the directory component. */
+#if defined(__linux) || defined(__MINGW32__)
+extern char* program_invocation_name;
+#endif
+
+/* ami_menurec / ami_menu are declared in terminal.h. At runtime, ami_menu
+   is a no-op on the terminal backend and a real menu bar under graphics.c.
+   AMI_CURSES_MENU gates whether curses.c actually builds and binds menus. */
 
 /* internal state */
 static int   cur_initialized = 0;
@@ -37,6 +56,712 @@ static int   cur_keypad = 1;    /* keypad mode (always on) */
 static attr_t cur_attrs = A_NORMAL;
 static int   cur_ended = 0;
 static int   cur_ungetch = -1;  /* ungetch buffer */
+
+/*******************************************************************************
+
+Adapter (.adp) tables and parser
+
+A .adp file named <progname>.adp alongside the executable maps Ami terminal
+events to key sequences that the adapted program consumes. When an adapter
+mapping exists for an incoming event, getch() returns the mapped string one
+character per call instead of the default curses KEY_* code. If the file is
+absent, the adapter layer is dormant and default behavior is unchanged.
+
+*******************************************************************************/
+
+typedef struct {
+    int  len;                         /* 0 = no mapping */
+    unsigned char s[ADP_MAXKEYSTR];
+    char label[ADP_MAXLABEL];         /* trailing-comment description */
+} adp_entry;
+
+static int       adp_loaded = 0;
+static adp_entry adp_evt[ADP_EVT_COUNT];   /* by event code */
+static adp_entry adp_fkey[ADP_MAXFKEY + 1];/* by function-key number (1..N) */
+
+/* Emission queue — chars pending delivery to getch() from a mapped string. */
+static unsigned char adp_outbuf[ADP_MAXKEYSTR];
+static int           adp_outpos = 0;
+static int           adp_outlen = 0;
+
+/* Pre-formatted hint line(s) shown at the bottom of the screen. Derived from
+   the mapped events + their trailing-comment labels. Each line fits COLS. */
+static char adp_hint[ADP_MAXHINT];
+static int  adp_hint_rows = 0;        /* number of reserved rows (0 = off) */
+
+/* forward decl — defined further down with the curses attribute code */
+static void apply_attrs(void);
+
+#ifdef AMI_CURSES_MENU
+/* Menu item key table — indexed by ami_menurec.id. When a menu item is
+   selected, we inject its mapped keystring via the emission queue. */
+#define ADP_MAX_MENU_ITEMS 128
+static adp_entry   adp_menu_keys[ADP_MAX_MENU_ITEMS];
+static ami_menuptr adp_menu_root      = NULL;
+static int         adp_menu_next_id   = 1;
+#endif
+
+/* Name-to-code table for .adp event identifiers. The spec drops the "ami_"
+   prefix in the file; "etfunN" (N a decimal integer) is handled separately
+   as a per-function-key mapping. */
+static const struct { const char* name; int code; } adp_evnames[] = {
+    { "etchar",    ami_etchar    }, { "etup",      ami_etup      },
+    { "etdown",    ami_etdown    }, { "etleft",    ami_etleft    },
+    { "etright",   ami_etright   }, { "etleftw",   ami_etleftw   },
+    { "etrightw",  ami_etrightw  }, { "ethome",    ami_ethome    },
+    { "ethomes",   ami_ethomes   }, { "ethomel",   ami_ethomel   },
+    { "etend",     ami_etend     }, { "etends",    ami_etends    },
+    { "etendl",    ami_etendl    }, { "etscrl",    ami_etscrl    },
+    { "etscrr",    ami_etscrr    }, { "etscru",    ami_etscru    },
+    { "etscrd",    ami_etscrd    }, { "etpagd",    ami_etpagd    },
+    { "etpagu",    ami_etpagu    }, { "ettab",     ami_ettab     },
+    { "etenter",   ami_etenter   }, { "etinsert",  ami_etinsert  },
+    { "etinsertl", ami_etinsertl }, { "etinsertt", ami_etinsertt },
+    { "etdel",     ami_etdel     }, { "etdell",    ami_etdell    },
+    { "etdelcf",   ami_etdelcf   }, { "etdelcb",   ami_etdelcb   },
+    { "etcopy",    ami_etcopy    }, { "etcopyl",   ami_etcopyl   },
+    { "etcan",     ami_etcan     }, { "etstop",    ami_etstop    },
+    { "etcont",    ami_etcont    }, { "etprint",   ami_etprint   },
+    { "etprintb",  ami_etprintb  }, { "etprints",  ami_etprints  },
+    { "etfun",     ami_etfun     }, { "etmenu",    ami_etmenu    },
+    { "etmouba",   ami_etmouba   }, { "etmoubd",   ami_etmoubd   },
+    { "etmoumov",  ami_etmoumov  }, { "ettim",     ami_ettim     },
+    { "etjoyba",   ami_etjoyba   }, { "etjoybd",   ami_etjoybd   },
+    { "etjoymov",  ami_etjoymov  }, { "etresize",  ami_etresize  },
+    { "etfocus",   ami_etfocus   }, { "etnofocus", ami_etnofocus },
+    { "ethover",   ami_ethover   }, { "etnohover", ami_etnohover },
+    { "etterm",    ami_etterm    }, { "etframe",   ami_etframe   },
+    { "etredraw",  ami_etredraw  }, { "etmin",     ami_etmin     },
+    { "etmax",     ami_etmax     }, { "etnorm",    ami_etnorm    },
+    { "etmenus",   ami_etmenus   },
+    { NULL, 0 }
+};
+
+/* -------- tokenizer -------- */
+
+typedef enum { ADP_TK_EOF, ADP_TK_IDENT, ADP_TK_STRING, ADP_TK_ERR } adp_tktype;
+
+typedef struct {
+    FILE* f;
+    int   pb;          /* pushback char, -1 if empty */
+    adp_tktype type;
+    char       ident[64];
+    unsigned char str[ADP_MAXKEYSTR];
+    int           strlen_;
+} adp_parser;
+
+static int adp_getc(adp_parser* p) {
+
+    int c;
+    if (p->pb != -1) { c = p->pb; p->pb = -1; return c; }
+    c = fgetc(p->f);
+    return c;
+
+}
+
+static void adp_ungetc(adp_parser* p, int c) { p->pb = c; }
+
+/* Skip whitespace and '!' comments (to end of line). */
+static void adp_skip_ws(adp_parser* p) {
+
+    int c;
+    for (;;) {
+        c = adp_getc(p);
+        if (c == EOF) return;
+        if (c == '!') {
+            while ((c = adp_getc(p)) != EOF && c != '\n') ;
+            continue;
+        }
+        if (!isspace(c)) { adp_ungetc(p, c); return; }
+    }
+
+}
+
+/* Hex digit to value, -1 if not hex. */
+static int adp_hex(int c) {
+
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + c - 'a';
+    if (c >= 'A' && c <= 'F') return 10 + c - 'A';
+    return -1;
+
+}
+
+/* Parse a single escape after the leading backslash. */
+static int adp_escape(adp_parser* p) {
+
+    int c = adp_getc(p);
+    int h1, h2, v;
+
+    switch (c) {
+        case 'r':  return '\r';
+        case 'n':  return '\n';
+        case 't':  return '\t';
+        case 'b':  return '\b';
+        case 'f':  return '\f';
+        case 'a':  return '\a';
+        case 'v':  return '\v';
+        case 'e':  return 0x1B;
+        case '\\': return '\\';
+        case '\'': return '\'';
+        case '"':  return '"';
+        case '0':
+            /* \0xNN hex form, or plain \0 (NUL) */
+            c = adp_getc(p);
+            if (c == 'x' || c == 'X') {
+                h1 = adp_hex(adp_getc(p));
+                if (h1 < 0) return 0;
+                h2 = adp_hex(adp_getc(p));
+                if (h2 < 0) return h1;
+                return (h1 << 4) | h2;
+            }
+            adp_ungetc(p, c);
+            return 0;
+        case 'x': case 'X':
+            h1 = adp_hex(adp_getc(p));
+            if (h1 < 0) return 0;
+            h2 = adp_hex(adp_getc(p));
+            if (h2 < 0) return h1;
+            v = (h1 << 4) | h2;
+            return v;
+        default:
+            return c; /* unknown escape: take literal */
+    }
+
+}
+
+/* Read the next token (identifier or quoted string). */
+static void adp_next(adp_parser* p) {
+
+    int c, ch;
+
+    adp_skip_ws(p);
+    c = adp_getc(p);
+    if (c == EOF) { p->type = ADP_TK_EOF; return; }
+
+    if (c == '\'') {
+        /* quoted string */
+        p->strlen_ = 0;
+        for (;;) {
+            c = adp_getc(p);
+            if (c == EOF)   { p->type = ADP_TK_ERR; return; }
+            if (c == '\'')  { p->type = ADP_TK_STRING; return; }
+            if (c == '^') {
+                ch = adp_getc(p);
+                if (ch == EOF) { p->type = ADP_TK_ERR; return; }
+                /* ctrl: toupper(ch) & 0x1F; preserves ^\ ^] ^_ etc. */
+                c = toupper((unsigned char)ch) & 0x1F;
+            } else if (c == '\\') {
+                c = adp_escape(p);
+            }
+            if (p->strlen_ < ADP_MAXKEYSTR)
+                p->str[p->strlen_++] = (unsigned char)c;
+        }
+    }
+
+    if (isalpha(c) || c == '_') {
+        int n = 0;
+        p->ident[n++] = (char)c;
+        while ((c = adp_getc(p)) != EOF
+               && (isalnum(c) || c == '_')) {
+            if (n < (int)sizeof(p->ident) - 1) p->ident[n++] = (char)c;
+        }
+        p->ident[n] = 0;
+        if (c != EOF) adp_ungetc(p, c);
+        p->type = ADP_TK_IDENT;
+        return;
+    }
+
+    p->type = ADP_TK_ERR;
+
+}
+
+/* -------- adapter lookup / resolution -------- */
+
+/* Match "et<name>" identifier. Handles "etfunN" as a special case, returning
+   the function-key index in *fkn (>0) with code=ami_etfun. Returns 1 if
+   matched, 0 otherwise. */
+static int adp_resolve(const char* id, int* code, int* fkn) {
+
+    int i;
+
+    *fkn = 0;
+    /* etfunN (decimal) */
+    if (!strncmp(id, "etfun", 5) && id[5]) {
+        int n = 0;
+        const char* q = id + 5;
+        while (*q >= '0' && *q <= '9') { n = n * 10 + (*q - '0'); q++; }
+        if (*q == 0 && n >= 1 && n <= ADP_MAXFKEY) {
+            *code = ami_etfun;
+            *fkn  = n;
+            return 1;
+        }
+    }
+    for (i = 0; adp_evnames[i].name; i++) {
+        if (!strcmp(adp_evnames[i].name, id)) {
+            *code = adp_evnames[i].code;
+            return 1;
+        }
+    }
+    return 0;
+
+}
+
+/* Store a parsed mapping. label may be NULL. */
+static void adp_store(int code, int fkn,
+                      const unsigned char* s, int len,
+                      const char* label) {
+
+    adp_entry* e;
+    if (len <= 0) return;
+    if (len > ADP_MAXKEYSTR) len = ADP_MAXKEYSTR;
+    if (fkn > 0 && code == ami_etfun) {
+        if (fkn <= 0 || fkn > ADP_MAXFKEY) return;
+        e = &adp_fkey[fkn];
+    } else {
+        if (code < 0 || code >= ADP_EVT_COUNT) return;
+        e = &adp_evt[code];
+    }
+    memcpy(e->s, s, len);
+    e->len = len;
+    if (label && *label) {
+        strncpy(e->label, label, ADP_MAXLABEL - 1);
+        e->label[ADP_MAXLABEL - 1] = 0;
+    } else {
+        e->label[0] = 0;
+    }
+
+}
+
+/* Read a trailing "! ... <newline>" comment on the current line, if any.
+   Writes the trimmed comment into out[0..maxlen-1]. Leaves the stream
+   positioned just before the terminating newline (or EOF). Non-comment
+   non-whitespace characters are pushed back so the main parser sees them. */
+static void adp_trailing_comment(adp_parser* p, char* out, int maxlen) {
+
+    int c, n;
+
+    out[0] = 0;
+    for (;;) {
+        c = adp_getc(p);
+        if (c == EOF) return;
+        if (c == '\n') { adp_ungetc(p, c); return; }
+        if (c == ' ' || c == '\t') continue;
+        if (c != '!') { adp_ungetc(p, c); return; }
+        /* consume comment text */
+        while ((c = adp_getc(p)) == ' ' || c == '\t') ;
+        n = 0;
+        while (c != EOF && c != '\n') {
+            if (n < maxlen - 1) out[n++] = (char)c;
+            c = adp_getc(p);
+        }
+        while (n > 0 && (out[n-1] == ' ' || out[n-1] == '\t')) n--;
+        out[n] = 0;
+        if (c == '\n') adp_ungetc(p, c);
+        return;
+    }
+
+}
+
+/* Parse a keyequ block: pairs of (identifier, string [, ! comment]) until
+   "keyend". */
+static void adp_parse_keyequ(adp_parser* p) {
+
+    int  code, fkn;
+    char label[ADP_MAXLABEL];
+
+    for (;;) {
+        adp_next(p);
+        if (p->type == ADP_TK_EOF) return;
+        if (p->type == ADP_TK_ERR) return;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "keyend")) return;
+        if (p->type != ADP_TK_IDENT) continue;
+        if (!adp_resolve(p->ident, &code, &fkn)) {
+            /* unknown event name: consume its value and ignore */
+            adp_next(p);
+            continue;
+        }
+        adp_next(p);
+        if (p->type != ADP_TK_STRING) continue;
+        adp_trailing_comment(p, label, sizeof(label));
+        adp_store(code, fkn, p->str, p->strlen_, label);
+    }
+
+}
+
+#ifdef AMI_CURSES_MENU
+
+/* Build a menu (or submenu) linked list from the .adp stream. endkw selects
+   whether this is the top-level "menuend" or a nested "submenuend". Each
+   leaf gets a unique id; its keystring is stored in adp_menu_keys[id] for
+   later retrieval when ami_etmenus fires. Nested submenus recurse. */
+static ami_menuptr adp_build_menu_body(adp_parser* p, const char* endkw) {
+
+    ami_menuptr head = NULL, tail = NULL;
+    int bar_pending = 0;
+    char face[ADP_MAXKEYSTR + 1];
+    int  facelen;
+    ami_menurec* item;
+
+    for (;;) {
+        adp_next(p);
+        if (p->type == ADP_TK_EOF || p->type == ADP_TK_ERR) break;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, endkw)) break;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "bar")) {
+            bar_pending = 1;
+            continue;
+        }
+        if (p->type != ADP_TK_STRING) continue;
+
+        /* capture the face string for this item */
+        facelen = p->strlen_;
+        if (facelen >= (int)sizeof(face)) facelen = sizeof(face) - 1;
+        memcpy(face, p->str, facelen);
+        face[facelen] = 0;
+
+        item = (ami_menurec*)calloc(1, sizeof(ami_menurec));
+        if (!item) continue;
+        item->face = strdup(face);
+        item->bar  = bar_pending;
+        bar_pending = 0;
+
+        adp_next(p);
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "submenu")) {
+            item->branch = adp_build_menu_body(p, "submenuend");
+        } else if (p->type == ADP_TK_STRING
+                   && adp_menu_next_id < ADP_MAX_MENU_ITEMS) {
+            adp_entry* k = &adp_menu_keys[adp_menu_next_id];
+            int klen = p->strlen_;
+            if (klen > ADP_MAXKEYSTR) klen = ADP_MAXKEYSTR;
+            memcpy(k->s, p->str, klen);
+            k->len   = klen;
+            item->id = adp_menu_next_id;
+            adp_menu_next_id++;
+        }
+
+        if (tail) { tail->next = item; tail = item; }
+        else      { head = tail = item; }
+    }
+    return head;
+
+}
+
+static void adp_apply_menu(void) {
+
+    if (adp_menu_root) ami_menu(stdout, adp_menu_root);
+
+}
+
+#else /* !AMI_CURSES_MENU — tokenize through the menu block and discard */
+
+static void adp_parse_menu_body(adp_parser* p, const char* endkw) {
+
+    for (;;) {
+        adp_next(p);
+        if (p->type == ADP_TK_EOF || p->type == ADP_TK_ERR) return;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, endkw)) return;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "bar")) continue;
+        if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "submenu")) {
+            adp_parse_menu_body(p, "submenuend");
+            continue;
+        }
+        if (p->type == ADP_TK_STRING) {
+            adp_next(p);
+            if (p->type == ADP_TK_IDENT && !strcmp(p->ident, "submenu")) {
+                adp_parse_menu_body(p, "submenuend");
+                continue;
+            }
+        }
+    }
+
+}
+
+#endif /* AMI_CURSES_MENU */
+
+/* -------- hint-line construction -------- */
+
+/* Short human-readable name for each event that makes sense as a key. */
+static const struct { int code; const char* name; } adp_keynames[] = {
+    { ami_etup,      "Up"       }, { ami_etdown,    "Down"     },
+    { ami_etleft,    "Left"     }, { ami_etright,   "Right"    },
+    { ami_etleftw,   "WordLeft" }, { ami_etrightw,  "WordRight"},
+    { ami_ethome,    "Home"     }, { ami_ethomel,   "Home"     },
+    { ami_ethomes,   "Home"     }, { ami_etend,     "End"      },
+    { ami_etendl,    "End"      }, { ami_etends,    "End"      },
+    { ami_etpagu,    "PgUp"     }, { ami_etpagd,    "PgDn"     },
+    { ami_ettab,     "Tab"      }, { ami_etenter,   "Enter"    },
+    { ami_etinsert,  "Ins"      }, { ami_etinsertl, "InsLine"  },
+    { ami_etinsertt, "InsTog"   }, { ami_etdel,     "Del"      },
+    { ami_etdell,    "DelLine"  }, { ami_etdelcf,   "Del>"     },
+    { ami_etdelcb,   "BkSp"     }, { ami_etcopy,    "Copy"     },
+    { ami_etcopyl,   "CopyLn"   }, { ami_etcan,     "Esc"      },
+    { ami_etstop,    "Stop"     }, { ami_etcont,    "Cont"     },
+    { ami_etprint,   "Print"    }, { ami_etprintb,  "PrintBlk" },
+    { ami_etprints,  "PrintScr" }, { ami_etmenu,    "Menu"     },
+    { ami_etterm,    "Quit"     },
+    { 0, NULL }
+};
+
+/* Append "piece " to adp_hint if it fits. */
+static void adp_hint_append(const char* piece) {
+
+    size_t n = strlen(adp_hint);
+    size_t plen = strlen(piece);
+    if (n + plen + 2 >= sizeof(adp_hint)) return;
+    memcpy(adp_hint + n, piece, plen);
+    adp_hint[n + plen]     = ' ';
+    adp_hint[n + plen + 1] = ' ';
+    adp_hint[n + plen + 2] = 0;
+
+}
+
+/* Format "<key>" or "<key>=<label>" into piece[]. */
+static void adp_fmt_piece(char* piece, int psize,
+                          const char* key, const char* label) {
+
+    int n = 0;
+    int klen = (int)strlen(key);
+    int llen = label ? (int)strlen(label) : 0;
+    if (klen > psize - 1) klen = psize - 1;
+    memcpy(piece, key, klen);
+    n = klen;
+    if (llen > 0 && n < psize - 1) {
+        piece[n++] = '=';
+        if (llen > psize - 1 - n) llen = psize - 1 - n;
+        memcpy(piece + n, label, llen);
+        n += llen;
+    }
+    piece[n] = 0;
+
+}
+
+/* Format "F<n>" or "F<n>=<label>" into piece[]. */
+static void adp_fmt_fkey(char* piece, int psize, int k, const char* label) {
+
+    char numbuf[8];
+    int  nn = 0, n = 0;
+    int  llen = label ? (int)strlen(label) : 0;
+    int  kk = k;
+    /* integer to decimal, reversed */
+    if (kk == 0) numbuf[nn++] = '0';
+    while (kk > 0) { numbuf[nn++] = (char)('0' + kk % 10); kk /= 10; }
+    if (n < psize - 1) piece[n++] = 'F';
+    while (nn > 0 && n < psize - 1) piece[n++] = numbuf[--nn];
+    if (llen > 0 && n < psize - 1) {
+        piece[n++] = '=';
+        if (llen > psize - 1 - n) llen = psize - 1 - n;
+        memcpy(piece + n, label, (size_t)llen);
+        n += llen;
+    }
+    piece[n] = 0;
+
+}
+
+/* Build the hint string from loaded mappings. Each mapped event becomes
+   "<KeyName>" (if label is empty or just a key echo) or "<KeyName>=<label>"
+   (short description of the action). Result goes into adp_hint. */
+static void adp_build_hint(void) {
+
+    char   piece[ADP_MAXLABEL + 32];
+    int    i;
+    const adp_entry* e;
+
+    adp_hint[0] = 0;
+    for (i = 0; adp_keynames[i].name; i++) {
+        int c = adp_keynames[i].code;
+        if (c < 0 || c >= ADP_EVT_COUNT) continue;
+        e = &adp_evt[c];
+        if (e->len == 0) continue;
+        /* avoid duplicate entries for aliased names (e.g., ethome/ethomel
+           both print "Home"): skip if an earlier synonym already appeared */
+        {
+            int j, seen = 0;
+            for (j = 0; j < i; j++) {
+                int cc = adp_keynames[j].code;
+                if (cc >= 0 && cc < ADP_EVT_COUNT
+                    && adp_evt[cc].len > 0
+                    && !strcmp(adp_keynames[j].name, adp_keynames[i].name)) {
+                    seen = 1; break;
+                }
+            }
+            if (seen) continue;
+        }
+        adp_fmt_piece(piece, (int)sizeof(piece),
+                      adp_keynames[i].name, e->label);
+        adp_hint_append(piece);
+    }
+    for (i = 1; i <= ADP_MAXFKEY; i++) {
+        if (adp_fkey[i].len == 0) continue;
+        adp_fmt_fkey(piece, (int)sizeof(piece), i, adp_fkey[i].label);
+        adp_hint_append(piece);
+    }
+
+}
+
+/* Count how many rows are needed to display the hint at width cols.
+   Uses simple word-wrap (break at spaces). Caps at 4 rows. */
+static int adp_hint_rows_for_width(int cols) {
+
+    int rows = 0;
+    int col  = 0;
+    const char* s = adp_hint;
+
+    if (!*s || cols <= 0) return 0;
+    rows = 1;
+    while (*s) {
+        const char* word = s;
+        int wlen;
+        while (*s && *s != ' ') s++;
+        wlen = (int)(s - word);
+        if (col > 0 && col + 1 + wlen > cols) {
+            if (rows >= 4) break;
+            rows++;
+            col = 0;
+        }
+        if (col > 0) col++;     /* space separator */
+        col += wlen;
+        if (col >= cols) { if (rows >= 4) break; rows++; col = 0; }
+        while (*s == ' ') s++;
+    }
+    return rows;
+
+}
+
+/* Draw the hint at the reserved bottom rows. Uses Ami direct calls so it
+   can run under both terminal.c and graphics.c linkage. Preserves the
+   program's cursor position and attribute state. */
+static void adp_draw_hint(void) {
+
+    int cx, cy, mx, my;
+    int row, col;
+    const char* s;
+
+    if (adp_hint_rows == 0 || !adp_hint[0]) return;
+
+    cx = ami_curx(stdout);
+    cy = ami_cury(stdout);
+    mx = ami_maxx(stdout);
+    my = ami_maxy(stdout);
+
+    ami_bcolor(stdout, ami_cyan);
+    ami_fcolor(stdout, ami_black);
+    s = adp_hint;
+    for (row = 0; row < adp_hint_rows; row++) {
+        ami_cursor(stdout, 1, my - adp_hint_rows + 1 + row);
+        col = 0;
+        while (*s) {
+            const char* word = s;
+            int wlen;
+            while (*s && *s != ' ') s++;
+            wlen = (int)(s - word);
+            if (col > 0 && col + 1 + wlen > mx) break;
+            if (col > 0) { putchar(' '); col++; }
+            {
+                int i;
+                for (i = 0; i < wlen && col < mx; i++, col++) putchar(word[i]);
+            }
+            while (*s == ' ') s++;
+        }
+        while (col < mx) { putchar(' '); col++; }
+    }
+    /* reset to curses defaults then re-apply any program-set attrs/pair */
+    ami_fcolor(stdout, ami_white);
+    ami_bcolor(stdout, ami_black);
+    apply_attrs();
+    ami_cursor(stdout, cx, cy);
+
+}
+
+/* -------- top-level loader -------- */
+
+static void adp_load(void) {
+
+    char pth[ADP_MAXSTR];
+    char nam[ADP_MAXSTR];
+    char ext[ADP_MAXSTR];
+    char fil[ADP_MAXSTR];
+    adp_parser p;
+    FILE* f;
+
+    if (adp_loaded) return;
+    adp_loaded = 1;
+
+    memset(adp_evt,  0, sizeof(adp_evt));
+    memset(adp_fkey, 0, sizeof(adp_fkey));
+
+    /* directory of the running program */
+    pth[0] = 0;
+    ami_getpgm(pth, ADP_MAXSTR);
+
+    /* basename of the running program */
+    nam[0] = 0;
+#if defined(__linux) || defined(__MINGW32__)
+    if (program_invocation_name && program_invocation_name[0]) {
+        ami_brknam(program_invocation_name,
+                   ext, ADP_MAXSTR,          /* path (discarded) */
+                   nam, ADP_MAXSTR,          /* name */
+                   ext, ADP_MAXSTR);         /* ext (discarded) */
+    }
+#endif
+    if (!nam[0]) return;  /* can't determine program name → dormant */
+
+    ami_maknam(fil, ADP_MAXSTR, pth, nam, "adp");
+    f = fopen(fil, "r");
+    if (!f) return;  /* file absent → dormant */
+
+    p.f = f;
+    p.pb = -1;
+    for (;;) {
+        adp_next(&p);
+        if (p.type == ADP_TK_EOF || p.type == ADP_TK_ERR) break;
+        if (p.type != ADP_TK_IDENT) continue;
+        if (!strcmp(p.ident, "keyequ")) {
+            adp_parse_keyequ(&p);
+        } else if (!strcmp(p.ident, "menu")) {
+#ifdef AMI_CURSES_MENU
+            adp_menu_root = adp_build_menu_body(&p, "menuend");
+            adp_apply_menu();
+#else
+            adp_parse_menu_body(&p, "menuend");
+#endif
+        }
+    }
+    fclose(f);
+
+    adp_build_hint();
+
+}
+
+/* Look up a mapping for an incoming event; return pointer/length or NULL. */
+static const unsigned char* adp_lookup(const ami_evtrec* er, int* out_len) {
+
+    if (!adp_loaded) return NULL;
+#ifdef AMI_CURSES_MENU
+    if (er->etype == ami_etmenus) {
+        int id = er->menuid;
+        if (id > 0 && id < ADP_MAX_MENU_ITEMS
+            && adp_menu_keys[id].len > 0) {
+            *out_len = adp_menu_keys[id].len;
+            return adp_menu_keys[id].s;
+        }
+        return NULL;
+    }
+#endif
+    if (er->etype == ami_etfun) {
+        int k = er->fkey;
+        if (k >= 1 && k <= ADP_MAXFKEY && adp_fkey[k].len > 0) {
+            *out_len = adp_fkey[k].len;
+            return adp_fkey[k].s;
+        }
+    }
+    if ((int)er->etype >= 0 && (int)er->etype < ADP_EVT_COUNT
+        && adp_evt[er->etype].len > 0) {
+        *out_len = adp_evt[er->etype].len;
+        return adp_evt[er->etype].s;
+    }
+    return NULL;
+
+}
 
 /* color pair table: fg/bg for each pair */
 static struct { short fg; short bg; } color_pairs[COLOR_PAIRS];
@@ -134,9 +859,10 @@ WINDOW* initscr(void) {
     cur_echo = 0;
 
     /* Ami terminal auto mode handles scrolling and cursor movement.
-       For curses compatibility we turn it off so we have full control. */
+       For curses compatibility we turn it off so we have full control.
+       Cursor visibility is left at the terminal default — real ncurses
+       does not hide it in initscr(); programs call curs_set(0) to hide. */
     ami_auto(stdout, 0);
-    ami_curvis(stdout, 0);
 
     /* query screen size */
     LINES = ami_maxy(stdout);
@@ -146,6 +872,17 @@ WINDOW* initscr(void) {
     memset(color_pairs, 0, sizeof(color_pairs));
     color_pairs[0].fg = COLOR_WHITE;
     color_pairs[0].bg = COLOR_BLACK;
+
+    /* load <progname>.adp alongside the executable, if present */
+    adp_load();
+
+    /* reserve bottom rows for the adapter hint line, if any */
+    adp_hint_rows = adp_hint_rows_for_width(COLS);
+    if (adp_hint_rows > 0) {
+        LINES -= adp_hint_rows;
+        if (LINES < 1) { LINES = 1; adp_hint_rows = 0; }
+    }
+    adp_draw_hint();
 
     return stdscr;
 
@@ -179,6 +916,7 @@ Output
 
 int refresh(void) {
 
+    adp_draw_hint();
     fflush(stdout);
     return OK;
 
@@ -314,6 +1052,11 @@ int getch(void) {
 
     ami_evtrec er;
 
+    /* emit queued chars from a previous adapter mapping */
+    if (adp_outpos < adp_outlen) {
+        return (int)adp_outbuf[adp_outpos++];
+    }
+
     /* check ungetch buffer first */
     if (cur_ungetch >= 0) {
 
@@ -336,7 +1079,21 @@ int getch(void) {
     /* blocking wait for event */
     while (1) {
 
+        const unsigned char* mapped;
+        int mlen = 0;
+
         ami_event(stdin, &er);
+
+        /* adapter override: if the .adp file mapped this event, emit
+           the mapped string one character per getch() call. */
+        mapped = adp_lookup(&er, &mlen);
+        if (mapped && mlen > 0) {
+            memcpy(adp_outbuf, mapped, (size_t)mlen);
+            adp_outlen = mlen;
+            adp_outpos = 1;
+            return (int)adp_outbuf[0];
+        }
+
         switch (er.etype) {
 
             case ami_etchar:   return er.echar;
@@ -529,6 +1286,55 @@ int nl(void) { return OK; }
 int nonl(void) { return OK; }
 char erasechar(void) { return '\b'; }
 char killchar(void) { return 0x15; /* Ctrl-U */ }
+int delwin(WINDOW* win) { (void)win; return OK; }
+int doupdate(void) { fflush(stdout); return OK; }
+int wnoutrefresh(WINDOW* win) { (void)win; return OK; }
+int clearok(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+int use_default_colors(void) { return OK; }
+
+int waddnstr(WINDOW* win, const char* str, int n) {
+
+    int i;
+    (void)win;
+    for (i = 0; i < n && str[i]; i++) addch((unsigned char)str[i]);
+    return OK;
+
+}
+
+int wredrawln(WINDOW* win, int beg, int num) {
+
+    (void)win; (void)beg; (void)num;
+    return OK;
+
+}
+
+int savetty(void) { return OK; }
+int resetty(void) { return OK; }
+int typeahead(int fd) { (void)fd; return OK; }
+int meta(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+int idlok(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+
+mmask_t mousemask(mmask_t newmask, mmask_t* oldmask) {
+
+    if (oldmask) *oldmask = 0;
+    (void)newmask;
+    return 0;
+
+}
+
+int getmouse(MEVENT* event) {
+
+    (void)event;
+    return ERR;
+
+}
+
+int ungetmouse(MEVENT* event) {
+
+    (void)event;
+    return ERR;
+
+}
 
 int winch(WINDOW* win) {
 
@@ -709,6 +1515,15 @@ int mvwprintw(WINDOW* win, int y, int x, const char* fmt, ...) {
 
 }
 
+int mvwaddnstr(WINDOW* win, int y, int x, const char* str, int n) {
+
+    wmove(win, y, x);
+    return waddnstr(win, str, n);
+
+}
+
 int wclear(WINDOW* win) { (void)win; return clear(); }
 int wclrtoeol(WINDOW* win) { (void)win; return clrtoeol(); }
 int wgetch(WINDOW* win) { (void)win; return getch(); }
+int wattron(WINDOW* win, int attrs) { (void)win; return attron(attrs); }
+int wattroff(WINDOW* win, int attrs) { (void)win; return attroff(attrs); }

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -1,25 +1,34 @@
 #
-# Makefile for BSD curses games on Petit-Ami
+# Makefile for BSD curses games and nano on Petit-Ami
 #
-# Builds each game in both terminal and graphics versions using the
+# Builds each program in both terminal and graphics versions using the
 # curses compatibility layer in apis/curses.c.
 #
-# Usage: make          (builds all)
-#        make snake     (builds snake_term and snake_gfx)
+# Usage: make               (builds all terminal + graphical variants)
+#        make nano nanog    (builds one program, terminal + graphical)
 #        make clean
 #
+# Naming convention (Ami standard):
+#   <name>   terminal build (links terminal.c)
+#   <name>g  graphical build (links graphics.c)
+#
+# Binaries and .adp adapter files are installed into $(BINDIR) so the
+# curses adapter (ami_getpgm) finds <progname>.adp alongside the binary.
+#
 
-ROOT    = ..
-CC      = gcc
+ROOT     = ..
+BINDIR   = $(ROOT)/bin
+CC       = gcc
 
 # flags for building the curses adapter (needs Ami stdio interception)
 AMIFLAGS = -g3 -I$(ROOT)/apis -I$(ROOT)/include -I$(ROOT)/libc \
            -I/usr/include/freetype2 -I/usr/include/libpng16 -DSTDIO_BYPASS
 
-# flags for building game source (standard libc, no Ami stdio override)
-CFLAGS  = -g3 -I$(ROOT)/apis -D'__COPYRIGHT(x)=' -D'__RCSID(x)='
+# flags for building program source (standard libc, no Ami stdio override)
+CFLAGS   = -g3 -I$(ROOT)/apis -D'__COPYRIGHT(x)=' -D'__RCSID(x)='
 
-CURSES_OBJ = $(ROOT)/apis/curses.o
+CURSES_TOBJ = $(ROOT)/apis/curses.o
+CURSES_GOBJ = $(ROOT)/apis/cursesg.o
 
 # Static link against Petit-Ami .o files directly.
 TOBJ    = $(ROOT)/linux/stdio.o $(ROOT)/linux/services.o \
@@ -35,91 +44,107 @@ GOBJ    = $(ROOT)/linux/stdio.o $(ROOT)/linux/services.o \
           $(ROOT)/utils/config.o $(ROOT)/utils/option.o \
           $(ROOT)/cpp/terminal.o
 
-TLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(TOBJ) \
+TLIBS   = $(CURSES_TOBJ) $(ROOT)/stub/keeper.o $(TOBJ) \
           $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
           $(ROOT)/linux/dumpsynthplug.o \
           -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd -lstdc++
 
-GLIBS   = $(CURSES_OBJ) $(ROOT)/stub/keeper.o $(GOBJ) \
+GLIBS   = $(CURSES_GOBJ) $(ROOT)/stub/keeper.o $(GOBJ) \
           $(ROOT)/linux/sound.o $(ROOT)/linux/fluidsynthplug.o \
           $(ROOT)/linux/dumpsynthplug.o \
           -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto \
           -lX11 -lXext -lfreetype -lfontconfig -lbsd -lstdc++
 
-GAMES   = snake rain worm worms canfield
+GAMES    = snake rain worm worms canfield
+PROGRAMS = $(GAMES) nano
+BINS     = $(PROGRAMS) $(addsuffix g,$(PROGRAMS))
+BIN_EXES = $(addprefix $(BINDIR)/,$(BINS))
 
-all: $(CURSES_OBJ) $(foreach g,$(GAMES),$(g)_term $(g)_gfx)
+# Any .adp files in this directory are staged next to the binaries.
+ADP_SRC  = $(wildcard *.adp)
+BIN_ADP  = $(addprefix $(BINDIR)/,$(ADP_SRC))
 
-snake: snake_term snake_gfx
-rain: rain_term rain_gfx
-worm: worm_term worm_gfx
-worms: worms_term worms_gfx
-canfield: canfield_term canfield_gfx
-gomoku: gomoku_term gomoku_gfx
+all: $(CURSES_TOBJ) $(CURSES_GOBJ) $(BIN_EXES) $(BIN_ADP)
 
-$(CURSES_OBJ): $(ROOT)/apis/curses.c $(ROOT)/apis/curses.h
-	$(CC) $(AMIFLAGS) -c $(ROOT)/apis/curses.c -o $(CURSES_OBJ)
+# Short phony aliases: `make nano` builds $(BINDIR)/nano.
+.PHONY: all clean $(BINS)
+$(foreach b,$(BINS),$(eval $(b): $(BINDIR)/$(b) $(BIN_ADP)))
+
+# curses.o — linked with terminal.c; menu code compiled out.
+$(CURSES_TOBJ): $(ROOT)/apis/curses.c $(ROOT)/apis/curses.h
+	$(CC) $(AMIFLAGS) -c $(ROOT)/apis/curses.c -o $(CURSES_TOBJ)
+
+# cursesg.o — linked with graphics.c; menu code enabled via AMI_CURSES_MENU.
+$(CURSES_GOBJ): $(ROOT)/apis/curses.c $(ROOT)/apis/curses.h
+	$(CC) $(AMIFLAGS) -DAMI_CURSES_MENU -c $(ROOT)/apis/curses.c -o $(CURSES_GOBJ)
+
+# Copy any .adp adapter file from the source dir to $(BINDIR).
+$(BINDIR)/%.adp: %.adp | $(BINDIR)
+	cp $< $@
+
+$(BINDIR):
+	mkdir -p $(BINDIR)
 
 # Snake
 SNAKE_SRC   = BSDGames/snake/snake/snake.c
 SNAKE_FLAGS = -IBSDGames/snake/snake
-
-snake_term: $(CURSES_OBJ) $(SNAKE_SRC)
+$(BINDIR)/snake:  $(CURSES_TOBJ) $(SNAKE_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(TLIBS) -lm
-
-snake_gfx: $(CURSES_OBJ) $(SNAKE_SRC)
+$(BINDIR)/snakeg: $(CURSES_GOBJ) $(SNAKE_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(SNAKE_FLAGS) -o $@ $(SNAKE_SRC) $(GLIBS) -lm
 
 # Rain
 RAIN_SRC = BSDGames/rain/rain.c
-
-rain_term: $(CURSES_OBJ) $(RAIN_SRC)
+$(BINDIR)/rain:  $(CURSES_TOBJ) $(RAIN_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(TLIBS)
-
-rain_gfx: $(CURSES_OBJ) $(RAIN_SRC)
+$(BINDIR)/raing: $(CURSES_GOBJ) $(RAIN_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(RAIN_SRC) $(GLIBS)
 
 # Worm
 WORM_SRC = BSDGames/worm/worm.c
-
-worm_term: $(CURSES_OBJ) $(WORM_SRC)
+$(BINDIR)/worm:  $(CURSES_TOBJ) $(WORM_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(TLIBS)
-
-worm_gfx: $(CURSES_OBJ) $(WORM_SRC)
+$(BINDIR)/wormg: $(CURSES_GOBJ) $(WORM_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(WORM_SRC) $(GLIBS)
 
 # Worms
 WORMS_SRC = BSDGames/worms/worms.c
-
-worms_term: $(CURSES_OBJ) $(WORMS_SRC)
+$(BINDIR)/worms:  $(CURSES_TOBJ) $(WORMS_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(TLIBS)
-
-worms_gfx: $(CURSES_OBJ) $(WORMS_SRC)
+$(BINDIR)/wormsg: $(CURSES_GOBJ) $(WORMS_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) -o $@ $(WORMS_SRC) $(GLIBS)
 
 # Canfield
 CANFIELD_SRC   = BSDGames/canfield/canfield/canfield.c
 CANFIELD_FLAGS = -IBSDGames/canfield/canfield
-
-canfield_term: $(CURSES_OBJ) $(CANFIELD_SRC)
+$(BINDIR)/canfield:  $(CURSES_TOBJ) $(CANFIELD_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(CANFIELD_FLAGS) -o $@ $(CANFIELD_SRC) $(TLIBS)
-
-canfield_gfx: $(CURSES_OBJ) $(CANFIELD_SRC)
+$(BINDIR)/canfieldg: $(CURSES_GOBJ) $(CANFIELD_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(CANFIELD_FLAGS) -o $@ $(CANFIELD_SRC) $(GLIBS)
 
-# Gomoku
+# Gomoku (not in `all`, build explicitly)
 GOMOKU_SRC   = BSDGames/gomoku/main.c BSDGames/gomoku/bdisp.c \
                BSDGames/gomoku/stoc.c BSDGames/gomoku/makemove.c \
                BSDGames/gomoku/pickmove.c BSDGames/gomoku/bdinit.c
 GOMOKU_FLAGS = -IBSDGames/gomoku -I$(ROOT)/apis/bsdcompat -Dgetline=gomoku_getline
-
-gomoku_term: $(CURSES_OBJ) $(GOMOKU_SRC)
+$(BINDIR)/gomoku:  $(CURSES_TOBJ) $(GOMOKU_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(GOMOKU_FLAGS) -o $@ $(GOMOKU_SRC) $(TLIBS)
-
-gomoku_gfx: $(CURSES_OBJ) $(GOMOKU_SRC)
+$(BINDIR)/gomokug: $(CURSES_GOBJ) $(GOMOKU_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(GOMOKU_FLAGS) -o $@ $(GOMOKU_SRC) $(GLIBS)
+.PHONY: gomoku gomokug
+gomoku:  $(BINDIR)/gomoku  $(BIN_ADP)
+gomokug: $(BINDIR)/gomokug $(BIN_ADP)
+
+# Nano (v1.2.5)
+NANO_SRC   = nano/nano.c nano/winio.c nano/files.c nano/cut.c \
+             nano/search.c nano/move.c nano/color.c nano/global.c \
+             nano/rcfile.c nano/utils.c
+NANO_FLAGS = -Inano -DNANO_SMALL
+$(BINDIR)/nano:  $(CURSES_TOBJ) $(NANO_SRC) | $(BINDIR)
+	$(CC) $(CFLAGS) $(NANO_FLAGS) -o $@ $(NANO_SRC) $(TLIBS)
+$(BINDIR)/nanog: $(CURSES_GOBJ) $(NANO_SRC) | $(BINDIR)
+	$(CC) $(CFLAGS) $(NANO_FLAGS) -o $@ $(NANO_SRC) $(GLIBS)
 
 clean:
-	rm -f $(CURSES_OBJ) *_term *_gfx
-
-.PHONY: all clean snake rain worm worms
+	rm -f $(CURSES_TOBJ) $(CURSES_GOBJ) $(BIN_EXES) $(BIN_ADP) \
+	      $(BINDIR)/gomoku $(BINDIR)/gomokug

--- a/curses/nano.adp
+++ b/curses/nano.adp
@@ -1,0 +1,70 @@
+! nano.adp - Adapter file for GNU nano text editor
+!
+! Maps Ami terminal events to nano's control key sequences.
+! Nano uses Emacs-style control keys for navigation and editing.
+
+keyequ
+
+    ! navigation
+    etup       '^p'       ! previous line
+    etdown     '^n'       ! next line
+    etleft     '^b'       ! backward one character
+    etright    '^f'       ! forward one character
+    ethomel    '^a'       ! beginning of line
+    etendl     '^e'       ! end of line
+    etpagu     '^y'       ! page up
+    etpagd     '^v'       ! page down
+    ethome     '\x01'     ! beginning of file (same as ^A for now)
+
+    ! editing
+    etenter    '\n'       ! enter/newline (nano inserts on LF, not CR)
+    ettab      '\t'       ! tab
+    etdelcb    '\x08'     ! backspace
+    etdelcf    '^d'       ! delete forward
+    etdel      '^k'       ! cut line (delete block)
+    etinsert   '^u'       ! uncut/paste (insert)
+    etcan      '^c'       ! cancel / show cursor position
+
+    ! function keys map to nano commands
+    etfun1     '^g'       ! F1 = help
+    etfun2     '^o'       ! F2 = write out (save)
+    etfun3     '^r'       ! F3 = read file (open/insert)
+    etfun4     '^w'       ! F4 = where is (search)
+    etfun5     '^\'       ! F5 = replace
+    etfun6     '^j'       ! F6 = justify
+    etfun7     '^t'       ! F7 = spell check
+
+    ! program control
+    etterm     '^x'       ! terminate = exit nano
+
+keyend
+
+! Menu bar for graphics-mode builds (ami_menu)
+! These appear in the window frame menu bar and generate the
+! corresponding nano control key sequence when clicked.
+
+menu
+
+    'File' submenu
+        'Read File  F3'  '^r'
+        'Save       F2'  '^o'
+        bar
+        'Exit       ^X'  '^x'
+    submenuend
+
+    'Edit' submenu
+        'Cut Line   ^K'  '^k'
+        'Paste      ^U'  '^u'
+        bar
+        'Search     F4'  '^w'
+        'Replace    F5'  '^\'
+        bar
+        'Go To Line ^_'  '^_'
+    submenuend
+
+    'Help' submenu
+        'Help       F1'  '^g'
+        'Position   ^C'  '^c'
+    submenuend
+
+menuend

--- a/curses/nanog.adp
+++ b/curses/nanog.adp
@@ -1,0 +1,70 @@
+! nano.adp - Adapter file for GNU nano text editor
+!
+! Maps Ami terminal events to nano's control key sequences.
+! Nano uses Emacs-style control keys for navigation and editing.
+
+keyequ
+
+    ! navigation
+    etup       '^p'       ! previous line
+    etdown     '^n'       ! next line
+    etleft     '^b'       ! backward one character
+    etright    '^f'       ! forward one character
+    ethomel    '^a'       ! beginning of line
+    etendl     '^e'       ! end of line
+    etpagu     '^y'       ! page up
+    etpagd     '^v'       ! page down
+    ethome     '\x01'     ! beginning of file (same as ^A for now)
+
+    ! editing
+    etenter    '\n'       ! enter/newline (nano inserts on LF, not CR)
+    ettab      '\t'       ! tab
+    etdelcb    '\x08'     ! backspace
+    etdelcf    '^d'       ! delete forward
+    etdel      '^k'       ! cut line (delete block)
+    etinsert   '^u'       ! uncut/paste (insert)
+    etcan      '^c'       ! cancel / show cursor position
+
+    ! function keys map to nano commands
+    etfun1     '^g'       ! F1 = help
+    etfun2     '^o'       ! F2 = write out (save)
+    etfun3     '^r'       ! F3 = read file (open/insert)
+    etfun4     '^w'       ! F4 = where is (search)
+    etfun5     '^\'       ! F5 = replace
+    etfun6     '^j'       ! F6 = justify
+    etfun7     '^t'       ! F7 = spell check
+
+    ! program control
+    etterm     '^x'       ! terminate = exit nano
+
+keyend
+
+! Menu bar for graphics-mode builds (ami_menu)
+! These appear in the window frame menu bar and generate the
+! corresponding nano control key sequence when clicked.
+
+menu
+
+    'File' submenu
+        'Read File  F3'  '^r'
+        'Save       F2'  '^o'
+        bar
+        'Exit       ^X'  '^x'
+    submenuend
+
+    'Edit' submenu
+        'Cut Line   ^K'  '^k'
+        'Paste      ^U'  '^u'
+        bar
+        'Search     F4'  '^w'
+        'Replace    F5'  '^\'
+        bar
+        'Go To Line ^_'  '^_'
+    submenuend
+
+    'Help' submenu
+        'Help       F1'  '^g'
+        'Position   ^C'  '^c'
+    submenuend
+
+menuend


### PR DESCRIPTION
## Summary

- `apis/curses.c` grows a runtime `.adp` adapter: on `initscr()` it looks up `<progname>.adp` next to the binary (via `ami_getpgm` + `ami_brknam`), parses `keyequ`/`menu` blocks, and injects mapped keystrings one char per `getch()` call. Trailing `!`-comments become hint labels.
- Cyan hint bar rendered at the bottom rows with per-key labels (`Up`, `PgUp`, `F1=help`, …), word-wrapped into up to 4 reserved rows. Screen height is shrunk so the adapted program never paints over it.
- Menu blocks build an `ami_menurec` tree and call `ami_menu()` under `-DAMI_CURSES_MENU` (graphics-only). `ami_etmenus` selections inject the item's keystring via a per-id side table.
- Cursor visibility left at terminal default in `initscr()` (real ncurses doesn't hide it; programs call `curs_set(0)` when they want it hidden).

## Build changes

- `curses/Makefile` splits `curses.o` / `cursesg.o` (the latter with `-DAMI_CURSES_MENU`).
- Binaries now follow the Ami naming convention (`nano` / `nanog`, `snake` / `snakeg`, …) and output to `$(ROOT)/bin/` to avoid colliding with the `nano/` source tree. A generic rule `$(BINDIR)/%.adp: %.adp` stages any adapter file next to its binary.
- `curses/nano` registered as a submodule pinned at GNU nano 1.2.5 (`d1861019`).

## Test plan

- [ ] `cd curses && make clean && make nano nanog` produces `bin/nano`, `bin/nanog`, `bin/nano.adp`, `bin/nanog.adp`
- [ ] `bin/nano <file>` shows the cyan hint bar at screen bottom; arrow keys / Enter / BkSp / F1–F7 behave per `nano.adp`
- [ ] `bin/nanog <file>` additionally shows a menu bar (File / Edit / Help); clicking an item triggers the corresponding nano control key
- [ ] Running a curses program with no `.adp` file next to it (e.g. any of the BSD games) behaves exactly as before — adapter stays dormant
- [ ] `make clean` leaves `bin/` populated only with non-adapter-built binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)