### PR TITLE
killwidget: clear the window-to-widget tracking entry (xltwig)

### DIFF
--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -1130,6 +1130,10 @@ static void intkillwidget(
     /* if there is a subwidget, kill that as well */
     if (wp->cw) ami_killwidget(wp->cw->pw->wf, wp->cw->id);
     if (wp->cw2) ami_killwidget(wp->cw2->pw->wf, wp->cw2->id);
+    xltwig[wp->wid+MAXFIL] = NULL; /* clear the window-to-widget tracking
+                                      entry, or a window id reused after this
+                                      widget is freed would dispatch events to
+                                      the freed entry */
     fclose(wp->wf); /* close the window file */
     opnfil[fn]->widgets[wid+MAXWIG] = NULL; /* clear widget slot  */
     putwig(wp); /* release widget data */


### PR DESCRIPTION
`widget_event` dispatches events to widgets through `xltwig`, indexed by the event's window id. Creating a widget sets `xltwig[wid]`; `intkillwidget` cleared the widget slot and freed the widget data but **left the `xltwig` entry pointing at the freed widget**.

When a later window reuses that window id — e.g. an `alert` dialog opened after a widget was killed — its events dispatch through the stale entry to the freed widget, which draws on its now-closed window and raises *"File is not attached to a window"* (a use-after-free).

Fix: clear `xltwig[wp->wid+MAXFIL]` in `intkillwidget` alongside the widget slot.

Surfaced by the Pascaline widget_test (whose window open/close timing reuses the freed window id at frame 12, the alert test), reproduced minimally as: create a button, killwidget it, then alert. The use-after-free is latent for any caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)