### PR TITLE
Add ami_linestyle: solid / dashed / dotted line rendering

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -61,8 +61,8 @@ extern "C" {
    widgets placed onto it. */
 typedef enum { ami_black, ami_white, ami_red, ami_green, ami_blue, ami_cyan,
                ami_yellow, ami_magenta, ami_backcolor } ami_color;
-/* line styles (passed as int to ami_linestyle) */
-enum { ami_lssolid, ami_lsdash, ami_lsdot };
+/* line styles */
+typedef enum { ami_lssolid, ami_lsdash, ami_lsdot } ami_lstyle;
 /* events */
 typedef enum {
     ami_etchar,     /* ANSI character returned */
@@ -402,7 +402,7 @@ int ami_curxg(FILE* f);
 int ami_curyg(FILE* f);
 void ami_line(FILE* f, int x1, int y1, int x2, int y2);
 void ami_linewidth(FILE* f, int w);
-void ami_linestyle(FILE* f, int style);
+void ami_linestyle(FILE* f, ami_lstyle style);
 void ami_rect(FILE* f, int x1, int y1, int x2, int y2);
 void ami_frect(FILE* f, int x1, int y1, int x2, int y2);
 void ami_rrect(FILE* f, int x1, int y1, int x2, int y2, int xs, int ys);
@@ -659,7 +659,7 @@ typedef int (*ami_curxg_t)(FILE* f);
 typedef int (*ami_curyg_t)(FILE* f);
 typedef void (*ami_line_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_linewidth_t)(FILE* f, int w);
-typedef void (*ami_linestyle_t)(FILE* f, int style);
+typedef void (*ami_linestyle_t)(FILE* f, ami_lstyle style);
 typedef void (*ami_rect_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_frect_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_rrect_t)(FILE* f, int x1, int y1, int x2, int y2, int xs, int ys);

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -61,6 +61,8 @@ extern "C" {
    widgets placed onto it. */
 typedef enum { ami_black, ami_white, ami_red, ami_green, ami_blue, ami_cyan,
                ami_yellow, ami_magenta, ami_backcolor } ami_color;
+/* line styles (passed as int to ami_linestyle) */
+enum { ami_lssolid, ami_lsdash, ami_lsdot };
 /* events */
 typedef enum {
     ami_etchar,     /* ANSI character returned */
@@ -400,6 +402,7 @@ int ami_curxg(FILE* f);
 int ami_curyg(FILE* f);
 void ami_line(FILE* f, int x1, int y1, int x2, int y2);
 void ami_linewidth(FILE* f, int w);
+void ami_linestyle(FILE* f, int style);
 void ami_rect(FILE* f, int x1, int y1, int x2, int y2);
 void ami_frect(FILE* f, int x1, int y1, int x2, int y2);
 void ami_rrect(FILE* f, int x1, int y1, int x2, int y2, int xs, int ys);
@@ -656,6 +659,7 @@ typedef int (*ami_curxg_t)(FILE* f);
 typedef int (*ami_curyg_t)(FILE* f);
 typedef void (*ami_line_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_linewidth_t)(FILE* f, int w);
+typedef void (*ami_linestyle_t)(FILE* f, int style);
 typedef void (*ami_rect_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_frect_t)(FILE* f, int x1, int y1, int x2, int y2);
 typedef void (*ami_rrect_t)(FILE* f, int x1, int y1, int x2, int y2, int xs, int ys);
@@ -910,6 +914,7 @@ void _pa_band_ovr(ami_band_t nfp, ami_band_t* ofp);
 void _pa_for_ovr(ami_for_t nfp, ami_for_t* ofp);
 void _pa_bor_ovr(ami_bor_t nfp, ami_bor_t* ofp);
 void _pa_linewidth_ovr(ami_linewidth_t nfp, ami_linewidth_t* ofp);
+void _pa_linestyle_ovr(ami_linestyle_t nfp, ami_linestyle_t* ofp);
 void _pa_chrsizx_ovr(ami_chrsizx_t nfp, ami_chrsizx_t* ofp);
 void _pa_chrsizy_ovr(ami_chrsizy_t nfp, ami_chrsizy_t* ofp);
 void _pa_fonts_ovr(ami_fonts_t nfp, ami_fonts_t* ofp);

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -457,6 +457,7 @@ typedef struct scncon { /* screen context */
 
     /* fields used by graph module */
     int     lwidth;      /* width of lines */
+    int     lstyle;      /* style of lines (ami_linestyle) */
     /* note that the pixel and character dimensions and positions are kept
       in parallel for both characters and pixels */
     int     maxx;        /* maximum characters in x */
@@ -989,6 +990,7 @@ static ami_curxg_t           curxg_vect;
 static ami_curyg_t           curyg_vect;
 static ami_line_t            line_vect;
 static ami_linewidth_t       linewidth_vect;
+static ami_linestyle_t       linestyle_vect;
 static ami_rect_t            rect_vect;
 static ami_frect_t           frect_vect;
 static ami_rrect_t           rrect_vect;
@@ -5197,6 +5199,7 @@ static void iniscn(winptr win, scnptr sc)
     sc->autof = win->gauto; /* set auto scroll and wrap */
     sc->curv = win->gcurv; /* set cursor visibility */
     sc->lwidth = 1; /* set single pixel width */
+    sc->lstyle = ami_lssolid; /* set default line style */
     sc->cfont = win->gcfont; /* set current font */
     sc->fmod = win->gfmod; /* set mix modes */
     sc->bmod = win->gbmod;
@@ -10402,6 +10405,53 @@ Sets the width of lines and several other figures.
 
 *******************************************************************************/
 
+/* Push the current lwidth/lstyle pair into the X GC. Shared by
+   linewidth_ivf and linestyle_ivf — setting either field re-applies both.
+
+   XSetDashes values are absolute pixels (X11 does not scale them with line
+   width), so we scale them ourselves here. Dashes stay visually proportional
+   as width grows, with a minimum floor so width-1 lines still read as
+   dashed/dotted rather than nearly-solid. Values clamped to 127 (signed char
+   range used by XSetDashes). */
+static void applylineattrs(scnptr sc)
+
+{
+
+    int  xstyle;
+    int  on, off;
+    char dashes[2];
+    int  w;
+
+    switch (sc->lstyle) {
+        case ami_lsdash: xstyle = LineOnOffDash; break;
+        case ami_lsdot:  xstyle = LineOnOffDash; break;
+        default:         xstyle = LineSolid;     break;
+    }
+    XSetLineAttributes(padisplay, sc->xcxt, sc->lwidth, xstyle,
+                       CapButt, JoinMiter);
+
+    if (sc->lstyle == ami_lsdash) {
+
+        w = sc->lwidth > 0 ? sc->lwidth : 1;
+        on  = w*4;  if (on  < 16) on  = 16;  if (on  > 127) on  = 127;
+        off = w*2;  if (off <  8) off =  8;  if (off > 127) off = 127;
+        dashes[0] = (char)on;
+        dashes[1] = (char)off;
+        XSetDashes(padisplay, sc->xcxt, 0, dashes, 2);
+
+    } else if (sc->lstyle == ami_lsdot) {
+
+        w = sc->lwidth > 0 ? sc->lwidth : 1;
+        on  = w;       if (on  <  2) on  =  2;  if (on  > 127) on  = 127;
+        off = w*3;     if (off <  6) off =  6;  if (off > 127) off = 127;
+        dashes[0] = (char)on;
+        dashes[1] = (char)off;
+        XSetDashes(padisplay, sc->xcxt, 0, dashes, 2);
+
+    }
+
+}
+
 void _pa_linewidth_ovr(ami_linewidth_t nfp, ami_linewidth_t* ofp)
     { *ofp = linewidth_vect; linewidth_vect = nfp; }
 void ami_linewidth(FILE* f, int w) { (*linewidth_vect)(f, w); }
@@ -10417,8 +10467,38 @@ static void linewidth_ivf(FILE* f, int w)
     sc = win->screens[win->curupd-1]; /* index update screen */
     sc->lwidth = w; /* set the line width */
     XWLOCK();
-    /* copy to X */
-    XSetLineAttributes(padisplay, sc->xcxt, w, LineSolid, CapButt, JoinMiter);
+    applylineattrs(sc); /* push width + current style into X */
+    XWUNLOCK();
+
+}
+
+/** ****************************************************************************
+
+Set line style
+
+Selects solid, dashed, or dotted line rendering for subsequent line-drawing
+primitives. X11 supports dashed/dotted lines at any width via
+XSetLineAttributes + XSetDashes. Dash patterns scale with line width so
+thick dashed lines remain visually dashed.
+
+*******************************************************************************/
+
+void _pa_linestyle_ovr(ami_linestyle_t nfp, ami_linestyle_t* ofp)
+    { *ofp = linestyle_vect; linestyle_vect = nfp; }
+void ami_linestyle(FILE* f, int style) { (*linestyle_vect)(f, style); }
+
+static void linestyle_ivf(FILE* f, int style)
+
+{
+
+    winptr win; /* windows record pointer */
+    scnptr sc;  /* screen pointer */
+
+    win = txt2win(f);
+    sc = win->screens[win->curupd-1];
+    sc->lstyle = style;
+    XWLOCK();
+    applylineattrs(sc);
     XWUNLOCK();
 
 }
@@ -16207,6 +16287,7 @@ static void ami_init_graphics(int argc, char *argv[])
     curyg_vect =           curyg_ivf;
     line_vect =            line_ivf;
     linewidth_vect =       linewidth_ivf;
+    linestyle_vect =       linestyle_ivf;
     rect_vect =            rect_ivf;
     frect_vect =           frect_ivf;
     rrect_vect =           rrect_ivf;

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -457,7 +457,7 @@ typedef struct scncon { /* screen context */
 
     /* fields used by graph module */
     int     lwidth;      /* width of lines */
-    int     lstyle;      /* style of lines (ami_linestyle) */
+    ami_lstyle lstyle;   /* style of lines */
     /* note that the pixel and character dimensions and positions are kept
       in parallel for both characters and pixels */
     int     maxx;        /* maximum characters in x */
@@ -10485,9 +10485,9 @@ thick dashed lines remain visually dashed.
 
 void _pa_linestyle_ovr(ami_linestyle_t nfp, ami_linestyle_t* ofp)
     { *ofp = linestyle_vect; linestyle_vect = nfp; }
-void ami_linestyle(FILE* f, int style) { (*linestyle_vect)(f, style); }
+void ami_linestyle(FILE* f, ami_lstyle style) { (*linestyle_vect)(f, style); }
 
-static void linestyle_ivf(FILE* f, int style)
+static void linestyle_ivf(FILE* f, ami_lstyle style)
 
 {
 

--- a/tests/graphics_test.c
+++ b/tests/graphics_test.c
@@ -1441,6 +1441,149 @@ goto skip;
     prtcen(ami_maxy(stdout), "45 degree lines test");
     waitnext();
 
+    /* ******************** Line style tests (dashed + dotted) ***************** *
+     *                                                                          *
+     * Repeat the Vertical / Horizontal / 45 degree lines tests for each of the *
+     * two non-solid styles. Each page sets ami_linestyle once, draws the same  *
+     * family of increasing-width lines as the solid version, then restores     *
+     * ami_lssolid so subsequent tests are unaffected.                          *
+     *                                                                          *
+     **************************************************************************/
+
+    /* ********************** Vertical lines test — dashed ********************* */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdash);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/50;
+    y = yspace;
+    w = 1;
+    while (y+w/2 < ami_maxyg(stdout)-ami_chrsizy(stdout)) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, xspace, y, ami_maxxg(stdout)-xspace, y);
+        y = y+yspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "Vertical lines test (dashed)");
+    waitnext();
+
+    /* ********************** Vertical lines test — dotted ********************* */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdot);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/50;
+    y = yspace;
+    w = 1;
+    while (y+w/2 < ami_maxyg(stdout)-ami_chrsizy(stdout)) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, xspace, y, ami_maxxg(stdout)-xspace, y);
+        y = y+yspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "Vertical lines test (dotted)");
+    waitnext();
+
+    /* ********************* Horizontal lines test — dashed ******************** */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdash);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/20;
+    x = xspace;
+    w = 1;
+    while (x+w/2 < ami_maxxg(stdout)-20) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, x, yspace, x, ami_maxyg(stdout)-ami_chrsizy(stdout));
+        x = x+xspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "Horizontal lines test (dashed)");
+    waitnext();
+
+    /* ********************* Horizontal lines test — dotted ******************** */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdot);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/20;
+    x = xspace;
+    w = 1;
+    while (x+w/2 < ami_maxxg(stdout)-20) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, x, yspace, x, ami_maxyg(stdout)-ami_chrsizy(stdout));
+        x = x+xspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "Horizontal lines test (dotted)");
+    waitnext();
+
+    /* ********************* 45 degree lines test — dashed ********************* */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdash);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/20;
+    ysize = ami_maxxg(stdout)+ami_maxyg(stdout);
+    y = -(ami_maxxg(stdout)-xspace);
+    w = 1;
+    while (y+w/2 < ami_maxyg(stdout)-ami_chrsizy(stdout)-yspace) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, 0, y, ysize, y+ysize);
+        y = y+xspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "45 degree lines test (dashed)");
+    waitnext();
+
+    /* ********************* 45 degree lines test — dotted ********************* */
+
+    putchar('\f');
+    grid();
+    ami_linestyle(stdout, ami_lsdot);
+    yspace = ami_maxyg(stdout)/20;
+    xspace = ami_maxxg(stdout)/20;
+    ysize = ami_maxxg(stdout)+ami_maxyg(stdout);
+    y = -(ami_maxxg(stdout)-xspace);
+    w = 1;
+    while (y+w/2 < ami_maxyg(stdout)-ami_chrsizy(stdout)-yspace) {
+
+        ami_linewidth(stdout, w);
+        ami_line(stdout, 0, y, ysize, y+ysize);
+        y = y+xspace;
+        w = w+1;
+
+    }
+    ami_linewidth(stdout, 1);
+    ami_linestyle(stdout, ami_lssolid);
+    prtcen(ami_maxy(stdout), "45 degree lines test (dotted)");
+    waitnext();
+
     /* **************************** Polar lines test *************************** */
 
     putchar('\f');


