### PR TITLE
widget_test frame numbers + fix child-framed widget window sizing

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -14850,9 +14850,21 @@ static void setsizg_ivf(FILE* f, int x, int y)
            set the dimensions now */
         if (!win->bufmod) {
 
-            /* reset tracking sizes */
-            win->gmaxxg = e.xconfigure.width; /* graphics x */
-            win->gmaxyg = e.xconfigure.height; /* graphics y */
+            /* reset tracking sizes. Child-framed windows resize synchronously
+               above and get no ConfigureNotify, so the event record e is never
+               filled for them; use the computed client dimensions directly
+               instead of reading the uninitialized event. */
+            if (win->childfrm) {
+
+                win->gmaxxg = xwc.width; /* graphics x */
+                win->gmaxyg = xwc.height; /* graphics y */
+
+            } else {
+
+                win->gmaxxg = e.xconfigure.width; /* graphics x */
+                win->gmaxyg = e.xconfigure.height; /* graphics y */
+
+            }
             /* find character size x */
             win->gmaxx = win->gmaxxg/win->charspace;
             /* find character size y */

--- a/tests/widget_test.c
+++ b/tests/widget_test.c
@@ -105,6 +105,23 @@ static char* str(char* s)
 
 }
 
+static int framenum = 0; /* current frame number */
+
+/* set the window title with the chapter frame number, as graphics_test does;
+   called at the start of each chapter so every screen is numbered, including
+   the interactive ones that wait on their own event loop instead of waitnext */
+static void setframe(void)
+
+{
+
+    char titlebuf[80];
+
+    framenum++;
+    sprintf(titlebuf, "widget_test: frame %d", framenum);
+    ami_title(stdout, titlebuf);
+
+}
+
 /* wait return to be pressed, or handle terminate */
 static void waitnext(void)
 
@@ -158,6 +175,8 @@ int main(void)
 
     /* ************************** Background test ************************* */
 
+    setframe();
+
     ami_bcolor(stdout, ami_backcolor);
     printf("\f");
     printf("Background pa_color test\n");
@@ -167,6 +186,8 @@ int main(void)
     ami_bcolor(stdout, ami_white);
 
     /* ************************** Terminal Button test ************************* */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -219,6 +240,8 @@ int main(void)
     ami_killwidget(stdout, 3);
 
     /* ************************* Graphical Buttons test ************************* */
+
+    setframe();
 
     printf("\f");
     printf("Graphical buttons test\n");
@@ -273,6 +296,8 @@ int main(void)
     ami_killwidget(stdout, 3);
 
     /* ************************** Terminal Checkbox test ************************** */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -358,6 +383,8 @@ int main(void)
     ami_killwidget(stdout, 3);
 
     /* ************************** Graphical Checkbox test ************************** */
+
+    setframe();
 
     printf("\f");
     printf("Graphical checkbox test\n");
@@ -447,6 +474,8 @@ int main(void)
 
     /* *********************** Terminal radio button test ********************* */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -531,6 +560,8 @@ int main(void)
     ami_killwidget(stdout, 3);
 
     /* *********************** Graphical radio button test ********************* */
+
+    setframe();
 
     printf("\f");
     printf("Graphical radio button test\n");
@@ -621,6 +652,8 @@ int main(void)
 
     /* *********************** Terminal Group box test ************************ */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -648,6 +681,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* *********************** Graphical Group box test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Graphical group box test\n");
@@ -682,6 +717,8 @@ int main(void)
 
     /* *********************** Terminal background test ************************ */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -698,6 +735,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* *********************** Graphical background test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Graphical background test\n");
@@ -720,6 +759,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* *********************** Terminal scroll bar test *********************** */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -759,6 +800,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* ******************* Terminal scroll bar sizing test ******************** */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -802,6 +845,8 @@ int main(void)
 
     /* ****************** Terminal scroll bar minimums test ******************* */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -835,6 +880,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* ************ Terminal scroll bar fat and skinny bars test ************** */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -874,6 +921,8 @@ int main(void)
 
     /* *********************** Graphical scroll bar test *********************** */
 
+    setframe();
+
     printf("\f");
     printf("Graphical scroll bar test\n");
     printf("\n");
@@ -910,6 +959,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* ******************* Graphical scroll bar sizing test ******************** */
+
+    setframe();
 
     printf("\f");
     printf("Graphical scroll bar sizing test\n");
@@ -957,6 +1008,8 @@ int main(void)
 
     /* ****************** Graphical scroll bar minimums test ******************* */
 
+    setframe();
+
     printf("\f");
     printf("Graphical scroll bar minimums test\n");
     printf("\n");
@@ -993,6 +1046,8 @@ int main(void)
     ami_killwidget(stdout, 2);
 
     /* ************ Graphical scroll bar fat and skinny bars test ************** */
+
+    setframe();
 
     printf("\f");
     printf("Graphical scroll bar fat and skinny bars test\n");
@@ -1036,6 +1091,8 @@ int main(void)
 
     /* ******************** Terminal number select box test ******************* */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -1054,6 +1111,8 @@ int main(void)
 
     /* ******************** Graphical number select box test ******************* */
 
+    setframe();
+
     printf("\f");
     printf("Graphical number select box test\n");
     printf("\n");
