### PR TITLE
Stream-aware 0x/0X hex scan in fscanf; fix waveout prototype typo

### DIFF
--- a/include/sound.h
+++ b/include/sound.h
@@ -435,7 +435,7 @@ int ami_setparamwaveout(int p, string name, string value);
 void ami_getparamsynthin(int p, string name, string value, int len);
 void ami_getparamsynthout(int p, string name, string value, int len);
 void ami_getparamwavein(int p, string name, string value, int len);
-void ami_getparamswaveout(int p, string name, string value, int len);
+void ami_getparamwaveout(int p, string name, string value, int len);
 
 /* non-standard local access calls */
 

--- a/libc/stdio.c
+++ b/libc/stdio.c
@@ -1224,7 +1224,8 @@ static unsigned long long strtoulso(
     } else {
 
         getnumro(s, &v, base, o, cnt, &fld, fd); /* parse digits in selected base */
-        if (base == 16 && !v && (**s == 'x' || **s == 'X')) {
+        if (base == 16 && !v && (chkfstrlen(*s, fld, fd) == 'x' ||
+                                 chkfstrlen(*s, fld, fd) == 'X')) {
 
             /* allow 0x/0X on hexadecimal */
             getfstr(s, fd); /* skip x/X */


### PR DESCRIPTION
Two small fixes surfaced while bringing up the cmach interpreter against the Ami libc and sound binding.

## `libc/stdio.c` — stream-aware hex prefix scan
`strtoulso`'s explicit-base-16 path tested for a following `x`/`X` with a raw `**s` dereference. On a **stream** source `*s` is null (characters are fetched through the stream, not a backing string), so scanning a hexadecimal field — e.g. `fscanf("%2lx%16lx")`, which cmach uses to read its deck — segfaulted. Use the stream-aware `chkfstrlen(*s, fld, fd)` that the auto-base branch already uses.

## `include/sound.h` — prototype typo
`ami_getparamwaveout` was declared `ami_getparamswaveout` (stray `s`), matching no definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)