### PR TITLE
Skip XCloseDisplay() in graphics teardown to avoid a static-Xlib double-free

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -16869,8 +16869,15 @@ static void ami_deinit_graphics()
         XWLOCK();
         /* destroy the main window */
         XDestroyWindow(padisplay, win->xwhan);
-        /* close X Window */
-        XCloseDisplay(padisplay);
+        /* Flush the destroy to the server, but do NOT call XCloseDisplay().
+           Like FT_Done_FreeType() and FcFini() below, it is process-exit
+           teardown that misbehaves under a static link: a statically linked
+           Xlib double-frees display-owned data in _XFreeDisplayStructure
+           ("double free or corruption" at every program exit). The process is
+           exiting, so the connection closes and the OS reclaims all memory
+           regardless. */
+        XFlush(padisplay);
+        /* XCloseDisplay(padisplay); -- skipped, see above */
         XWUNLOCK();
 
     }


### PR DESCRIPTION
## Problem

Every statically linked graphics program aborts at process exit — after the program completes, during shutdown — with `double free or corruption (out)`. The backtrace:

```
_int_free
_XFreeDisplayStructure
XCloseDisplay
ami_deinit_graphics   (linux/graphics.c, the destructor)
__run_exit_handlers / exit
```

## Root cause

`XCloseDisplay()` under a **statically linked Xlib** double-frees display-owned data inside its own `_XFreeDisplayStructure`. A dynamically linked Xlib tolerates the call, which is why the issue is invisible in dynamic builds.

Isolated with a minimal control: the same trivial C program (`ami_autohold(0)`, print, exit) built twice from identical amitk sources — **statically linked: aborts every run; dynamically linked: exits clean.** So the fault is in the static X11 stack's exit-time cleanup, not in amitk's window or heap handling.

## Fix

Skip `XCloseDisplay()` in `ami_deinit_graphics`, for the same reason `FT_Done_FreeType()` and `FcFini()` are already skipped in this teardown block: the process is exiting, so the connection closes and the OS reclaims all memory regardless. An `XFlush()` replaces the call's implicit flush so the main-window destroy still reaches the server before exit.

```c
        XDestroyWindow(padisplay, win->xwhan);
        XFlush(padisplay);
        /* XCloseDisplay(padisplay); -- skipped, see above */
```

## Verification

Statically linked probe (Pascaline binding, full static X11 closure): was aborting on every exit; now exits 0 — five consecutive clean runs. Window behavior unchanged (the destroy is flushed; process exit closes the connection and the server reclaims the windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)