### PR DESCRIPTION
## Summary

Implements the proposal from [discussion #73](https://github.com/samiam95124/amitk/discussions/73) — a minimal `linestyle` API with **solid**, **dashed**, and **dotted** modes. Dash rendering via `XSetDashes` at arbitrary line widths is non-trivial to emulate from the base primitives, which fits the toolkit philosophy of only providing what isn't readily buildable.

## API

```c
enum { ami_lssolid, ami_lsdash, ami_lsdot };
void ami_linestyle(FILE* f, int style);
```

Standard Petit-Ami override plumbing (`ami_linestyle_t`, `_pa_linestyle_ovr`) included. The enum is intentionally anonymous so the function name `ami_linestyle` stays free — callers pass the constants as `int`.

## Implementation ([linux/graphics.c](linux/graphics.c))

- New `int lstyle;` field in `scnrec`, initialized to `ami_lssolid` in screen init (multi-screen programs get per-screen styles).
- New `applylineattrs(sc)` helper that pushes `sc->lwidth` + `sc->lstyle` through `XSetLineAttributes` + (for non-solid styles) `XSetDashes`. `linewidth_ivf` and `linestyle_ivf` both call it, so changing either field re-applies both.
- `XSetDashes` values are **absolute pixels** (X11 does not scale them by line width), so `applylineattrs` scales the dash on/off values proportional to `sc->lwidth` with a minimum floor. Thin lines still look clearly dashed/dotted; thick lines don't turn into blotches. Values clamped to 127 (signed char range `XSetDashes` uses).

| line width | dash on / off | dot on / off |
|:-:|:-:|:-:|
| 1  | 16 / 8  | 2 / 6  |
| 5  | 20 / 10 | 5 / 15 |
| 10 | 40 / 20 | 10 / 30 |
| 20 | 80 / 40 | 20 / 60 |

## Tests ([tests/graphics_test.c](tests/graphics_test.c))

Six new test pages inserted after the 45-degree-lines test, before the Polar-lines test:

1. Vertical lines test (dashed)
2. Vertical lines test (dotted)
3. Horizontal lines test (dashed)
4. Horizontal lines test (dotted)
5. 45 degree lines test (dashed)
6. 45 degree lines test (dotted)

Each mirrors its solid counterpart's geometry and increasing-width loop exactly; only `ami_linestyle(...)` at the top differs, and each page restores `ami_lssolid` at the end so downstream tests are unaffected.

## Test plan

- [ ] `make graphics_test` succeeds
- [ ] Press Enter through existing solid-line tests to reach the new pages
- [ ] Each dashed page shows clearly dashed lines at every width
- [ ] Each dotted page shows clearly dotted lines at every width
- [ ] Subsequent tests (Polar lines, color tests) remain solid (style was restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)