### PR TITLE
windows: fix dpm truncation and em/cell mismatch in point-size API; drop stale 19pt config

### DIFF
--- a/petit_ami.cfg
+++ b/petit_ami.cfg
@@ -88,10 +88,11 @@ end
 begin graphics
 
     #
-    # Set console font size (points)
+    # Set console font size (points). Uncomment to override the default of
+    # 11 points, sized at the display DPI.
     #
-    console_points 19
-    
+    # console_points 11
+
     #
     # Send runtime errors to dialog/parent console window
     #

--- a/tests/fontsize_check.c
+++ b/tests/fontsize_check.c
@@ -1,0 +1,32 @@
+/* Verify DPI/point-size font math: prints dpm, startup cell/points, and the
+   cell and readback points after ami_setpoints() calls, to a plain file. */
+#include <stdio.h>
+#include <graphics.h>
+
+int main(void)
+
+{
+
+    FILE* rf;
+
+    rf = fopen("fontsize_results.txt", "w");
+    if (!rf) return 1;
+    fprintf(rf, "dpmx: %d dpmy: %d\n", ami_dpmx(stdout), ami_dpmy(stdout));
+    fprintf(rf, "startup: cell %dx%d points %.2f\n",
+            ami_chrsizx(stdout), ami_chrsizy(stdout), ami_points(stdout));
+    ami_auto(stdout, 0); /* fixed font sizing requires auto off */
+    ami_setpoints(stdout, 12.0f);
+    fprintf(rf, "set 12.0pt: cell %dx%d points %.2f\n",
+            ami_chrsizx(stdout), ami_chrsizy(stdout), ami_points(stdout));
+    ami_setpoints(stdout, 10.5f);
+    fprintf(rf, "set 10.5pt: cell %dx%d points %.2f\n",
+            ami_chrsizx(stdout), ami_chrsizy(stdout), ami_points(stdout));
+    ami_setpoints(stdout, 24.0f);
+    fprintf(rf, "set 24.0pt: cell %dx%d points %.2f\n",
+            ami_chrsizx(stdout), ami_chrsizy(stdout), ami_points(stdout));
+    fclose(rf);
+    ami_autohold(0); /* exit without holding the window */
+
+    return 0;
+
+}

--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -6532,9 +6532,13 @@ void ami_fontsiz(FILE* f, int s)
 
 Set font size by point size
 
-Sets the font size by point size (typographic points). The font pixel height
-is computed from the display DPI, with 2835 being the number of points per
-meter (72 points per inch times 39.37 inches per meter). The resulting
+Sets the font size by point size (typographic points). The em-square pixel
+size is computed from the display DPI, with 2835 being the number of points
+per meter (72 points per inch times 39.37 inches per meter), matching the
+Linux driver. The point size gives the em square, which the character cell
+exceeds by the internal leading, so the current face is measured at that em
+size and the resulting cell height applied via ifontsiz(), whose heights
+(like positive CreateFont heights) select fonts by cell. The resulting
 character cell height can be queried via ami_chrsizy().
 
 *******************************************************************************/
@@ -6543,14 +6547,36 @@ void ami_setpoints(FILE* f, float ps)
 
 {
 
-    winptr win;  /* windows record pointer */
-    int    s;    /* font pixel height */
+    winptr     win;    /* windows record pointer */
+    int        pixsiz; /* em-square pixel size */
+    HFONT      tf;     /* probe font at em size */
+    HGDIOBJ    of;     /* previous font in DC */
+    TEXTMETRIC tm;     /* text metric structure */
+    scnptr     sc;     /* screen pointer */
+    int        b;      /* result holder */
 
     lockmain(); /* start exclusive access */
     win = txt2win(f); /* get window pointer from text file */
-    s = (int)(ps*(float)win->sdpmy/2835.0f+0.5f); /* points to pixels */
-    if (s < 1) s = 1; /* clamp to minimum */
-    ifontsiz(win, s); /* set font size */
+    sc = win->screens[win->curupd-1];
+    pixsiz = (int)(ps*(float)win->sdpmy/2835.0f+0.5f); /* points to pixels */
+    if (pixsiz < 1) pixsiz = 1; /* clamp to minimum */
+    /* measure the cell height of the font newfont() will select, sized by
+       em square (negative CreateFont heights size the glyphs, like
+       FT_Set_Pixel_Sizes on Linux) */
+    tf = CreateFont(-pixsiz, 0, 0, 0, FW_REGULAR, FALSE, FALSE, FALSE,
+                    ANSI_CHARSET, OUT_TT_ONLY_PRECIS, CLIP_DEFAULT_PRECIS,
+                    FQUALITY, sc->cfont->sys? FIXED_PITCH: DEFAULT_PITCH,
+                    sc->cfont->sys? "Consolas": sc->cfont->fn);
+    if (!tf) winerr(); /* process windows error */
+    of = SelectObject(sc->bdc, tf); /* select to buffer DC */
+    if (of == HGDI_ERROR) error(enosel);
+    b = GetTextMetrics(sc->bdc, &tm); /* get the metrics */
+    if (!b) winerr(); /* process windows error */
+    of = SelectObject(sc->bdc, of); /* restore previous font */
+    if (of == HGDI_ERROR) error(enosel);
+    b = DeleteObject(tf); /* release the probe font */
+    if (!b) winerr(); /* process windows error */
+    ifontsiz(win, tm.tmHeight); /* set font size by cell height */
     unlockmain(); /* end exclusive access */
 
 }
