### PR TITLE
Create SSL contexts lazily on first secure use

### DIFF
--- a/linux/network.c
+++ b/linux/network.c
@@ -244,6 +244,21 @@ static SSL_CTX* client_dtls_ctx;
 static SSL_CTX* server_tls_ctx;
 static SSL_CTX* server_dtls_ctx;
 
+/* Each SSL context loads certificate and key .pem files. Those files need not
+   exist for a program that performs no secure networking, so the contexts are
+   created lazily, on the first secure use of each, rather than in the startup
+   constructor. Otherwise every program linking this library would have to carry
+   the .pem files (and would abort at startup without them). The pthread_once
+   guards make the lazy creation safe under the multithreaded server. */
+static pthread_once_t client_tls_once  = PTHREAD_ONCE_INIT;
+static pthread_once_t client_dtls_once = PTHREAD_ONCE_INIT;
+static pthread_once_t server_tls_once  = PTHREAD_ONCE_INIT;
+static pthread_once_t server_dtls_once = PTHREAD_ONCE_INIT;
+static void init_client_tls(void);
+static void init_client_dtls(void);
+static void init_server_tls(void);
+static void init_server_dtls(void);
+
 /* server secret cookie */
 unsigned char cookie_secret[COOKIE_SECRET_LENGTH];
 /* cookie has been initialized */
