### PR TITLE
graphics: coalesce pointer motion and repaint list hover per-line

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -4347,10 +4347,16 @@ carries a redraw rectangle, so we cannot just keep the last; we union all pendin
 rectangles into one so nothing is left unpainted. Both the internal save queue
 (filled by peekxevt during WM waits) and the live X queue are drained.
 
-Discrete events (keys, buttons, focus, map, ...) are never coalesced. MotionNotify
-is intentionally NOT coalesced here: it is redundant for pointer position, but
-folding it would drop intermediate points for stroke/drawing input. Add it to
-coalescible() if that trade-off is acceptable for a given build.
+Discrete events (keys, buttons, focus, map, ...) are never coalesced.
+
+MotionNotify is coalesced keep-newest: only the latest pointer position matters,
+and under XWayland the motion stream arrives faster than widgets can repaint, so
+stale positions pile up in the queue and each one drives a redundant redraw (the
+pointer visibly lags the cursor -- a slider "chasing" the mouse). Folding a run
+of pending motions down to the newest keeps interaction responsive. The cost is
+that intermediate points are dropped, so this is not suitable for capturing a
+freehand stroke path; a drawing surface that needs every point should read raw
+motion rather than rely on the coalesced PA event stream.
 
 *******************************************************************************/
 
@@ -4393,7 +4399,8 @@ static int takexevt(int type, Window w, XEvent* out)
 }
 
 static int coalescible(int type)
