### PR TITLE
brknam: handle a trailing path separator (directory spec)

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -1580,6 +1580,8 @@ void ami_brknam(
 
     int i, s, f, t; /* string indexes */
     char *s1, *s2;
+    char buf[MAXSTR]; /* trimmed working copy of the spec */
+    int len;          /* length of the trimmed spec */
 
     /* clear all strings */
     *p = 0;
@@ -1589,6 +1591,17 @@ void ami_brknam(
     s1 = fn; /* index file spec */
     /* skip spaces */
     while (*s1 && *s1 == ' ') s1++;
+    /* Work on a trimmed copy: drop trailing spaces (the input may be a space-
+       padded fixed string) and a single trailing path separator, so a
+       directory spec such as ".../bin/" yields name "bin" rather than an empty
+       name. The root "/" (len 1) keeps its separator. */
+    len = strlen(s1);
+    while (len > 0 && s1[len-1] == ' ') len--;
+    if (len > 1 && s1[len-1] == ami_pthchr()) len--;
+    if (len >= MAXSTR) error("String to large for destination\n");
+    memcpy(buf, s1, len);
+    buf[len] = 0;
+    s1 = buf;
     /* find last '/' that will mark the path */
     s2 = strrchr(s1, ami_pthchr());
     if (s2) {


### PR DESCRIPTION
## Summary

`ami_brknam` split a file spec at the last path separator, so a **directory spec ending in a separator** — e.g. `.../bin/`, as returned by `getpgm` — yielded an **empty name** instead of the last component (`bin`).

## Fix

In `linux/services.c` `ami_brknam`: trim trailing spaces (the input may be a space-padded fixed string) and drop a single trailing separator before the path/name split. The root `/` (length 1) keeps its separator; normal filespecs (`/what/ho/junk.com` → `/what/ho/` + `junk` + `com`) are unchanged.

## Validation

`brknam(".../bin/")` now returns name `bin` — verified with a Pascal-P6 helper (`getpgm(s); brknam(s); writeln(n)` → `bin`); the services_test brknam cases (32–35) are unaffected and pass.

The windows and stub `ami_brknam` carry the same pattern and would want the same fix — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
