### PR TITLE
Add NOSTDWIN: graphics without the automatic standard I/O window

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -16727,10 +16727,12 @@ static void ami_init_graphics(int argc, char *argv[])
     /* find frame characteristics */
     fndfrm();
 
+#ifndef NOSTDWIN
     /* open stdin and stdout as I/O window set */
     ifn = fileno(stdin); /* get logical id stdin */
     ofn = fileno(stdout); /* get logical id stdout */
     openio(stdin, stdout, ifn, ofn, -1, 1, FALSE); /* process open */
+#endif
 
     /* select XWindow display file */
     XWLOCK();


### PR DESCRIPTION
Compiled with `NOSTDWIN`, the graphics model skips binding stdin/stdout to the automatic main window at initialization. The system-call overrides still install — they pass through for non-window descriptors, and `openwin` window files need them — so the model is inert until an `openwin` call.

Motivation: a hosting program keeps its own console and gives a guest its own window. The Pascal-P6 graphics-hosted interpreter (pintg) builds its "blonde" graphics archive with this flag: the interpreter's messages stay on the terminal, `openwin` hosts the interpreted program's standard I/O in a window, and stderr remains on the console.

Tested: a NOSTDWIN-linked host prints normally to its console, opens a window via `openwin`, and the guest's output/line-edited input flow through the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)