### PR TITLE
graphics: trim font names, fix font-list test loops, force graphics link in testg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ testc: $(CLIBSD) test.c
 	$(CC) $(CFLAGS) test.c $(CLIBS) -o testc
 	
 testg: $(GLIBSD) test.c
-	$(CC) $(CFLAGS) test.c $(GLIBS) -o testg
+	$(CC) $(CFLAGS) test.c -Wl,-u,ami_cursorg $(GLIBS) -o testg
 	
 test+: $(PLIBSD) test.cp
 	$(CPP) $(CFLAGS) test.cp $(PLIBS) -o test
@@ -1007,7 +1007,7 @@ testc++: $(CLIBSCPPD) test.cpp
 	$(CPP) $(CFLAGSCPP) test.cpp $(CLIBSCPP) -o testc
 	
 testg++: $(GLIBSD) test.cpp
-	$(CPP) $(CFLAGS) test.cpp $(GLIBS) -o testg
+	$(CPP) $(CFLAGS) test.cpp -Wl,-u,ami_cursorg $(GLIBS) -o testg
 	
 #
 # Target programs that use Petit-Ami, such as games, utilities, etc.

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -2744,6 +2744,31 @@ void stdfont(void)
 
 /*******************************************************************************
 
+Append trimmed lowercase string
+
+Copies a source string onto the build pointer, lowercased, with any leading and
+trailing whitespace removed. Used to assemble font names so that no stray spaces
+appear at the start or end of a component. Returns the advanced build pointer.
+
+*******************************************************************************/
+
+static char* apptrim(char* dp, const char* s)
+
+{
+
+    const char* e; /* end of trimmed source */
+
+    while (*s && isspace((unsigned char)*s)) s++; /* skip leading whitespace */
+    e = s+strlen(s); /* find end of source */
+    while (e > s && isspace((unsigned char)e[-1])) e--; /* trim trailing space */
+    while (s < e) *dp++ = tolower((unsigned char)*s++); /* copy lowercased */
+
+    return (dp); /* return advanced pointer */
+
+}
+
+/*******************************************************************************
+
 Load fonts list
 
 Loads the font list using fontconfig. We only load scalable fonts, since PA has
@@ -2811,19 +2836,12 @@ void getfonts(void)
         if (FcPatternGetInteger(font, FC_INDEX, 0, &fcindex) != FcResultMatch)
             fcindex = 0;
 
-        /* construct display name: "foundry: family: iso10646-1" */
+        /* construct display name: "foundry: family: iso10646-1", trimming
+           leading and trailing whitespace from each component */
         dp = buf;
-        {
-            const char* s;
-            s = (const char*)fcfoundry;
-            while (*s) { *dp = tolower(*s); dp++; s++; }
-        }
+        dp = apptrim(dp, (const char*)fcfoundry);
         *dp++ = ':'; *dp++ = ' ';
