### PR TITLE
windows: fix pgup/pgdn falling through to F1 in key event translation

### DIFF
--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -7826,8 +7826,8 @@ static void ctlevent(winptr win, ami_evtrec* er, MSG* msg, int* keep)
             else er->etype = ami_etdelcf; /* insert toggle */
             break;
 
-        case VK_PRIOR: er->etype = ami_etpagu; /* page up */
-        case VK_NEXT: er->etype = ami_etpagd; /* page down */
+        case VK_PRIOR: er->etype = ami_etpagu; break; /* page up */
+        case VK_NEXT: er->etype = ami_etpagd; break; /* page down */
         case VK_F1: /* f1 */
             if (win->cntrl) er->etype = ami_etcopy; /* copy block */
             else if (win->shift) er->etype = ami_etcopyl; /* copy line */


### PR DESCRIPTION
## Summary
- `VK_PRIOR` and `VK_NEXT` cases in the keyboard event translation switch in `windows/graphics.c` were missing `break` statements, so Page Up and Page Down fell through into the `VK_F1` handler and were delivered as F1 function key events (`etfun`/`fkey=1`) instead of `etpagu`/`etpagd`.
- Added the missing `break` statements so both keys deliver their correct events.

## Testing
- Rebuilt `graphics_test` and verified Page Up/Page Down now zoom in/out on the "View drawing scale test" frame, where they previously produced no reaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
