### PR TITLE
Add htop as curses-adapter target; extend adapter to host it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "curses/nano"]
 	path = curses/nano
 	url = https://git.savannah.gnu.org/git/nano.git
+[submodule "curses/htop"]
+	path = curses/htop
+	url = https://github.com/htop-dev/htop.git

--- a/apis/curses.c
+++ b/apis/curses.c
@@ -787,6 +787,13 @@ void* cur_term = NULL;              /* terminfo state — dummy (we don't use th
                                        ncurses terminfo layer; provided so
                                        programs that include <term.h> link) */
 
+/* terminfo capability string externs — NULL in our adapter. Programs that
+   pass these to tputs get a no-op; screen-mode transitions handled by
+   terminal.c's own xterm sync. */
+char* enter_ca_mode = NULL;
+char* exit_ca_mode  = NULL;
+char* clear_screen  = NULL;
+
 /* map curses color to Ami color */
 static ami_color color_to_ami(short c) {
 
@@ -1657,4 +1664,19 @@ int wadd_wchnstr(WINDOW* win, const cchar_t* cchs, int n) {
     /* waddchnstr/wadd_wchnstr do not advance the cursor (X/Open) */
     ami_cursor(stdout, cx, cy);
     return OK;
+}
+
+int mvadd_wch(int y, int x, const cchar_t* cch) {
+    move(y, x);
+    return wadd_wch(stdscr, cch);
+}
+
+int mvadd_wchnstr(int y, int x, const cchar_t* cchs, int n) {
+    move(y, x);
+    return wadd_wchnstr(stdscr, cchs, n);
+}
+
+int mvaddnstr(int y, int x, const char* str, int n) {
+    move(y, x);
+    return addnstr(str, n);
 }

--- a/apis/curses.c
+++ b/apis/curses.c
@@ -782,6 +782,10 @@ static WINDOW stdscr_data;
 WINDOW* stdscr = &stdscr_data;
 int LINES = 25;
 int COLS = 80;
+int COLORS = 8;                     /* number of foreground colors supported */
+void* cur_term = NULL;              /* terminfo state — dummy (we don't use the
+                                       ncurses terminfo layer; provided so
+                                       programs that include <term.h> link) */
 
 /* map curses color to Ami color */
 static ami_color color_to_ami(short c) {
@@ -1527,3 +1531,130 @@ int wclrtoeol(WINDOW* win) { (void)win; return clrtoeol(); }
 int wgetch(WINDOW* win) { (void)win; return getch(); }
 int wattron(WINDOW* win, int attrs) { (void)win; return attron(attrs); }
 int wattroff(WINDOW* win, int attrs) { (void)win; return attroff(attrs); }
+
+/* X/Open attr_t-based variants — route through existing int attrs APIs. */
+int wattr_on(WINDOW* win, attr_t attrs, void* opts) {
+    (void)opts; return wattron(win, (int)attrs);
+}
+int wattr_off(WINDOW* win, attr_t attrs, void* opts) {
+    (void)opts; return wattroff(win, (int)attrs);
+}
+int wattrset(WINDOW* win, attr_t attrs) {
+    (void)win; return attrset((int)attrs);
+}
+
+int whline(WINDOW* win, chtype ch, int n) { (void)win; return hline((int)ch, n); }
+int wvline(WINDOW* win, chtype ch, int n) { (void)win; return vline((int)ch, n); }
+
+/*******************************************************************************
+
+Terminfo surface (stubs for programs that pull in <term.h>)
+
+Our adapter does not drive terminfo — initscr() talks to terminal.c directly.
+Programs like htop include <term.h> anyway and reference cur_term/define_key/
+tputs/... as part of their CRT setup. These no-op stubs let them link; the
+program's curses-level calls (initscr, attron, refresh, ...) do the real work.
+
+*******************************************************************************/
+
+int set_escdelay(int ms) { (void)ms; return OK; }
+int define_key(const char* definition, int keycode) {
+    (void)definition; (void)keycode; return OK;
+}
+int mouseinterval(int interval) { (void)interval; return 0; }
+int intrflush(WINDOW* win, int bf) { (void)win; (void)bf; return OK; }
+int mvcur(int oldrow, int oldcol, int newrow, int newcol) {
+    (void)oldrow; (void)oldcol;
+    return move(newrow, newcol);
+}
+
+/* tputs — emit a terminfo capability string via the outc callback. Skips
+   padding specs of the form $<N>, $<N*>, $<N/> (we don't simulate delays). */
+int tputs(const char* str, int affcnt, int (*outc_fn)(int)) {
+    (void)affcnt;
+    if (!str || !outc_fn) return ERR;
+    while (*str) {
+        if (str[0] == '$' && str[1] == '<') {
+            str += 2;
+            while (*str && *str != '>') str++;
+            if (*str) str++;
+            continue;
+        }
+        outc_fn((unsigned char)*str++);
+    }
+    return OK;
+}
+
+/*******************************************************************************
+
+Wide-character curses (minimal shim)
+
+setcchar/getcchar round-trip the cchar_t struct. wadd_wch encodes chars[0]
+as UTF-8 and feeds the bytes through addch — terminal.c's plcchrext reassembles
+them in the target cell. chars[1..] (combining marks) are dropped; terminal.c
+stores a single codepoint per cell so combining marks have nowhere to go.
+
+*******************************************************************************/
+
+int setcchar(cchar_t* cch, const wchar_t* wch, const attr_t attrs,
+             short color_pair, const void* opts) {
+    int i;
+    (void)opts;
+    if (!cch || !wch) return ERR;
+    cch->attr      = attrs | COLOR_PAIR(color_pair);
+    cch->ext_color = 0;
+    for (i = 0; i < CCHARW_MAX - 1 && wch[i]; i++) cch->chars[i] = wch[i];
+    cch->chars[i] = 0;
+    return OK;
+}
+
+int getcchar(const cchar_t* cch, wchar_t* wch, attr_t* attrs,
+             short* color_pair, void* opts) {
+    int i, n = 0;
+    (void)opts;
+    if (!cch) return ERR;
+    while (n < CCHARW_MAX && cch->chars[n]) n++;
+    if (!wch) return n;                 /* query-only form */
+    if (attrs)      *attrs      = cch->attr;
+    if (color_pair) *color_pair = (short)PAIR_NUMBER(cch->attr);
+    for (i = 0; i < n; i++) wch[i] = cch->chars[i];
+    wch[n] = 0;
+    return OK;
+}
+
+int wadd_wch(WINDOW* win, const cchar_t* cch) {
+    unsigned int code;
+    (void)win;
+    if (!cch || !cch->chars[0]) return OK;
+    code = (unsigned int)cch->chars[0];
+    if (code < 0x80) {
+        addch((int)code);
+    } else if (code < 0x800) {
+        addch(0xC0 |  (code >> 6));
+        addch(0x80 |  (code        & 0x3F));
+    } else if (code < 0x10000) {
+        addch(0xE0 |  (code >> 12));
+        addch(0x80 | ((code >>  6) & 0x3F));
+        addch(0x80 |  (code        & 0x3F));
+    } else {
+        addch(0xF0 |  (code >> 18));
+        addch(0x80 | ((code >> 12) & 0x3F));
+        addch(0x80 | ((code >>  6) & 0x3F));
+        addch(0x80 |  (code        & 0x3F));
+    }
+    return OK;
+}
+
+int wadd_wchnstr(WINDOW* win, const cchar_t* cchs, int n) {
+    int i;
+    int cx, cy;
+    if (!cchs) return ERR;
+    cx = ami_curx(stdout);
+    cy = ami_cury(stdout);
+    for (i = 0; (n < 0 || i < n) && cchs[i].chars[0]; i++) {
+        wadd_wch(win, &cchs[i]);
+    }
+    /* waddchnstr/wadd_wchnstr do not advance the cursor (X/Open) */
+    ami_cursor(stdout, cx, cy);
+    return OK;
+}

--- a/apis/curses.h
+++ b/apis/curses.h
@@ -151,6 +151,10 @@ int     wvline(WINDOW* win, chtype ch, int n);
    cur_term is a dummy and these are mostly no-op stubs. */
 extern int   COLORS;
 extern void* cur_term;
+/* terminfo capability strings — NULL in our adapter; tputs is a no-op on NULL */
+extern char* enter_ca_mode;
+extern char* exit_ca_mode;
+extern char* clear_screen;
 int set_escdelay(int ms);
 int define_key(const char* definition, int keycode);
 int mouseinterval(int interval);
@@ -191,6 +195,12 @@ typedef struct { short id; int x, y, z; mmask_t bstate; } MEVENT;
 #define BUTTON1_CLICKED    0x004
 #define BUTTON1_PRESSED    0x002
 #define BUTTON1_RELEASED   0x001
+#define BUTTON2_CLICKED    0x040
+#define BUTTON2_PRESSED    0x020
+#define BUTTON2_RELEASED   0x010
+#define BUTTON3_CLICKED    0x400
+#define BUTTON3_PRESSED    0x200
+#define BUTTON3_RELEASED   0x100
 #define KEY_MOUSE          0x199
 #define REPORT_MOUSE_POSITION 0x100000
 mmask_t mousemask(mmask_t newmask, mmask_t* oldmask);
@@ -235,7 +245,10 @@ int mvvline(int y, int x, int ch, int n);
 #define KEY_F0        0x109
 #define KEY_F(n)      (KEY_F0 + (n))
 #define KEY_ENTER     0x157
+#define KEY_SLEFT     0x189   /* shift-left arrow */
+#define KEY_SRIGHT    0x192   /* shift-right arrow */
 #define KEY_RESIZE    0x19A
+#define KEY_MAX       0x1FF   /* maximum legal key value */
 
 /* Wide-character curses (X/Open Option). Minimal shim: we store a single
    wide char per cell — combining marks in chars[1..] are dropped. That's
@@ -255,5 +268,8 @@ int getcchar(const cchar_t* cch, wchar_t* wch, attr_t* attrs,
              short* color_pair, void* opts);
 int wadd_wch(WINDOW* win, const cchar_t* cch);
 int wadd_wchnstr(WINDOW* win, const cchar_t* cchs, int n);
+int mvadd_wch(int y, int x, const cchar_t* cch);
+int mvadd_wchnstr(int y, int x, const cchar_t* cchs, int n);
+int mvaddnstr(int y, int x, const char* str, int n);
 
 #endif /* _AMI_CURSES_H */

--- a/apis/curses.h
+++ b/apis/curses.h
@@ -134,9 +134,29 @@ int     mvwaddch(WINDOW* win, int y, int x, int ch);
 int     mvwaddstr(WINDOW* win, int y, int x, const char* str);
 int     wprintw(WINDOW* win, const char* fmt, ...);
 int     mvwprintw(WINDOW* win, int y, int x, const char* fmt, ...);
+int     mvwaddnstr(WINDOW* win, int y, int x, const char* str, int n);
 int     wclear(WINDOW* win);
 int     wclrtoeol(WINDOW* win);
 int     wgetch(WINDOW* win);
+int     wattron(WINDOW* win, int attrs);
+int     wattroff(WINDOW* win, int attrs);
+int     wattr_on(WINDOW* win, attr_t attrs, void* opts);
+int     wattr_off(WINDOW* win, attr_t attrs, void* opts);
+int     wattrset(WINDOW* win, attr_t attrs);
+int     whline(WINDOW* win, chtype ch, int n);
+int     wvline(WINDOW* win, chtype ch, int n);
+
+/* terminfo / low-level terminal — minimal surface for programs that use
+   <term.h> (e.g. htop's CRT.c). Our adapter doesn't drive terminfo, so
+   cur_term is a dummy and these are mostly no-op stubs. */
+extern int   COLORS;
+extern void* cur_term;
+int set_escdelay(int ms);
+int define_key(const char* definition, int keycode);
+int mouseinterval(int interval);
+int intrflush(WINDOW* win, int bf);
+int mvcur(int oldrow, int oldcol, int newrow, int newcol);
+int tputs(const char* str, int affcnt, int (*outc_fn)(int));
 
 /* misc */
 int napms(int ms);
@@ -152,6 +172,30 @@ int nl(void);
 int nonl(void);
 char erasechar(void);
 char killchar(void);
+int delwin(WINDOW* win);
+int doupdate(void);
+int wnoutrefresh(WINDOW* win);
+int clearok(WINDOW* win, int bf);
+int use_default_colors(void);
+int waddnstr(WINDOW* win, const char* str, int n);
+int wredrawln(WINDOW* win, int beg, int num);
+int savetty(void);
+int resetty(void);
+int typeahead(int fd);
+int meta(WINDOW* win, int bf);
+int idlok(WINDOW* win, int bf);
+
+/* mouse (minimal stubs) */
+typedef unsigned long mmask_t;
+typedef struct { short id; int x, y, z; mmask_t bstate; } MEVENT;
+#define BUTTON1_CLICKED    0x004
+#define BUTTON1_PRESSED    0x002
+#define BUTTON1_RELEASED   0x001
+#define KEY_MOUSE          0x199
+#define REPORT_MOUSE_POSITION 0x100000
+mmask_t mousemask(mmask_t newmask, mmask_t* oldmask);
+int getmouse(MEVENT* event);
+int ungetmouse(MEVENT* event);
 
 /* box drawing */
 int box(WINDOW* win, int verch, int horch);
@@ -188,8 +232,28 @@ int mvvline(int y, int x, int ch, int n);
 #define KEY_IC        0x14B  /* insert */
 #define KEY_DC        0x14A  /* delete */
 #define KEY_BACKSPACE 0x107
-#define KEY_F(n)      (0x109 + (n))
+#define KEY_F0        0x109
+#define KEY_F(n)      (KEY_F0 + (n))
 #define KEY_ENTER     0x157
 #define KEY_RESIZE    0x19A
+
+/* Wide-character curses (X/Open Option). Minimal shim: we store a single
+   wide char per cell — combining marks in chars[1..] are dropped. That's
+   fine for the programs we target (htop only fills chars[0]), and it
+   matches terminal.c's own UTF-8-per-cell storage model. */
+#include <stddef.h>                 /* for wchar_t without pulling in stdio */
+#define CCHARW_MAX 5
+typedef struct {
+    attr_t   attr;
+    wchar_t  chars[CCHARW_MAX];
+    int      ext_color;
+} cchar_t;
+
+int setcchar(cchar_t* cch, const wchar_t* wch, const attr_t attrs,
+             short color_pair, const void* opts);
+int getcchar(const cchar_t* cch, wchar_t* wch, attr_t* attrs,
+             short* color_pair, void* opts);
+int wadd_wch(WINDOW* win, const cchar_t* cch);
+int wadd_wchnstr(WINDOW* win, const cchar_t* cchs, int n);
 
 #endif /* _AMI_CURSES_H */

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -57,10 +57,12 @@ GLIBS   = $(CURSES_GOBJ) $(ROOT)/stub/keeper.o $(GOBJ) \
 
 GAMES     = snake rain worm worms canfield
 PROGRAMS  = $(GAMES) nano
-# Standalone programs: have their own build system, terminal-only (no graphical
-# variant today), built by this Makefile as a per-target recipe.
+# Standalone programs: have their own build system (autotools etc.). Built
+# by this Makefile as per-target recipes, both terminal and graphical
+# variants following the <name> / <name>g convention.
 STANDALONE = htop
-BINS      = $(PROGRAMS) $(addsuffix g,$(PROGRAMS)) $(STANDALONE)
+BINS      = $(PROGRAMS) $(addsuffix g,$(PROGRAMS)) \
+            $(STANDALONE) $(addsuffix g,$(STANDALONE))
 BIN_EXES  = $(addprefix $(BINDIR)/,$(BINS))
 
 # Any .adp files in this directory are staged next to the binaries.
@@ -148,14 +150,17 @@ $(BINDIR)/nano:  $(CURSES_TOBJ) $(NANO_SRC) | $(BINDIR)
 $(BINDIR)/nanog: $(CURSES_GOBJ) $(NANO_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(NANO_FLAGS) -o $@ $(NANO_SRC) $(GLIBS)
 
-# htop (terminal only — uses its own autoconf+automake build).
-# Overrides LIBS / AM_CPPFLAGS to swap ncursesw for the Petit-Ami stack.
-# Configure runs once (autogen then configure) per fresh tree; thereafter
-# htop's own Makefile handles incremental rebuilds. The $(CURSES_TOBJ)
-# prerequisite forces a re-link if the adapter changes.
+# htop — uses its own autoconf+automake build. We override LIBS / AM_CPPFLAGS
+# to swap ncursesw for the Petit-Ami stack. Configure runs once per fresh
+# tree; thereafter htop's own Makefile handles incremental rebuilds. Built
+# twice — once against terminal.c (htop) and once against graphics.c (htopg).
 HTOP_DIR      = htop
 HTOP_ROOT     = $(abspath $(ROOT))
-HTOP_PA_LIBS  = $(HTOP_ROOT)/apis/curses.o $(HTOP_ROOT)/stub/keeper.o \
+
+# Per-variant backend object lists (abspath form — htop's Makefile runs from
+# its own subdirectory). The curses object is variant-specific; everything
+# else matches the TLIBS / GLIBS recipes above.
+HTOP_TOBJ     = $(HTOP_ROOT)/apis/curses.o $(HTOP_ROOT)/stub/keeper.o \
                 $(HTOP_ROOT)/linux/stdio.o $(HTOP_ROOT)/linux/services.o \
                 $(HTOP_ROOT)/linux/network.o $(HTOP_ROOT)/linux/terminal.o \
                 $(HTOP_ROOT)/linux/system_event.o \
@@ -164,9 +169,23 @@ HTOP_PA_LIBS  = $(HTOP_ROOT)/apis/curses.o $(HTOP_ROOT)/stub/keeper.o \
                 $(HTOP_ROOT)/linux/sound.o $(HTOP_ROOT)/linux/fluidsynthplug.o \
                 $(HTOP_ROOT)/linux/dumpsynthplug.o \
                 -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd -lstdc++
+
+HTOP_GOBJ     = $(HTOP_ROOT)/apis/cursesg.o $(HTOP_ROOT)/stub/keeper.o \
+                $(HTOP_ROOT)/linux/stdio.o $(HTOP_ROOT)/linux/services.o \
+                $(HTOP_ROOT)/linux/network.o $(HTOP_ROOT)/linux/graphics.o \
+                $(HTOP_ROOT)/linux/system_event.o \
+                $(HTOP_ROOT)/portable/gnome_widgets.o \
+                $(HTOP_ROOT)/utils/config.o $(HTOP_ROOT)/utils/option.o \
+                $(HTOP_ROOT)/cpp/terminal.o \
+                $(HTOP_ROOT)/linux/sound.o $(HTOP_ROOT)/linux/fluidsynthplug.o \
+                $(HTOP_ROOT)/linux/dumpsynthplug.o \
+                -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto \
+                -lX11 -lXext -lfreetype -lfontconfig -lbsd -lstdc++
+
 HTOP_PA_CPPFLAGS = -I$(HTOP_ROOT)/apis -I$(HTOP_ROOT)/include \
                    -I/usr/include/libunwind -DNDEBUG
-HTOP_LIBS_OVERRIDE = -lunwind -Wl,-Bsymbolic-functions $(HTOP_PA_LIBS) -ldl -lm
+HTOP_T_LIBS   = -lunwind -Wl,-Bsymbolic-functions $(HTOP_TOBJ) -ldl -lm
+HTOP_G_LIBS   = -lunwind -Wl,-Bsymbolic-functions $(HTOP_GOBJ) -ldl -lm
 
 $(HTOP_DIR)/configure:
 	cd $(HTOP_DIR) && ./autogen.sh
@@ -187,9 +206,20 @@ $(HTOP_DIR)/Makefile: $(HTOP_DIR)/configure
 	    -e 's|^/\* #undef HAVE_CURSES_H \*/|#define HAVE_CURSES_H 1|' \
 	    $(HTOP_DIR)/config.h
 
+# htop's Makefile only ever produces one file called `htop`. For each of our
+# two variants (terminal / graphics), force-relink by deleting it first,
+# then move the output under the Petit-Ami <name>/<name>g convention.
 $(BINDIR)/htop: $(CURSES_TOBJ) $(HTOP_DIR)/Makefile | $(BINDIR)
+	rm -f $(HTOP_DIR)/htop
 	cd $(HTOP_DIR) && $(MAKE) \
-	    LIBS='$(HTOP_LIBS_OVERRIDE)' \
+	    LIBS='$(HTOP_T_LIBS)' \
+	    AM_CPPFLAGS='$(HTOP_PA_CPPFLAGS)' htop
+	mv $(HTOP_DIR)/htop $@
+
+$(BINDIR)/htopg: $(CURSES_GOBJ) $(HTOP_DIR)/Makefile | $(BINDIR)
+	rm -f $(HTOP_DIR)/htop
+	cd $(HTOP_DIR) && $(MAKE) \
+	    LIBS='$(HTOP_G_LIBS)' \
 	    AM_CPPFLAGS='$(HTOP_PA_CPPFLAGS)' htop
 	mv $(HTOP_DIR)/htop $@
 

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -55,10 +55,13 @@ GLIBS   = $(CURSES_GOBJ) $(ROOT)/stub/keeper.o $(GOBJ) \
           -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto \
           -lX11 -lXext -lfreetype -lfontconfig -lbsd -lstdc++
 
-GAMES    = snake rain worm worms canfield
-PROGRAMS = $(GAMES) nano
-BINS     = $(PROGRAMS) $(addsuffix g,$(PROGRAMS))
-BIN_EXES = $(addprefix $(BINDIR)/,$(BINS))
+GAMES     = snake rain worm worms canfield
+PROGRAMS  = $(GAMES) nano
+# Standalone programs: have their own build system, terminal-only (no graphical
+# variant today), built by this Makefile as a per-target recipe.
+STANDALONE = htop
+BINS      = $(PROGRAMS) $(addsuffix g,$(PROGRAMS)) $(STANDALONE)
+BIN_EXES  = $(addprefix $(BINDIR)/,$(BINS))
 
 # Any .adp files in this directory are staged next to the binaries.
 ADP_SRC  = $(wildcard *.adp)
@@ -145,6 +148,54 @@ $(BINDIR)/nano:  $(CURSES_TOBJ) $(NANO_SRC) | $(BINDIR)
 $(BINDIR)/nanog: $(CURSES_GOBJ) $(NANO_SRC) | $(BINDIR)
 	$(CC) $(CFLAGS) $(NANO_FLAGS) -o $@ $(NANO_SRC) $(GLIBS)
 
+# htop (terminal only — uses its own autoconf+automake build).
+# Overrides LIBS / AM_CPPFLAGS to swap ncursesw for the Petit-Ami stack.
+# Configure runs once (autogen then configure) per fresh tree; thereafter
+# htop's own Makefile handles incremental rebuilds. The $(CURSES_TOBJ)
+# prerequisite forces a re-link if the adapter changes.
+HTOP_DIR      = htop
+HTOP_ROOT     = $(abspath $(ROOT))
+HTOP_PA_LIBS  = $(HTOP_ROOT)/apis/curses.o $(HTOP_ROOT)/stub/keeper.o \
+                $(HTOP_ROOT)/linux/stdio.o $(HTOP_ROOT)/linux/services.o \
+                $(HTOP_ROOT)/linux/network.o $(HTOP_ROOT)/linux/terminal.o \
+                $(HTOP_ROOT)/linux/system_event.o \
+                $(HTOP_ROOT)/utils/config.o $(HTOP_ROOT)/utils/option.o \
+                $(HTOP_ROOT)/cpp/terminal.o \
+                $(HTOP_ROOT)/linux/sound.o $(HTOP_ROOT)/linux/fluidsynthplug.o \
+                $(HTOP_ROOT)/linux/dumpsynthplug.o \
+                -lasound -lfluidsynth -lm -lpthread -lssl -lcrypto -lbsd -lstdc++
+HTOP_PA_CPPFLAGS = -I$(HTOP_ROOT)/apis -I$(HTOP_ROOT)/include \
+                   -I/usr/include/libunwind -DNDEBUG
+HTOP_LIBS_OVERRIDE = -lunwind -Wl,-Bsymbolic-functions $(HTOP_PA_LIBS) -ldl -lm
+
+$(HTOP_DIR)/configure:
+	cd $(HTOP_DIR) && ./autogen.sh
+
+# After configure, tweak config.h so htop's ProvideCurses.h /
+# ProvideTerm.h land on plain <curses.h> / <term.h> (ours, via AM_CPPFLAGS)
+# instead of the system ncursesw/ncurses variants. HAVE_LIBNCURSESW stays
+# on so htop keeps its wide-character code paths.
+$(HTOP_DIR)/Makefile: $(HTOP_DIR)/configure
+	cd $(HTOP_DIR) && ./configure
+	sed -i \
+	    -e '/^#define HAVE_NCURSESW_CURSES_H /d' \
+	    -e '/^#define HAVE_NCURSESW_TERM_H /d' \
+	    -e '/^#define HAVE_NCURSES_CURSES_H /d' \
+	    -e '/^#define HAVE_NCURSES_TERM_H /d' \
+	    -e '/^#define HAVE_NCURSES_NCURSES_H /d' \
+	    -e '/^#define HAVE_NCURSES_H /d' \
+	    -e 's|^/\* #undef HAVE_CURSES_H \*/|#define HAVE_CURSES_H 1|' \
+	    $(HTOP_DIR)/config.h
+
+$(BINDIR)/htop: $(CURSES_TOBJ) $(HTOP_DIR)/Makefile | $(BINDIR)
+	cd $(HTOP_DIR) && $(MAKE) \
+	    LIBS='$(HTOP_LIBS_OVERRIDE)' \
+	    AM_CPPFLAGS='$(HTOP_PA_CPPFLAGS)' htop
+	mv $(HTOP_DIR)/htop $@
+
 clean:
 	rm -f $(CURSES_TOBJ) $(CURSES_GOBJ) $(BIN_EXES) $(BIN_ADP) \
 	      $(BINDIR)/gomoku $(BINDIR)/gomokug
+	@if [ -f $(HTOP_DIR)/Makefile ]; then \
+	    $(MAKE) -C $(HTOP_DIR) clean > /dev/null 2>&1 || true; \
+	fi


### PR DESCRIPTION
## Summary

Brings **htop** under the Petit-Ami curses adapter, both terminal and graphical variants, via the `<name>` / `<name>g` convention. `make -C curses htop htopg` drives the full autogen → configure → build → install pipeline and drops `bin/htop` (3.5 MB) and `bin/htopg` (4.1 MB).

## Commits

1. **Register `curses/htop` as submodule** — pinned at `htop-dev/htop` v3.5.0+10 (`13187f2`).
2. **Extend curses adapter to cover htop's API surface** — window X/Open variants (`wattr_on`/`wattr_off`/`wattrset`, `whline`/`wvline`), terminfo compatibility stubs (`COLORS`, `cur_term`, `enter_ca_mode`/`exit_ca_mode`/`clear_screen`, `set_escdelay`, `define_key`, `mouseinterval`, `intrflush`, `mvcur`, `tputs`), and the wide-character option (`cchar_t`, `setcchar`/`getcchar`/`wadd_wch`/`wadd_wchnstr` + `mvadd_wch`/`mvadd_wchnstr`/`mvaddnstr`). Single codepoint per cell — combining marks in `chars[1..]` dropped, matches `linux/terminal.c`'s UTF-8 storage. Extra key/button constants: `KEY_SLEFT`/`KEY_SRIGHT`/`KEY_MAX`, `BUTTON2_*`/`BUTTON3_*`.
3. **`curses/Makefile`: add htop target** — new `HTOP_*` rules drive autogen/configure, sed-rewrite `config.h` to point htop's `ProvideCurses.h` / `ProvideTerm.h` at plain `<curses.h>` (our adapter via `-I$(ROOT)/apis`) instead of system `<ncursesw/curses.h>`. `HAVE_LIBNCURSESW` stays on so htop keeps wide-character code paths. Link overrides via `LIBS` swap ncursesw for the Petit-Ami backend. `make clean` defers to htop's own clean.
4. **`curses/Makefile`: add htopg graphical variant** — mirrors nano/snake/etc. `htop` links `curses.o` + `terminal.o` + TLIBS; `htopg` links `cursesg.o` (with `-DAMI_CURSES_MENU`) + `graphics.o` + GLIBS (X11 / freetype / fontconfig). htop's Makefile only produces one `htop` binary, so each recipe rm's it first to force a re-link before moving to the final path.

## Test plan

- [ ] `cd curses && make htop htopg` from a fresh tree produces `bin/htop` and `bin/htopg`
- [ ] From project root, `bin/htop` launches (certs resolve) and paints the process list in a terminal
- [ ] `bin/htopg` opens an X11 window and paints the same
- [ ] Braille graph meters in CPU/memory panes render correctly (tests the wide-char shim)
- [ ] Arrow keys, F1/F2/F3 menus, process sort/filter work
- [ ] No regressions in `bin/nano`, `bin/nanog`, or the BSD games
- [ ] Native htop build (`cd curses/htop && make`) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)