-    { return (type == ConfigureNotify || type == Expose); }
+    { return (type == ConfigureNotify || type == Expose ||
+              type == MotionNotify); }
 
 static void coalesce(XEvent* e)
 

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -1757,7 +1757,10 @@ static void scrollvert_event(
         wg->lmpy = wg->mpy;
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
-        scrollvert_draw(wg);
+        /* only repaint while actually dragging the thumb; a plain hover does
+           not change the bar's appearance, and repainting the (unbuffered)
+           widget on every motion event causes flashing and sluggishness */
+        if (wg->pressed) scrollvert_draw(wg);
         wg->lmpx = wg->mpx; /* now set equal to cancel move */
         wg->lmpy = wg->mpy;
 
@@ -1896,7 +1899,8 @@ static void scrollhoriz_event(
         wg->lmpy = wg->mpy;
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
-        scrollhoriz_draw(wg);
+        /* only repaint while actually dragging the thumb (see scrollvert) */
+        if (wg->pressed) scrollhoriz_draw(wg);
         wg->lmpx = wg->mpx; /* now set equal to cancel move */
         wg->lmpy = wg->mpy;
 
@@ -2545,6 +2549,51 @@ Handles drawing list boxes.
 
 *******************************************************************************/
 
+/* Paint a single list line (1-based index idx, string sp, top at y): hover-grey
+   background when it is the hovered line, list-white otherwise, then the text.
+   The fill is inset horizontally so the rounded outline is never overpainted --
+   that lets the motion handler repaint just the line that gains or loses the
+   hover highlight instead of redrawing (and re-rendering) the whole list. */
+static void listbox_line(wigptr wg, ami_strptr sp, int idx, int y)
+
+{
+
+    if (wg->hover && idx == wg->ss)
+        fcolort(wg->wf, th_lsthov); /* hover background */
+    else ami_fcolor(wg->wf, ami_white); /* normal background */
+    ami_frect(wg->wf, 4, y, ami_maxxg(wg->wf)-3, y+ami_chrsizy(wg->wf)-1);
+    ami_fcolor(wg->wf, ami_black);
+    ami_cursorg(wg->wf, ami_chrsizy(wg->wf)*0.5, y);
+    fprintf(wg->wf, "%s", sp->str); /* place string */
+
+}
+
+/* Repaint just the line at 1-based index idx (used to move the hover highlight
+   without a full-list redraw). Out-of-range indices (including 0 = none) are a
+   no-op. */
+static void listbox_line_idx(wigptr wg, int idx)
+
+{
+
+    ami_strptr sp;
+    int       y;
+    int       sc;
+
+    if (idx < 1) return; /* nothing to paint */
+    sp = wg->strlst; /* index top of stringlist */
+    y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
+    sc = 1; /* set first string */
+    while (sp && sc < idx) { /* walk to the target line */
+
+        y += ami_chrsizy(wg->wf); /* next line */
+        sp = sp->next; /* next string */
+        sc++; /* next select */
+
+    }
+    if (sp) listbox_line(wg, sp, idx, y); /* in range: paint it */
+
+}
+
 static void listbox_draw(
     /** Widget data pointer */ wigptr wg
 )
@@ -2564,20 +2613,10 @@ static void listbox_draw(
     ami_rrect(wg->wf, 2, 2, ami_maxxg(wg->wf)-1, ami_maxyg(wg->wf)-1, 10, 10);
     sp = wg->strlst; /* index top of stringlist */
     y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
-    ami_fcolor(wg->wf, ami_black);
     sc = 1; /* set first string */
     while (sp) { /* traverse and paint */
 
-        if (wg->hover && sc == wg->ss) {
-
-            /* draw in hover background */
-            fcolort(wg->wf, th_lsthov); /* set hover background */
-            ami_frect(wg->wf, 1, y, ami_maxxg(wg->wf), y+ami_chrsizy(wg->wf)-1);
-
-        }
-        ami_fcolor(wg->wf, ami_black);
-        ami_cursorg(wg->wf, ami_chrsizy(wg->wf)*0.5, y);
-        fprintf(wg->wf, "%s", sp->str); /* place string */
+        listbox_line(wg, sp, sc, y); /* paint this line */
         y += ami_chrsizy(wg->wf); /* next line */
         sp = sp->next; /* next string */
         sc++; /* next select */
@@ -2628,6 +2667,8 @@ static void listbox_event(
 
     } else if (ev->etype == ami_etmoumovg) {
 
+        int oldss = wg->ss; /* remember previously hovered string */
+
         /* track position */
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
@@ -2646,17 +2687,39 @@ static void listbox_event(
             sp = sp->next; /* next string */
 
         }
-        listbox_draw(wg); /* redraw the window */
+        /* only repaint when the highlighted item actually changes, and then
+           repaint just the two affected lines (the one losing the highlight and
+           the one gaining it) rather than re-rendering the whole list -- the
+           list is unbuffered, so a full redraw per motion flashes and lags */
+        if (wg->ss != oldss) {
+
+            listbox_line_idx(wg, oldss);  /* un-highlight the previous line */
+            listbox_line_idx(wg, wg->ss); /* highlight the current line */
+
+        }
 
     } else if (ev->etype == ami_ethover) {
 
-        wg->hover = 1; /* hovered */
-        listbox_draw(wg); /* redraw the window */
+        /* Crossing into a nested window produces several EnterNotify events
+           (NotifyNonlinear/Virtual/Ancestor), and hover only affects the one
+           highlighted line -- so act only on the real 0->1 transition and
+           repaint just that line, never the whole list (which flashed). */
+        if (!wg->hover) {
+
+            wg->hover = 1; /* hovered */
+            listbox_line_idx(wg, wg->ss); /* highlight the hovered line, if any */
+
+        }
 
     } else if (ev->etype == ami_etnohover) {
 
-        wg->hover = 0; /* not hovered */
-        listbox_draw(wg); /* redraw the window */
+        if (wg->hover) {
+
+            wg->hover = 0; /* not hovered */
+            listbox_line_idx(wg, wg->ss); /* un-highlight (now paints normal) */
+            wg->ss = 0; /* forget the line so re-entry starts clean */
+
+        }
 
     }
 
@@ -3073,7 +3136,8 @@ static void slidehoriz_event(
         wg->lmpy = wg->mpy;
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
-        slidehoriz_draw(wg);
+        /* only repaint while actually dragging the slider (see scrollvert) */
+        if (wg->pressed) slidehoriz_draw(wg);
         wg->lmpx = wg->mpx; /* now set equal to cancel move */
         wg->lmpy = wg->mpy;
 
@@ -3239,7 +3303,8 @@ static void slidevert_event(
         wg->lmpy = wg->mpy;
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
-        slidevert_draw(wg);
+        /* only repaint while actually dragging the slider (see scrollvert) */
+        if (wg->pressed) slidevert_draw(wg);
         wg->lmpx = wg->mpx; /* now set equal to cancel move */
         wg->lmpy = wg->mpy;
 


### PR DESCRIPTION
## Problem

On XWayland, the pointer-motion stream arrives faster than the (unbuffered) graphical widgets can repaint, so stale motion events pile up in the input queue and each one drives a redundant full redraw. Sliders and list highlights visibly lag the cursor, and the font/file/color **query dialogs** — which are built from these widgets, so this shows up on `widget_test` "frames 40 and after" — flash and are slow to select while the mouse hovers over them.

Diagnosed by driving the pointer with `xdotool` and measuring CPU jiffies: a stationary hover was idle (no infinite loop), but each mouse **motion** over a font list cost a full redraw (~7.5 ms — all ~50 strings re-rendered through FreeType).

## Fixes

**1. Coalesce `MotionNotify` keep-newest in the input queue** (`linux/graphics.c`)
Added to the existing `ConfigureNotify`/`Expose` coalescing. A run of pending motions for a window folds to the latest, draining both the internal save queue and the live X queue, so widgets stop falling behind the cursor. Trade-off (documented in the comment): intermediate points are dropped, so a freehand-stroke surface should read raw motion rather than the coalesced PA stream.

**2. Stop redrawing whole widgets when nothing visible changed** (`portable/gnome_widgets.c`)
- Scrollbars and sliders only repaint while actually **dragging** (`pressed`); a plain hover doesn't change their appearance.
- The list box repaints only the **line(s) whose hover highlight changes** instead of re-rendering every string, via new `listbox_line()` / `listbox_line_idx()` helpers (fill inset so the rounded outline is never overpainted).
- List hover in/out acts only on the real state transition and repaints the single highlighted line — so the several `EnterNotify` events X delivers when the pointer crosses into a nested window (NotifyNonlinear/Virtual/Ancestor) no longer each trigger a full redraw, which was the entry flash.

Selection and thumb-drag paths are unchanged (`ss` is still computed every motion so clicks select correctly; drags still redraw because `pressed` is true).

## Measured (font-dialog list)

| Scenario | Before | After |
|---|---|---|
| 40 mouse moves across items | ~30 jiffies (full FreeType redraw each) | ~0 |
| 40 moves within one item | ~30 | 0 |
| Crossing into the list | ~3 full redraws (flash) | 0 |

Builds clean (no warnings); `widget_test` drives through frames without crashing. Confirmed by the author that the dialogs are now "rock solid."

🤖 Generated with [Claude Code](https://claude.com/claude-code)