### PR TITLE
Skip FcFini() in graphics teardown to avoid a static-fontconfig double-free

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -16859,13 +16859,15 @@ static void ami_deinit_graphics()
 
     /* shutdown FreeType and fontconfig.
        Note: we clear the glyph cache (freeing X pixmaps) but do NOT call
-       FT_Done_FreeType(). Individual FT_Done_Face() calls have already
-       been made during window close, and FT_Done_FreeType() would try to
-       free them again (double-free → segfault). The process is exiting,
-       so the OS reclaims all heap memory regardless. */
+       FT_Done_FreeType() or FcFini(). Individual FT_Done_Face() calls have
+       already been made during window close, and FT_Done_FreeType() would try
+       to free them again (double-free → segfault). FcFini() has the same
+       problem under a statically linked fontconfig: it tears down fontconfig's
+       internal config, which double-frees at exit ("double free or corruption").
+       The process is exiting, so the OS reclaims all heap memory regardless. */
     ft_cache_clear();
     /* FT_Done_FreeType(ftlibrary); — skipped, see above */
-    FcFini();
+    /* FcFini(); — skipped, see above */
 
     /* close joysticks */
     for (ji = 0; ji < MAXJOY; ji++) if (joytab[ji]) close(joytab[ji]->fid);


### PR DESCRIPTION
## Problem

A graphics program that links **fontconfig statically** aborts at exit with `double free or corruption (out)`. The crash is in `ami_deinit_graphics` (graphics teardown), at the `FcFini()` call.

`FcFini()` tears down fontconfig's internal config. Under a statically linked fontconfig this double-frees that config at process exit. A dynamically linked fontconfig happens to tolerate the call, so the bug is invisible in dynamic builds (e.g. the default Linux build) and only surfaces in fully static binaries.

## Fix

`ami_deinit_graphics` already skips `FT_Done_FreeType()` for the analogous reason — the font faces are torn down at window close, so calling it again double-frees. `FcFini()` has the same character: it's a process-exit teardown that double-frees under static linking. Skip it for the same reason already documented in that block: the process is exiting, so the OS reclaims all heap memory regardless.

```c
    ft_cache_clear();
    /* FT_Done_FreeType(ftlibrary); — skipped, see above */
    /* FcFini(); — skipped, see above */
```

No functional loss: `FcFini()` only releases memory at exit, which the OS reclaims anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)