-        {
-            const char* s;
-            s = (const char*)fcfamily;
-            while (*s) { *dp = tolower(*s); dp++; s++; }
-        }
+        dp = apptrim(dp, (const char*)fcfamily);
         *dp++ = ':'; *dp++ = ' ';
         {
             const char* cs = "iso10646-1";

--- a/tests/graphics_test.c
+++ b/tests/graphics_test.c
@@ -1205,7 +1205,6 @@ int main(void)
 
     ami_frametimer(stdout, TRUE); /* start frame timer */
     if (setjmp(terminate_buf)) goto terminate;
-goto skip;
     ami_curvis(stdout, FALSE);
     ami_binvis(stdout);
     printf("Graphics screen test vs. 0.1\n");
@@ -2673,17 +2672,10 @@ goto skip;
     grid();
     printf("Number of fonts: %d\n", ami_fonts(stdout));
     printf("\n");
-    i = 1;
     cnt = ami_fonts(stdout);
-    while (cnt > 0) {
+    for (i = 1; i <= cnt; i++) { /* visit each font code */
 
-        /* find defined font code */
-        do {
-
-            ami_fontnam(stdout, i, fns, 100);
-            if (!strlen(fns)) i++;
-
-        } while (!strlen(fns));
+        ami_fontnam(stdout, i, fns, 100);
         printf("%d: %s\n", i, fns);
         if (ami_cury(stdout) >= ami_maxy (stdout)) { /* screen overflows */
 
@@ -2693,8 +2685,6 @@ goto skip;
             grid();
 
         }
-        i = i+1; /* next font code */
-        cnt = cnt-1; /* count fonts */
 
     }
     printf("\n");
@@ -2708,17 +2698,10 @@ goto skip;
     ami_auto(stdout, OFF);
     ami_bcolor(stdout, ami_cyan);
     ami_bover(stdout);
-    i = 1;
     cnt = ami_fonts(stdout);
-    while (cnt) {
+    for (i = 1; i <= cnt; i++) { /* visit each font code */
 
-        /* find defined font code */
-        do {
-
-            ami_fontnam(stdout, i, fns, 100);
-            if (!strlen(fns)) i++;
-
-        } while (!strlen(fns));
+        ami_fontnam(stdout, i, fns, 100);
         ami_font(stdout, i);
         printf("%d: %s\n", i, fns);
         if (ami_cury(stdout) >= ami_maxy(stdout)) { /* screen overflows */
@@ -2732,8 +2715,6 @@ goto skip;
             ami_bcolor(stdout, ami_cyan);
 
         }
-        i++; /* next font code */
-        cnt--; /* count fonts */
 
     }
     ami_bcolor(stdout, ami_white);
@@ -2815,7 +2796,6 @@ goto skip;
 
     /* ************************** Polar text lines test ************************ */
 
-skip:
     putchar('\f');
     grid();
     ami_auto(stdout, OFF); /* rotated text is incompatible with the text grid */


### PR DESCRIPTION
## Summary

Three related graphics/font fixes surfaced while chasing the "Invalid font number" font-list test crash.

### `linux/graphics.c` — trim font names
`getfonts()` assembled font names directly from raw fontconfig foundry/family strings, so a leading or trailing space on a component landed at the start or end of the name (e.g. a leading space, or `"family : iso10646-1"`). A leading space was the source of a name being mistaken for a blank entry. A new `apptrim()` helper copies each component lowercased with leading/trailing whitespace stripped; the deliberate `": "` separators are preserved.

### `tests/graphics_test.c` — simplify font loops + remove debug skip
- The *Font list* and *Font examples* loops used a fragile form: count down a separate total (`ami_fonts()`) while advancing the font code through an unbounded inner `do/while` that skipped blank-named entries. That assumed the total and the named-code sequence stayed in lockstep; if they ever diverged the code index could run past `fntcnt` and raise `error(einvftn)` ("Invalid font number"). Both loops are replaced with a straightforward bounded `for (i = 1; i <= ami_fonts(); i++)` that visits every code once and prints it. There is **no** blank-skipping: the font list contains no blank entries (names are now trimmed and `ami_fonts()` equals the number of named fonts), so every code in `1..ami_fonts()` is valid.
- Removed a leftover `goto skip;` debug jump that bypassed most of `main()` — including the font tests — so the full test runs again.

### `Makefile` — force graphics module in `testg`
`testg` / `testg++` build `test.c`, which uses only the generic Petit-Ami API, so nothing forced the graphical backend module to be pulled in. Added `-Wl,-u,ami_cursorg` so the graphics module is referenced (matters for the static archive link path).

## Verification
- Built `lib/petit_ami_graph.so` and `bin/graphics_test` clean.
- Ran a headless (Xvfb) enumeration of every font code against the rebuilt library:
  ```
  ami_fonts()=155 blank=0 lead=0 trail=0
  ```
  155 fonts, no blanks, no leading/trailing spaces, count unchanged by the trim — so iterating `1..ami_fonts()` with no skip is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
