### PR TITLE
network: bound clear-path message receive with SO_RCVTIMEO

### DIFF
--- a/linux/network.c
+++ b/linux/network.c
@@ -1237,6 +1237,15 @@ int ami_openmsg(
         /* set secure udp */
         opnfil[fn]->sudp = TRUE;
 
+    } else {
+
+        /* clear (plain UDP): bound the receive so a lost or late reply fails
+           the read instead of blocking forever -- the secured path above gets
+           this via BIO_CTRL_DGRAM_SET_RECV_TIMEOUT */
+        timeout.tv_sec = 3;
+        timeout.tv_usec = 0;
+        setsockopt(fn, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
     }
 
     return (fn); /* return fid */
@@ -1318,6 +1327,15 @@ int ami_openmsgv6(
 
         /* set secure udp */
         opnfil[fn]->sudp = TRUE;
+
+    } else {
+
+        /* clear (plain UDP): bound the receive so a lost or late reply fails
+           the read instead of blocking forever -- the secured path above gets
+           this via BIO_CTRL_DGRAM_SET_RECV_TIMEOUT */
+        timeout.tv_sec = 3;
+        timeout.tv_usec = 0;
+        setsockopt(fn, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
 
     }
 
@@ -1431,6 +1449,16 @@ int ami_waitmsg(/* port number to wait on */ int port,
 
         /* set secure udp */
         opnfil[fn]->sudp = TRUE;
+
+    } else {
+
+        /* clear (plain UDP): bound the receive so a dropped client message
+           (e.g. sent before this server bound) times out and the server exits
+           instead of lingering -- the secured path above gets this via
+           BIO_CTRL_DGRAM_SET_RECV_TIMEOUT */
+        timeout.tv_sec = 5;
+        timeout.tv_usec = 0;
+        setsockopt(fn, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
 
     }
 


### PR DESCRIPTION
The clear (non-DTLS) message sockets in `ami_openmsg`, `ami_openmsgv6`, and
`ami_waitmsg` create a `SOCK_DGRAM` socket but set a receive timeout only on the
**secured** branch (`BIO_CTRL_DGRAM_SET_RECV_TIMEOUT`). The clear path had none,
so `rdmsg` could block **forever** when a datagram was lost or late — e.g. a
loopback client message sent before the freshly `exec`'d server had bound.

This adds `SO_RCVTIMEO` on the clear path of all three, mirroring the existing
DTLS timeouts (3s on the clients, 5s on the server). A lost message now times
the read out — the client fails, the server exits — instead of wedging.

Found via Pascal-P6's `network_test`, which self-spawns a loopback server; the
message-exchange subtest intermittently wedged on this receive under cmach in a
clean-checkout regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)