### PR TITLE
management_test title fix + restore focus after decoration changes

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -2113,6 +2113,53 @@ void prtwintre(winptr wp)
 
 /** ****************************************************************************
 
+Request the window manager to (re)activate a window
+
+Changing _MOTIF_WM_HINTS makes Mutter (GNOME's compositor) drop the window's
+input focus -- it lands on whatever sits underneath, e.g. the terminal that
+launched us. (Note Mutter also ignores the decoration change itself once the
+window is mapped, but the focus loss still happens.) After such a change we ask
+the WM to focus/raise our window again via the EWMH
+_NET_ACTIVE_WINDOW client message. The WM applies it in order with the
+decoration change, so it is race-free (unlike a bare XSetInputFocus). No-op on
+window managers that don't advertise the atom.
+
+*******************************************************************************/
+
+static void wmactivate(Window w)
+
+{
+
+    XEvent ev;
+    Atom   naw;
+
+    XWLOCK();
+    naw = XInternAtom(padisplay, "_NET_ACTIVE_WINDOW", True);
+    if (naw != None) {
+
+        ev.xclient.type = ClientMessage;
+        ev.xclient.serial = 0;
+        ev.xclient.send_event = True;
+        ev.xclient.display = padisplay;
+        ev.xclient.window = w;
+        ev.xclient.message_type = naw;
+        ev.xclient.format = 32;
+        ev.xclient.data.l[0] = 1; /* source indication: application */
+        ev.xclient.data.l[1] = CurrentTime;
+        ev.xclient.data.l[2] = 0;
+        ev.xclient.data.l[3] = 0;
+        ev.xclient.data.l[4] = 0;
+        XSendEvent(padisplay, DefaultRootWindow(padisplay), False,
+                   SubstructureRedirectMask|SubstructureNotifyMask, &ev);
+        XFlush(padisplay);
+
+    }
+    XWUNLOCK();
+
+}
+
+/** ****************************************************************************
+
 Enable or disable window frame
 
 Turns the window frame on and off. Expects the Xwindow handle, and an on/off
@@ -2135,6 +2182,10 @@ void enbxfrm(Window xwh, int e)
     XChangeProperty(padisplay, xwh, mwmHintsProperty, mwmHintsProperty,
                     32, PropModeReplace, (unsigned char *)&hints, 5);
     XWUNLOCK();
+
+    /* Mutter drops input focus when the decoration hints change; ask it to
+       return focus to us so it doesn't strand on the launching terminal. */
+    wmactivate(xwh);
 
 }
 
@@ -2206,6 +2257,9 @@ void enbxsiz(Window xwh, int e)
 
     XWUNLOCK();
 
+    /* re-focus: Mutter drops focus when the decoration hints change */
+    wmactivate(xwh);
+
 }
 
 /** ****************************************************************************
@@ -2232,6 +2286,9 @@ void enbxsys(Window xwh, int e)
     XChangeProperty(padisplay, xwh, mwmHintsProperty, mwmHintsProperty,
                     32, PropModeReplace, (unsigned char *)&hints, 5);
     XWUNLOCK();
+
+    /* re-focus: Mutter drops focus when the decoration hints change */
+    wmactivate(xwh);
 
 }
 

--- a/tests/management_test.c
+++ b/tests/management_test.c
@@ -86,7 +86,7 @@ extern void screen_capture(void);
 
 /* wait return to be pressed, or handle terminate */
 
-static void waitnext(void)
+static void waitnextt(int keeptitle)
 
 {
 
@@ -94,8 +94,15 @@ static void waitnext(void)
     char titlebuf[80];
 
     framenum++;
-    sprintf(titlebuf, "management_test: frame %d", framenum);
-    ami_title(stdout, titlebuf);
+    /* Stamp the frame number into the title bar, unless the caller is testing
+       ami_title itself: keeptitle=TRUE preserves the title under test instead
+       of clobbering it. */
+    if (!keeptitle) {
+
+        sprintf(titlebuf, "management_test: frame %d", framenum);
+        ami_title(stdout, titlebuf);
+
+    }
 
     screen_capture();
 
@@ -104,6 +111,10 @@ static void waitnext(void)
     if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
 
 }
+
+/* wait return to be pressed, or handle terminate (stamps the frame number) */
+
+static void waitnext(void) { waitnextt(FALSE); }
 
 /* wait return to be pressed, or handle terminate, while printing characters */
 
@@ -333,7 +344,7 @@ int main(void)
     ami_title(stdout, "This is a mangement test window");
     printf("The title bar of this window should read: This is a mangement test window\n");
     prtceng(ami_maxyg(stdout)-ami_chrsizy(stdout), "Window title test");
-    waitnext();
+    waitnextt(TRUE); /* keep the title we just set -- this frame IS the title test */
 
     /* ************************** Multiple windows ************************** */
 


### PR DESCRIPTION
Two more XWayland/Mutter compat fixes found while running `management_test` on Ubuntu 26.04 (GNOME 50).

## 1. Title test never showed its title (`tests/management_test.c`)
`waitnext()` stamps `"management_test: frame N"` into the title bar on every wait (handy for identifying frames). But the title test does `ami_title("This is a management test window")` immediately followed by `waitnext()`, so the frame stamp overwrote the title under test — it could never be seen (looked like `ami_title` was broken; it wasn't).

Split `waitnext()` into `waitnextt(keeptitle)` + a `waitnext()` wrapper. The title test calls `waitnextt(TRUE)` so its title survives; every other frame keeps its number stamp.

## 2. Focus lost to the terminal on frame controls (`linux/graphics.c`)
`ami_frame` / `ami_sysbar` / `ami_sizable` change `_MOTIF_WM_HINTS`, and on GNOME/Mutter that drops the window's input focus — it lands on whatever's underneath (typically the launching terminal), leaving the program window unable to receive keystrokes. `management_test` got stuck at the frame-controls section because Return went to the terminal.

Added a `wmactivate()` helper that re-requests focus/raise via the EWMH `_NET_ACTIVE_WINDOW` client message (the WM applies it in order with the property change, so it's race-free — unlike a bare `XSetInputFocus`), called after each decoration change. No-op on WMs that don't advertise the atom.

### Verified
- Title test: driving to the title frame, `WM_NAME` now reads the custom title instead of the frame stamp.
- Focus: after `ami_frame` off→on, `_NET_ACTIVE_WINDOW` points back at our window (confirmed with a minimal repro).

### Note
Separately confirmed (not fixed here) that Mutter only reads `_MOTIF_WM_HINTS` at map time and ignores post-map decoration changes, so `ami_sysbar`/`ami_frame`/`ami_sizable` can't actually change decorations on a live window under Mutter regardless — a compositor limitation worth documenting later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)