### PR TITLE
Add 45 degree lines test to graphics_test.c

### DIFF
--- a/tests/graphics_test.c
+++ b/tests/graphics_test.c
@@ -1414,6 +1414,33 @@ goto skip;
     ami_linewidth(stdout, 1);
     waitnext();
 
+    /* ************************** 45 degree lines test ************************* */
+
+    putchar('\f');
+    grid();
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/20;
+    /* Lines have slope 1 (y = x + y_intercept). Draw them long enough to
+       exit the window on both ends — X11 clips to the window area. Stepping
+       the y-intercept from below the top-right corner down to above the
+       bottom-left fills the whole usable window with parallel diagonals. */
+    ysize = ami_maxxg(stdout)+ami_maxyg(stdout);
+    y = -(ami_maxxg(stdout)-xspace);
+    w = 1;
+    while (y+w/2 < ami_maxyg(stdout)-ami_chrsizy(stdout)-yspace) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, 0, y, ysize, y+ysize);
+        y = y+xspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    /* caption last — the text blanks the background behind it, so it's
+       still readable after the diagonals have swept through the bottom */
+    prtcen(ami_maxy(stdout), "45 degree lines test");
+    waitnext();
+
     /* **************************** Polar lines test *************************** */
 
     putchar('\f');


### PR DESCRIPTION
## Summary

Adds a **45 degree lines test** to `tests/graphics_test.c`, modeled after the existing Vertical and Horizontal lines tests. Parallel slope-1 diagonals of increasing width fill the whole usable window area.

Inserted after the Horizontal lines test, before the Polar lines test.

## Details

- Step the y-intercept from below the top-right corner down to above the bottom-left, stepping by `xspace` each iteration.
- Draw each line from `(0, y)` to `(xmax+ymax, y+xmax+ymax)` — extends well past both window corners so X11's automatic clipping trims to the visible area.
- Line width increments by 1 each iteration, matching the pattern in the horizontal/vertical tests.
- Caption (`prtcen("45 degree lines test")`) moved to AFTER the drawing and just before `waitnext()`, so the text-render's background-blank keeps the caption legible despite diagonals passing through the bottom row.

## Test plan

- [ ] `make graphics_test` succeeds
- [ ] Run `./bin/graphics_test` and press Enter past earlier panels until the **45 degree lines test** screen
- [ ] Diagonals fill the whole usable window area, each wider than the previous
- [ ] Caption at the bottom is readable (not overlapped)
- [ ] Subsequent tests (Polar lines, color tests, etc.) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)