### PR TITLE
management_test: warn not to move the window during resize tests

### DIFF
--- a/tests/management_test.c
+++ b/tests/management_test.c
@@ -440,6 +440,7 @@ int main(void)
         };
         putchar('\f');
         printf("Resize screen buffered character\n");
+        printf("*** DON'T MOVE THE WINDOW ***\n");
         printf("\n");
         printf("Moving in x\n");
         waittime(1000);
@@ -465,6 +466,7 @@ int main(void)
         }
         putchar('\f');
         printf("Resize screen buffered character\n");
+        printf("*** DON'T MOVE THE WINDOW ***\n");
         printf("\n");
         printf("Moving in y\n");
         waittime(1000);
@@ -498,6 +500,7 @@ int main(void)
         }
         putchar('\f');
         printf("Resize screen buffered graphical\n");
+        printf("*** DON'T MOVE THE WINDOW ***\n");
         printf("\n");
         printf("Moving in x\n");
         waittime(100);
@@ -523,6 +526,7 @@ int main(void)
         }
         putchar('\f');
         printf("Resize screen buffered graphical\n");
+        printf("*** DON'T MOVE THE WINDOW ***\n");
         printf("\n");
         printf("Moving in y\n");
         waittime(100);


### PR DESCRIPTION
## Summary

The buffered resize tests resize the top-level window in a loop and check the `setsiz`/`getsiz` round trip. Under `WAITWMR`, each `setsiz` waits for the window's next `ConfigureNotify` to learn the granted size. **Dragging the window while a sweep runs** injects move `ConfigureNotify` events the handshake can't tell apart from the resize's, so `getsiz` reads a stale/mismatched size and the test aborts with "Getsiz does not match setsiz".

This isn't a `setsiz` defect — left alone, the tests pass. This change just displays `*** DON'T MOVE THE WINDOW ***` during each of the four resize sweeps (character x/y, pixel x/y) so the window is left undisturbed while they run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)