### PR TITLE
Init services before the I/O models so config can resolve $HOME

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -3417,7 +3417,12 @@ Note the environment is unordered.
 
 *******************************************************************************/
 
-static void ami_init_services (int argc, char* argv[]) __attribute__((constructor (102)));
+/* Priority 101 (before the I/O models at 102+): the environment list this
+   builds is a dependency of config reading. The graphics/terminal/... init at
+   102+ call ami_config -> ami_getusr -> ami_getenv, which need the env list to
+   resolve $HOME; if services ran at the same priority (link-order dependent),
+   that lookup could fail and the user-home config would be missed. */
+static void ami_init_services (int argc, char* argv[]) __attribute__((constructor (101)));
 static void ami_init_services(int argc, char* argv[])
 
 {


### PR DESCRIPTION
## Problem

A graphics (or terminal) program never reads its **user-home** config file (`~/.petit_ami.cfg`). The window comes up at the built-in default size, ignoring `console_points` in the user config.

Traced with `strace`: the config search's "User" slot opens files in the **program directory**, not the home directory — i.e. `ami_getusr` fell back to the program path instead of returning `$HOME`.

Root cause: `ami_config` (run from each I/O model's constructor) resolves the home dir via `ami_getusr` → `ami_getenv("HOME")`, and `ami_getenv` reads only the environment list that `ami_init_services` builds from `environ` (no direct `environ` fallback). `ami_init_services` and `ami_init_graphics` were **both constructor priority 102**, so their execution order was link-determined. When graphics ran first (confirmed via `.init_array`), the env list was still empty at config-read time, so `ami_getenv("HOME")` returned nothing and `ami_getusr` fell back to `ami_getpgm`. The user-home config was never tried.

(It looks fine from a runtime `getenv` probe because by `main()` the services constructor has run — but the config was already read in the constructor, before it.)

## Fix

Lower `ami_init_services` to constructor priority **101** — alongside `system_event` (which has no env-list dependency) — so the environment list is built before any of the I/O models at 102+ read config.

```c
static void ami_init_services(...) __attribute__((constructor (101)));   // was 102
```

Verified via `.init_array`: `ami_init_services` now precedes `ami_init_graphics`, so `ami_getenv("HOME")` resolves at config time and the user-home config is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)