### PR TITLE
Drag dialogs from the graphics layer with a pointer grab

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -478,6 +478,7 @@ void ami_setsiz(FILE* f, int x, int y);
 void ami_setsizg(FILE* f, int x, int y);
 void ami_setpos(FILE* f, int x, int y);
 void ami_setposg(FILE* f, int x, int y);
+void ami_dragwin(FILE* f);
 void ami_scnsiz(FILE* f, int* x, int* y);
 void ami_scnsizg(FILE* f, int* x, int*y);
 void ami_scncen(FILE* f, int* x, int* y);

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -14969,6 +14969,111 @@ static void setposg_ivf(FILE* f, int x, int y)
 
 /** ****************************************************************************
 
+Drag a window under pointer control
+
+Interactively moves the given window, tracking the pointer until the mouse
+button is released. This is called when an application (typically a dialog that
+draws its own title bar) detects a press on its drag handle and wants the window
+to follow the pointer.
+
+The tracking is done entirely in desktop (root) coordinates against the window's
+position at the start of the drag:
+
+    window_pos = start_pos + (pointer_root_now - pointer_root_start)
+
+i.e. the window moves by exactly the pointer's root-space displacement, so the
+point of the window grabbed at button-down stays under the cursor. Because both
+terms are in root and parent coordinates -- never the window-relative client
+frame that moves as the window moves -- there is no feedback to diverge. The
+grab offset is captured once, implicitly, as the difference between the start
+pointer position and the start window position, and is never re-measured.
+
+The pointer is grabbed for the duration so motion continues to be delivered even
+when the pointer outruns the window and leaves its bounds, which a drag does
+constantly. XMoveWindow positions relative to the window's parent, so this works
+unchanged whether the window is a free desktop child, a child of one of our
+windows, or nested arbitrarily deep -- the move math and clipping are uniform at
+every level.
+
+*******************************************************************************/
+
+void ami_dragwin(FILE* f)
+
+{
+
+    winptr win;             /* pointer to windows context */
+    Window root_ret;        /* root the pointer is on */
+    Window child_ret;       /* child the pointer is in */
+    int    rx, ry;          /* pointer root position */
+    int    wx, wy;          /* pointer window position (unused) */
+    unsigned int mask;      /* button/modifier mask (unused) */
+    int    startx, starty;  /* pointer root position at drag start */
+    int    origx, origy;    /* window position at drag start */
+    XEvent de;              /* drag event */
+    int    dragging;        /* drag in progress */
+
+    win = txt2win(f); /* get window context */
+
+    XWLOCK();
+    /* snapshot the pointer's root position and the window's parent-relative
+       position at the instant the drag begins; their difference is the
+       (constant) grab offset, which never needs to be re-measured */
+    XQueryPointer(padisplay, win->xmwhan, &root_ret, &child_ret,
+                  &rx, &ry, &wx, &wy, &mask);
+    startx = rx; starty = ry;
+    origx = win->xmwr.x; origy = win->xmwr.y;
+    /* redirect all pointer motion to us for the duration, so tracking
+       continues even when the pointer leaves the window's bounds */
+    XGrabPointer(padisplay, win->xmwhan, False,
+                 ButtonReleaseMask | PointerMotionMask,
+                 GrabModeAsync, GrabModeAsync, None, None, CurrentTime);
+    XWUNLOCK();
+
+    dragging = TRUE;
+    while (dragging) {
+
+        XWLOCK();
+        XNextEvent(padisplay, &de);
+        XWUNLOCK();
+        if (de.type == MotionNotify) {
+
+            /* move the window by the pointer's root-space delta */
+            int dx = de.xmotion.x_root - startx;
+            int dy = de.xmotion.y_root - starty;
+            win->xmwr.x = origx + dx;
+            win->xmwr.y = origy + dy;
+            XWLOCK();
+            XMoveWindow(padisplay, win->xmwhan, win->xmwr.x, win->xmwr.y);
+            XWUNLOCK();
+
+        } else if (de.type == ButtonRelease) {
+
+            dragging = FALSE;
+
+        } else if (de.type == Expose) {
+
+            /* repaint anything the move exposed, dispatched to its window */
+            int ofn = fndevt(de.xany.window);
+            if (ofn >= 0) {
+
+                winptr ewin = lfn2win(ofn);
+                if (ewin->childfrm && ewin->xmwhan == de.xany.window)
+                    childfrm_draw(ewin);
+                else restore(ewin);
+
+            }
+
+        }
+
+    }
+    XWLOCK();
+    XUngrabPointer(padisplay, CurrentTime);
+    XWUNLOCK();
+
+}
+
+/** ****************************************************************************
+
 Set window position character
 
 Sets the onscreen window position, in character terms. If the window has a

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -6304,13 +6304,10 @@ static void iquerycolor(
     int           rs, gs, bs; /* colors selected */
     unsigned long rgb; /* packed color selected */
     int           cursel; /* currently selected color widget */