@@ -6560,7 +6586,9 @@ void ami_setpoints(FILE* f, float ps)
 Find font point size
 
 Returns the current font size in typographic points, derived from the font
-pixel height and the display DPI. This is the inverse of ami_setpoints().
+em-square pixel size and the display DPI. This is the inverse of
+ami_setpoints(). The em square is the character cell height less the
+internal leading, taken from the metrics of the currently selected font.
 
 *******************************************************************************/
 
@@ -6568,12 +6596,18 @@ float ami_points(FILE* f)
 
 {
 
-    winptr win;  /* windows record pointer */
-    float  ps;   /* point size */
+    winptr     win; /* windows record pointer */
+    float      ps;  /* point size */
+    TEXTMETRIC tm;  /* text metric structure */
+    int        b;   /* result holder */
 
     lockmain(); /* start exclusive access */
     win = txt2win(f); /* get window pointer from text file */
-    ps = (float)win->gfhigh*2835.0f/(float)win->sdpmy; /* pixels to points */
+    /* get the metrics of the current font */
+    b = GetTextMetrics(win->screens[win->curupd-1]->bdc, &tm);
+    if (!b) winerr(); /* process windows error */
+    /* the em square is the cell height less the internal leading */
+    ps = (float)(tm.tmHeight-tm.tmInternalLeading)*2835.0f/(float)win->sdpmy;
     unlockmain(); /* end exclusive access */
 
     return (ps);
@@ -10212,8 +10246,8 @@ static void opnwin(int fn, int pfn)
     win->svsize = GetDeviceCaps(win->devcon, VERTSIZE); /* size y in millimeters */
     win->shres = GetDeviceCaps(win->devcon, HORZRES); /* pixels in x */
     win->svres = GetDeviceCaps(win->devcon, VERTRES); /* pixels in y */
-    win->sdpmx = win->shres/win->shsize*1000; /* find dots per meter x */
-    win->sdpmy = win->svres/win->svsize*1000; /* find dots per meter y */
+    win->sdpmx = win->shres*1000/win->shsize; /* find dots per meter x */
+    win->sdpmy = win->svres*1000/win->svsize; /* find dots per meter y */
     win->gmaxxg = maxxd*win->charspace; /* find client size x */
     win->gmaxyg = maxyd*win->linespace; /* find client size y */
     win->gmaxx = maxxd; /* character max x */


### PR DESCRIPTION
Follow-up to the DPI awareness work on `windows-dpi-aware-scaling`. The default terminal font came out 21x45 px per cell at 150% scaling — nearly twice the Windows console's Consolas (24 px cell). The DPI sizing math itself was correct; the size came from `petit_ami.cfg` overriding `console_points` to 19, a 2021-era value tuned to compensate for pre-DPI-awareness behavior. Two real defects in the point-size path were found while chasing it.

## Changes

- **Drop the `console_points 19` override** in `petit_ami.cfg`, leaving the option documented. The built-in 11 pt default produces a 12x26 cell at 150% scaling, within 2 px of the console's.
- **Fix dots-per-meter truncation** (`windows/graphics.c`): `shres/shsize*1000` truncated the integer division before scaling, so dpm was always a multiple of 1000 (6000 instead of 6400 here, up to ~25% off elsewhere). Now multiplies first, matching the Linux driver.
- **Fix em vs. cell mismatch in `ami_setpoints()`/`ami_points()`**: the point size was converted to an em-square pixel size but applied as a cell height (positive `CreateFont` height), making fonts ~18% smaller than requested and inconsistent with the Linux driver's `FT_Set_Pixel_Sizes` semantics. `ami_setpoints()` now measures the current face at the em size (like the startup DPI probe) and applies the resulting cell height; `ami_points()` derives the em square from the selected font's metrics instead of reporting the cell height as points.

## Verification

New `tests/fontsize_check.c`, run on a 3840x2160, 600x340 mm display at 150% scaling:

| | before | after |
|---|---|---|
| dpm | 6000 x 6000 | 6400 x 6352 |
| startup cell | 21 x 45 | 12 x 26 (console: 24 high) |
| setpoints(12) readback | — | 12.05 pt |
| setpoints(10.5) readback | — | 10.71 pt |
| setpoints(24) readback | — | 24.55 pt |

Round-trip error is within one em pixel of quantization. The GDI probe/recreate sequence was also verified stable standalone (no drift across newfont recreations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)