@@ -1069,6 +1128,8 @@ int main(void)
     ami_killwidget(stdout, 1);
 
     /* ************************* Terminal edit box test ************************ */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -1094,6 +1155,8 @@ int main(void)
 
     /* ************************* Graphical edit box test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Graphical edit box test\n");
     printf("\n");
@@ -1115,6 +1178,8 @@ int main(void)
     ami_killwidget(stdout, 1);
 
     /* *********************** Terminal progress bar test ********************* */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -1152,6 +1217,8 @@ int main(void)
 
     /* *********************** Graphical progress bar test ********************* */
 
+    setframe();
+
     printf("\f");
     printf("Graphical progress bar test\n");
     printf("\n");
@@ -1185,6 +1252,8 @@ int main(void)
     ami_killwidget(stdout, 1);
 
     /* ************************* Terminal list box test ************************ */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -1229,6 +1298,8 @@ int main(void)
 
     /* ************************* Graphical list box test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Graphical list box test\n");
     printf("\n");
@@ -1266,6 +1337,8 @@ int main(void)
     ami_killwidget(stdout, 1);
 
     /* ************************* Terminal dropdown box test ************************ */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -1310,6 +1383,8 @@ int main(void)
 
     /* ************************* Graphical dropdown box test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Graphical dropdown box test\n");
     printf("\n");
@@ -1348,6 +1423,8 @@ int main(void)
 
     /* ******************* Terminal dropdown edit box test ******************** */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -1385,6 +1462,8 @@ int main(void)
 
     /* ******************* Graphical dropdown edit box test ******************** */
 
+    setframe();
+
     printf("\f");
     printf("Graphical dropdown edit box test\n");
     printf("\n");
@@ -1417,6 +1496,8 @@ int main(void)
 
     /* ************************* Terminal slider test ************************ */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -1444,6 +1525,8 @@ int main(void)
     ami_killwidget(stdout, 4);
 
     /* ************************* Graphical slider test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Graphical slider test\n");
@@ -1481,6 +1564,8 @@ int main(void)
     ami_killwidget(stdout, 4);
 
     /* ************************* Terminal tab bar test ************************ */
+
+    setframe();
 
     printf("\f");
     chrgrid();
@@ -1589,6 +1674,8 @@ int main(void)
     ami_killwidget(stdout, 4);
 
    /* ************************* Graphical tab bar test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Graphical tab bar test\n");
@@ -1717,6 +1804,8 @@ int main(void)
 
     /* ************************* Terminal overlaid tab bar test ************************ */
 
+    setframe();
+
     printf("\f");
     chrgrid();
     ami_binvis(stdout);
@@ -1825,6 +1914,8 @@ int main(void)
 
     /* ************************* Graphical overlaid tab bar test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Graphical overlaid tab bar test\n");
     printf("\n");
@@ -1930,6 +2021,8 @@ int main(void)
 
     /* ************************* Alert test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Alert test\n");
     printf("\n");
@@ -1941,6 +2034,8 @@ int main(void)
     waitnext();
 
     /* ************************* Color query test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Color query test\n");
@@ -1959,6 +2054,8 @@ int main(void)
 
     /* ************************* Open file query test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Open file query test\n");
     printf("\n");
@@ -1974,6 +2071,8 @@ int main(void)
 
     /* ************************* Save file query test ************************ */
 
+    setframe();
+
     printf("\f");
     printf("Save file query test\n");
     printf("\n");
@@ -1988,6 +2087,8 @@ int main(void)
     waitnext();
 
     /* ************************* Find query test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Find query test\n");
@@ -2010,6 +2111,8 @@ int main(void)
     waitnext();
 
     /* ************************* Find/replace query test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Find/replace query test\n");
@@ -2041,6 +2144,8 @@ int main(void)
     waitnext();
 
     /* ************************* Font query test ************************ */
+
+    setframe();
 
     printf("\f");
     printf("Font query test\n");


### PR DESCRIPTION
Two widget-test fixes.

## 1. Frame numbers on widget_test

graphics_test numbers each screen in the window title; widget_test did not. A `setframe()` helper is called at the start of every chapter so each test screen is numbered — including the interactive chapters that wait on their own event loop instead of `waitnext()`. A screen can then be referred to by number ("frame 12").

## 2. Child-framed widget window sizing (the number-select box input bug)

`setsizg_ivf` set a window's tracked client size (`gmaxxg`/`gmaxyg`) from an `XEvent e`:

    win->gmaxxg = e.xconfigure.width;

But `e` is only filled by the `WAITWMR` ConfigureNotify peek, which runs only for top-level windows (`if (!win->childfrm)`). Child-framed windows resize synchronously and get no ConfigureNotify, so for them `e` was uninitialized and the tracked size became garbage (full-screen sized).

Every widget is a child-framed window, so every widget sub-window tracked a full-screen size. An edit box centers its text at `maxyg/2`, which then fell far below the actual small widget — so typed digits, and the +/- signs, in the number-select box were drawn off the visible box and never seen.

Fix: for child-framed windows, set `gmaxxg`/`gmaxyg` from the computed client dimensions (`xwc.width`/`xwc.height`) instead of the uninitialized event.

Diagnosed by stderr instrumentation: the digit was received and accepted by the edit box and the draw loop wrote it, but the box reported a full-screen geometry (1371×1055) instead of its real size (117×61), placing the centered text off-screen. Confirmed fixed on real hardware — digits and signs now display.

This is graphics-wide: it corrects the tracked geometry of every widget sub-window, not just the number box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)