-    int           mpx, mpy; /* mouse position */
-    int           lmpx, lmpy; /* last mouse position */
-    int           pressed; /* mouse button 1 pressed */
+    int           mpy; /* mouse position */
     int           sx, sy; /* screen center */
     int           wpx, wpy; /* window position in parent */
     int           x, y;
-    int           dx, dy;
 
     /* colors for cancel button */
     ccolor cancel_cbc = {
@@ -6465,9 +6462,7 @@ static void iquerycolor(
     ami_selectwidget(out, 2+36, TRUE); /* select the widget */
     cursel = 2+36; /* save selection */
 
-    pressed = FALSE; /* set no mouse button pressed */
-    mpx = 0; /* set no mouse position */
-    mpy = 0;
+    mpy = 0; /* no tracked pointer position yet */
 
     /* start with events */
     do {
@@ -6524,42 +6519,14 @@ static void iquerycolor(
                 break;
 
             case ami_etmoumovg:
-                lmpx = mpx; /* save last mouse position */
-                lmpy = mpy;
-                mpx = er.moupxg; /* save mouse position */
-                mpy = er.moupyg;
-                if (pressed && mpx && mpy && lmpx && lmpy && 
-                    (lmpx != mpx || lmpy != mpy)) {
-
-                    /* mouse button pressed and has moved */
-                    dx = mpx-lmpx; /* find difference */
-                    dy = mpy-lmpy;
-                    x = wpx+dx; /* find potential new position */
-                    y = wpy+dy;
-                    if (x > 0 && y > 0) { /* valid new position */
-
-                        wpx = x; /* set new position */
-                        wpy = y;
-                        ami_setposg(out, wpx, wpy); /* set new position */
-                        /* Need to adjust the mouse relative positions. The 
-                           mouse moves opposite from the window. */
-                        lmpx -= dx;
-                        lmpy -= dy;
-                        mpx -= dx;
-                        mpy -= dy;
-
-                    }
-
-                }
+                mpy = er.moupyg; /* track pointer y for title-bar hit test */
                 break;
 
             case ami_etmouba:
-                if (er.amoubn == 1 && mpy <= titbot)
-                    pressed = TRUE; /* set mouse button assert */
-                break;
-
-            case ami_etmoubd:
-                if (er.dmoubn == 1) pressed = FALSE;
+                /* Press on the title bar: hand the drag to the graphics layer,
+                   which tracks in desktop coordinates with the pointer grabbed
+                   (see the other query dialogs). */
+                if (er.amoubn == 1 && mpy <= titbot) ami_dragwin(out);
                 break;
 
             default: ;
@@ -6737,9 +6704,8 @@ static void qfl_dialog(char* s, int sl, const char* title) {
     wigptr     wp;
     int        chrsz;
     int        titbot;
-    int        mpx, mpy, lmpx, lmpy;
-    int        pressed;
-    int        sx, sy, x, y, wpx, wpy, dx, dy;
+    int        mpy;
+    int        sx, sy, x, y, wpx, wpy;
     int        cancelled;
     char       curdir[4096];
     char       curfile[512];
@@ -6832,8 +6798,7 @@ static void qfl_dialog(char* s, int sl, const char* title) {
                 chrsz*49, titbot+chrsz*20.3, "Cancel",
                 QFL_ID_CANCEL, wtcbutton, &wp);
 
-    pressed = FALSE;
-    mpx = 0; mpy = 0; lmpx = 0; lmpy = 0;
+    mpy = 0;
     cancelled = FALSE;
 
     do {
@@ -6927,27 +6892,17 @@ static void qfl_dialog(char* s, int sl, const char* title) {
                 break;
 
             case ami_etmoumovg:
-                lmpx = mpx; lmpy = mpy;
-                mpx = er.moupxg; mpy = er.moupyg;
-                if (pressed && mpx && mpy && lmpx && lmpy &&
-                    (lmpx != mpx || lmpy != mpy)) {
-                    dx = mpx-lmpx; dy = mpy-lmpy;
-                    x = wpx+dx; y = wpy+dy;
-                    if (x > 0 && y > 0) {
-                        wpx = x; wpy = y;
-                        ami_setposg(out, wpx, wpy);
-                        lmpx -= dx; lmpy -= dy;
-                        mpx  -= dx; mpy  -= dy;
-                    }
-                }
+                mpy = er.moupyg; /* track pointer y for title-bar hit test */
                 break;
 
             case ami_etmouba:
-                if (er.amoubn == 1 && mpy <= titbot) pressed = TRUE;
-                break;
-
-            case ami_etmoubd:
-                if (er.dmoubn == 1) pressed = FALSE;
+                /* Press on the title bar: hand the drag to the graphics layer.
+                   It tracks in desktop coordinates with the pointer grabbed, so
+                   the window follows smoothly even when the pointer outruns it
+                   and leaves the window's bounds -- a window-relative self-drag
+                   cannot, because motion stops being delivered the moment the
+                   pointer is no longer over the dialog. */
+                if (er.amoubn == 1 && mpy <= titbot) ami_dragwin(out);
                 break;
 
             default: ;
@@ -7069,10 +7024,8 @@ static void iqueryfind(
     wigptr     wp;
     int        chrsz;     /* character height in pixels */
     int        titbot;    /* bottom of title bar */
-    int        mpx, mpy;  /* mouse position */
-    int        lmpx, lmpy;
-    int        pressed;
-    int        sx, sy, x, y, wpx, wpy, dx, dy;
+    int        mpy;  /* mouse position */
+    int        sx, sy, x, y, wpx, wpy;
     int        case_on, up_on, re_on; /* checkbox states */
     int        cancelled;
 
@@ -7155,8 +7108,7 @@ static void iqueryfind(
     re_on = !!(*opt & (1 << ami_qfnre));
     if (re_on) ami_selectwidget(out, QFN_ID_RE, TRUE);
 
-    pressed = FALSE;
-    mpx = 0; mpy = 0; lmpx = 0; lmpy = 0;
+    mpy = 0;
     cancelled = FALSE;
 
     /* event loop */
@@ -7215,27 +7167,17 @@ static void iqueryfind(
                 break;
 
             case ami_etmoumovg:
-                lmpx = mpx; lmpy = mpy;
-                mpx = er.moupxg; mpy = er.moupyg;
-                if (pressed && mpx && mpy && lmpx && lmpy &&
-                    (lmpx != mpx || lmpy != mpy)) {
-                    dx = mpx-lmpx; dy = mpy-lmpy;
-                    x = wpx+dx; y = wpy+dy;
-                    if (x > 0 && y > 0) {
-                        wpx = x; wpy = y;
-                        ami_setposg(out, wpx, wpy);
-                        lmpx -= dx; lmpy -= dy;
-                        mpx  -= dx; mpy  -= dy;
-                    }
-                }
+                mpy = er.moupyg; /* track pointer y for title-bar hit test */
                 break;
 
             case ami_etmouba:
-                if (er.amoubn == 1 && mpy <= titbot) pressed = TRUE;
-                break;
-
-            case ami_etmoubd:
-                if (er.dmoubn == 1) pressed = FALSE;
+                /* Press on the title bar: hand the drag to the graphics layer.
+                   It tracks in desktop coordinates with the pointer grabbed, so
+                   the window follows smoothly even when the pointer outruns it
+                   and leaves the window's bounds -- a window-relative self-drag
+                   cannot, because motion stops being delivered the moment the
+                   pointer is no longer over the dialog. */
+                if (er.amoubn == 1 && mpy <= titbot) ami_dragwin(out);
                 break;
 
             default: ;
@@ -7308,9 +7250,8 @@ static void iqueryfindrep(
     wigptr     wp;
     int        chrsz;
     int        titbot;
-    int        mpx, mpy, lmpx, lmpy;
-    int        pressed;
-    int        sx, sy, x, y, wpx, wpy, dx, dy;
+    int        mpy;
+    int        sx, sy, x, y, wpx, wpy;
     int        case_on, up_on, re_on;
     int        cancelled, did_find, did_replall;
 
@@ -7408,8 +7349,7 @@ static void iqueryfindrep(
     re_on = !!(*opt & (1 << ami_qfrre));
     if (re_on) ami_selectwidget(out, QFR_ID_RE, TRUE);
 
-    pressed = FALSE;
-    mpx = 0; mpy = 0; lmpx = 0; lmpy = 0;
+    mpy = 0;
     cancelled = FALSE; did_find = FALSE; did_replall = FALSE;
 
     do {
@@ -7464,27 +7404,17 @@ static void iqueryfindrep(
                 break;
 
             case ami_etmoumovg:
-                lmpx = mpx; lmpy = mpy;
-                mpx = er.moupxg; mpy = er.moupyg;
-                if (pressed && mpx && mpy && lmpx && lmpy &&
-                    (lmpx != mpx || lmpy != mpy)) {
-                    dx = mpx-lmpx; dy = mpy-lmpy;
-                    x = wpx+dx; y = wpy+dy;
-                    if (x > 0 && y > 0) {
-                        wpx = x; wpy = y;
-                        ami_setposg(out, wpx, wpy);
-                        lmpx -= dx; lmpy -= dy;
-                        mpx  -= dx; mpy  -= dy;
-                    }
-                }
+                mpy = er.moupyg; /* track pointer y for title-bar hit test */
                 break;
 
             case ami_etmouba:
-                if (er.amoubn == 1 && mpy <= titbot) pressed = TRUE;
-                break;
-
-            case ami_etmoubd:
-                if (er.dmoubn == 1) pressed = FALSE;
+                /* Press on the title bar: hand the drag to the graphics layer.
+                   It tracks in desktop coordinates with the pointer grabbed, so
+                   the window follows smoothly even when the pointer outruns it
+                   and leaves the window's bounds -- a window-relative self-drag
+                   cannot, because motion stops being delivered the moment the
+                   pointer is no longer over the dialog. */
+                if (er.amoubn == 1 && mpy <= titbot) ami_dragwin(out);
                 break;
 
             default: ;
@@ -7549,9 +7479,8 @@ static void iqueryfont(
     wigptr      wp;
     int         chrsz;
     int         titbot;
-    int         mpx, mpy, lmpx, lmpy;
-    int         pressed;
-    int         sx, sy, x, y, wpx, wpy, dx, dy;
+    int         mpy;
+    int         sx, sy, x, y, wpx, wpy;
     int         cancelled;
     int         strike_on, under_on, bold_on, italic_on;
     int         nfonts, i;
@@ -7676,8 +7605,7 @@ static void iqueryfont(
     widget(out, chrsz*32, titbot+chrsz*2.8,
                 chrsz*41, titbot+chrsz*4.2, "Cancel", 1, wtcbutton, &wp);
 
-    pressed = FALSE;
-    mpx = 0; mpy = 0; lmpx = 0; lmpy = 0;
+    mpy = 0;
     cancelled = FALSE;
 
     do {
@@ -7794,27 +7722,17 @@ static void iqueryfont(
                 break;
 
             case ami_etmoumovg:
-                lmpx = mpx; lmpy = mpy;
-                mpx = er.moupxg; mpy = er.moupyg;
-                if (pressed && mpx && mpy && lmpx && lmpy &&
-                    (lmpx != mpx || lmpy != mpy)) {
-                    dx = mpx-lmpx; dy = mpy-lmpy;
-                    x = wpx+dx; y = wpy+dy;
-                    if (x > 0 && y > 0) {
-                        wpx = x; wpy = y;
-                        ami_setposg(out, wpx, wpy);
-                        lmpx -= dx; lmpy -= dy;
-                        mpx  -= dx; mpy  -= dy;
-                    }
-                }
+                mpy = er.moupyg; /* track pointer y for title-bar hit test */
                 break;
 
             case ami_etmouba:
-                if (er.amoubn == 1 && mpy <= titbot) pressed = TRUE;
-                break;
-
-            case ami_etmoubd:
-                if (er.dmoubn == 1) pressed = FALSE;
+                /* Press on the title bar: hand the drag to the graphics layer.
+                   It tracks in desktop coordinates with the pointer grabbed, so
+                   the window follows smoothly even when the pointer outruns it
+                   and leaves the window's bounds -- a window-relative self-drag
+                   cannot, because motion stops being delivered the moment the
+                   pointer is no longer over the dialog. */
+                if (er.amoubn == 1 && mpy <= titbot) ami_dragwin(out);
                 break;
 
             default: ;


### PR DESCRIPTION
The query dialogs (find, replace, open, save, color) draw their own title bars and are undecorated, so they implement their own window drag. They did it in the dialog event loop, moving the window per mouse-motion event using window-relative coordinates. That fails two ways:

- **Wrong coordinate frame.** `moupxg`/`moupyg` are relative to the dialog itself, so they shift as the window moves under the pointer. The move math feeds back on itself and diverges into wild jumps.
- **Lost events.** A window only receives motion while the pointer is over it. A drag constantly puts the pointer ahead of the window; motion stops being delivered and tracking stalls and lurches.

## Fix

Add `ami_dragwin(FILE*)` to the graphics layer; each dialog calls it on a title-bar press instead of self-dragging. It runs the same loop the child frames already use successfully:

1. Grab the pointer, so motion keeps flowing even when the pointer leaves the window.
2. Move the window by the pointer's **desktop (root) coordinate** delta from the drag start:

   `window_pos = start_pos + (pointer_root_now - pointer_root_start)`

All terms are in root/parent coordinates that don't move with the window, so there's no feedback. `XMoveWindow` is parent-relative, so this is uniform whether the dragged window is a free desktop child, a child of one of our windows, or nested arbitrarily deep. The grab offset is captured once, implicitly, and never re-measured.

The dialogs now track only the pointer y for the title-bar hit test; the window-relative drag state (`pressed`, last-position, deltas) is removed. No change to any existing function or the event interface.

Validated live: find/replace and color dialogs now drag smoothly, including when the cursor outruns the window.