@@ -1044,6 +1059,7 @@ static FILE* opennet(
         opnfil[sfn]->opn = TRUE;
         pthread_mutex_unlock(&opnfil[sfn]->lock); /* release file entry lock */
 
+        pthread_once(&client_tls_once, init_client_tls); /* ensure context */
         ssl = SSL_new(client_tls_ctx); /* create new ssl */
         if (!ssl) error(esslnew);
         /* connect the ssl side to the shadow fid */
@@ -1197,6 +1213,7 @@ int ami_openmsg(
         if (r) linuxerror();
 
         /* create socket struct */
+        pthread_once(&client_dtls_once, init_client_dtls); /* ensure context */
         opnfil[fn]->ssl = SSL_new(client_dtls_ctx);
         if (!opnfil[fn]->ssl) sslerrorqueue();
 
@@ -1278,6 +1295,7 @@ int ami_openmsgv6(
         if (r) linuxerror();
 
         /* create socket struct */
+        pthread_once(&client_dtls_once, init_client_dtls); /* ensure context */
         opnfil[fn]->ssl = SSL_new(client_dtls_ctx);
         if (!opnfil[fn]->ssl) sslerrorqueue();
 
@@ -1374,6 +1392,7 @@ int ami_waitmsg(/* port number to wait on */ int port,
         timeout.tv_usec = 0;
         BIO_ctrl(opnfil[fn]->bio, BIO_CTRL_DGRAM_SET_RECV_TIMEOUT, 0, &timeout);
 
+        pthread_once(&server_dtls_once, init_server_dtls); /* ensure context */
         opnfil[fn]->ssl = SSL_new(server_dtls_ctx);
         if (!opnfil[fn]->ssl) sslerrorqueue();
 
@@ -1716,6 +1735,7 @@ FILE* ami_waitnet(/* port number to wait on */ int port,
         opnfil[sfn]->opn = TRUE;
         pthread_mutex_unlock(&opnfil[sfn]->lock); /* release file entry lock */
 
+        pthread_once(&server_tls_once, init_server_tls); /* ensure context */
         ssl = SSL_new(server_tls_ctx); /* create new ssl */
         if (!ssl) error(esslnew);
         /* connect the ssl side to the shadow fid */
@@ -2682,6 +2702,63 @@ void initctx(
 
 /*******************************************************************************
 
+Lazy SSL context creation
+
+These create each SSL context on first secure use (run once via pthread_once),
+loading the relevant certificate/key .pem files only then. A program that does
+no secure networking never reaches these, so it never needs the .pem files.
+
+*******************************************************************************/
+
+static void init_client_tls(void)
+
+{
+
+    initctx(&client_tls_ctx, TLS_client_method(), "client_tls_cert.pem",
+                                                  "client_tls_key.pem");
+
+}
+
+static void init_client_dtls(void)
+
+{
+
+    initctx(&client_dtls_ctx, DTLS_client_method(), "client_dtls_cert.pem",
+                                                    "client_dtls_key.pem");
+
+}
+
+static void init_server_tls(void)
+
+{
+
+    initctx(&server_tls_ctx, TLS_server_method(), "server_tls_cert.pem",
+                                                  "server_tls_key.pem");
+    SSL_CTX_set_ecdh_auto(server_tls_ctx, 1);
+
+}
+
+static void init_server_dtls(void)
+
+{
+
+    initctx(&server_dtls_ctx, DTLS_server_method(), "server_dtls_cert.pem",
+                                                    "server_dtls_key.pem");
+    SSL_CTX_set_ecdh_auto(server_dtls_ctx, 1);
+
+    /* Client has to authenticate */
+    SSL_CTX_set_verify(server_dtls_ctx,
+                       SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE,
+                       dtls_verify_callback);
+
+    SSL_CTX_set_session_cache_mode(server_dtls_ctx, SSL_SESS_CACHE_OFF);
+    SSL_CTX_set_cookie_generate_cb(server_dtls_ctx, generate_cookie);
+    SSL_CTX_set_cookie_verify_cb(server_dtls_ctx, &verify_cookie);
+
+}
+
+/*******************************************************************************
+
 Network startup
 
 *******************************************************************************/
@@ -2723,36 +2800,10 @@ static void ami_init_network()
     OpenSSL_add_ssl_algorithms();
     SSL_load_error_strings();
 
-    /* create new client TLS SSL context */
-    initctx(&client_tls_ctx, TLS_client_method(), "client_tls_cert.pem",
-                                                  "client_tls_key.pem");
-
-    /* create new client DTLS SSL context */
-    initctx(&client_dtls_ctx, DTLS_client_method(), "client_dtls_cert.pem",
-                                                    "client_dtls_key.pem");
-
-    /* create new server TLS SSL context */
-    initctx(&server_tls_ctx, TLS_server_method(), "server_tls_cert.pem",
-                                                  "server_tls_key.pem");
-
-    /* configure server context */
-    SSL_CTX_set_ecdh_auto(server_tls_ctx, 1);
-
-    /* create new server DTLS SSL context */
-    initctx(&server_dtls_ctx, DTLS_server_method(), "server_dtls_cert.pem",
-                                                    "server_dtls_key.pem");
-
-    /* configure server context */
-    SSL_CTX_set_ecdh_auto(server_dtls_ctx, 1);
-
-    /* Client has to authenticate */
-    SSL_CTX_set_verify(server_dtls_ctx,
-                       SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE,
-                       dtls_verify_callback);
-
-    SSL_CTX_set_session_cache_mode(server_dtls_ctx, SSL_SESS_CACHE_OFF);
-    SSL_CTX_set_cookie_generate_cb(server_dtls_ctx, generate_cookie);
-    SSL_CTX_set_cookie_verify_cb(server_dtls_ctx, &verify_cookie);
+    /* The four SSL contexts are created lazily on first secure use (see the
+       init_client_tls/init_client_dtls/init_server_tls/init_server_dtls
+       functions above), so the certificate/key .pem files are not required by
+       a program that does no secure networking. */
 
     /* set cookie uninitialized */
     cookie_initialized = FALSE;


### PR DESCRIPTION
## Summary

The network binding's startup constructor (`ami_init_network`) built all four `SSL_CTX` objects — client/server TLS and DTLS — and in doing so loaded eight certificate/key `.pem` files. Now that the network binding is linked as standard into every Pascaline interpreter, this made those `.pem` files a hard startup dependency for *every* program: a missing file drove `initctx` into `sslerrorqueue()` → `net_abort()`, aborting before `main()`.

This moves each context's creation and configuration into its own `init_*` function (`init_client_tls`, `init_client_dtls`, `init_server_tls`, `init_server_dtls`), each fired through `pthread_once` immediately before the matching `SSL_new()` call. The constructor now performs only file-free setup: library init, algorithm registration, error strings, the mutexes, and the I/O overrides.

## Effect

- A program doing **no** secure networking never opens the `.pem` files.
- A secure program lacking them fails at **connect time**, not at startup.
- `pthread_once` keeps lazy creation safe under the multithreaded server.

## Verification

- `network_test` from a `.pem`-less directory now starts and passes the three in-the-clear tests, reaching the missing-file errors only at the DTLS phase (instead of aborting before any output).
- `network_test` from a directory with the `.pem` files still passes **7/7**, including secure DTLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)