### PR TITLE
windows: fix common dialogs in graphics driver

### DIFF
--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -15767,7 +15767,7 @@ Create window to pass messages only. The window will have no display.
 
 *******************************************************************************/
 
-static void createdummy(WNDPROC wndproc, char* name, HWND* dummywin)
+static void createdummy(WNDPROC wndproc, char* name, HWND* dummywin, int owner)
 
 {
 
@@ -15787,10 +15787,21 @@ static void createdummy(WNDPROC wndproc, char* name, HWND* dummywin)
     wc.lpszClassName = str(name);
     /* register that class */
     b = RegisterClass(&wc);
-    /* create the window */
-    *dummywin =
-        CreateWindow(name, "", 0, 0, 0, 0, 0, HWND_MESSAGE, 0,
-                     GetModuleHandle(NULL), NULL);
+    /* Create the window. If this window will own visible dialogs (the
+       common-dialog find/replace boxes name it as hwndOwner), it must be a
+       real, though hidden, top level window: a message-only window
+       (HWND_MESSAGE parent) cannot own a visible window, so the modeless
+       find/replace dialog would be created but never appear. Otherwise use a
+       message-only window, which is cheaper and stays out of window
+       enumeration. WS_EX_TOOLWINDOW keeps the hidden owner off the taskbar. */
+    if (owner)
+        *dummywin =
+            CreateWindowEx(WS_EX_TOOLWINDOW, name, "", 0, 0, 0, 0, 0, 0, 0,
+                           GetModuleHandle(NULL), NULL);
+    else
+        *dummywin =
+            CreateWindow(name, "", 0, 0, 0, 0, 0, HWND_MESSAGE, 0,
+                         GetModuleHandle(NULL), NULL);
 
 }
 
@@ -15813,7 +15824,7 @@ static DWORD WINAPI dispthread(LPVOID lpParameter)
     LRESULT r;   /* result holder */
 
     /* create dummy window for message handling */
-    createdummy(wndproc, "dispthread", &dispwin);
+    createdummy(wndproc, "dispthread", &dispwin, FALSE);
 
     b = SetEvent(threadstart); /* flag subthread has started up */
 
@@ -15945,7 +15956,7 @@ static LRESULT CALLBACK wndprocdialog(HWND hwnd, UINT imsg, WPARAM wparam,
             case imqcolor:
                 /* set starting color */
                 cr.rgbResult = rgb2win(ip->clrred, ip->clrgreen, ip->clrblue);
-                cr.lStructSize = 9*4; /* set size */
+                cr.lStructSize = sizeof(CHOOSECOLOR); /* set size */
                 cr.hwndOwner = 0; /* set no owner */
                 cr.hInstance = 0; /* no instance */
                 /*??? cr.rgbResult = 0;*/ /* clear color */
@@ -15985,7 +15996,11 @@ static LRESULT CALLBACK wndprocdialog(HWND hwnd, UINT imsg, WPARAM wparam,
                 fr.lStructSize = sizeof(OPENFILENAME); /* set size */
                 fr.hwndOwner = 0;
                 fr.hInstance = 0;
-                fr.lpstrFilter = NULL;
+                /* A default "all files" filter is required: without one the
+                   legacy (non-OFN_EXPLORER) file dialog leaves its file list
+                   empty, since the list is populated by matching against the
+                   filter pattern. */
+                fr.lpstrFilter = "All files (*.*)\0*.*\0\0";
                 fr.lpstrCustomFilter = NULL;
                 fr.nFilterIndex = 0;
                 fr.lpstrFile = bs;
@@ -16062,16 +16077,16 @@ static LRESULT CALLBACK wndprocdialog(HWND hwnd, UINT imsg, WPARAM wparam,
 
             case imqfindrep:
                 /* find length of search string */
-                fsl =strlen(ip->fnrsch);
+                fsl =strlen(ip->fnrsch)+1;
                 if (fsl < 80) fsl = 80; /* ensure >= 80 */
-                fs = imalloc(sl); /* get string */
+                fs = imalloc(fsl); /* get string */
                 strcpy(fs, ip->fnrsch); /* copy input string to buffer */
                 ifree(ip->fnrsch); /* free the passed string */
                 ip->fnrsch = fs; /* index buffer for return */
                 /* find length of replacement string */
-                rsl = strlen(ip->fnrrep);
+                rsl = strlen(ip->fnrrep)+1;
                 if (rsl < 80) rsl = 80; /* ensure >= 80 */
-                rs = imalloc(sl); /* get string */
+                rs = imalloc(rsl); /* get string */
                 strcpy(rs, ip->fnrrep); /* copy input string to buffer */
                 ifree(ip->fnrrep); /* free the passed string */
                 ip->fnrrep = rs; /* index buffer for return */
@@ -16245,7 +16260,7 @@ static DWORD WINAPI dialogthread(LPVOID lpParameter)
     LRESULT r;   /* result holder */
 
     /* create dummy window for message handling */
-    createdummy(wndprocdialog, "dialogthread", &dialogwin);
+    createdummy(wndprocdialog, "dialogthread", &dialogwin, TRUE);
 
     b = SetEvent(threadstart); /* flag subthread has started up */
 
@@ -16621,7 +16636,7 @@ static void ami_init_graph()
 
     /* Create dummy window for message handling. This is only required so that
       the main thread can be attached to the display thread */
-    createdummy(wndprocmain, "mainthread", &mainwin);
+    createdummy(wndprocmain, "mainthread", &mainwin, FALSE);
     mainthreadid = GetCurrentThreadId();
 
     getpgm(); /* get the program name from the command line */


### PR DESCRIPTION
## Summary

Four fixes for the Windows common dialogs, found while running `widget_test` (color query dialog missing at frame 39, empty file list at frame 40, find/replace dialog missing at frame 43).

- **Color query dialog never appeared** (frame 39): `cr.lStructSize` was hardcoded as `9*4` (36 bytes, the 32-bit `CHOOSECOLOR` size). On 64-bit the struct is 72 bytes, so `ChooseColor` rejected it with `CDERR_STRUCTSIZE` before showing anything. Use `sizeof(CHOOSECOLOR)`.
- **Open/save file dialog showed an empty file list** (frame 40): the legacy (non-`OFN_EXPLORER`) file dialog populates its list by matching against `lpstrFilter`, which was `NULL`. Supply a default `"All files (*.*)"` filter.
- **Find/replace dialog never appeared** (frame 43): it names `dialogwin` as `hwndOwner`, but `dialogwin` was a message-only window (`HWND_MESSAGE` parent), which cannot own a visible window — so the modeless dialog was created (valid handle, no error) but never displayed. `createdummy` gains an `owner` flag so the dialog thread's window is a real but hidden top-level window (`WS_EX_TOOLWINDOW` keeps it off the taskbar) that can own the dialog and still receive the `commdlg_FindReplace` termination message. This also repairs the find-only dialog, which shared the same owner. The disp/main dummy windows stay message-only.
- **Find/replace dialog appeared only intermittently even after the owner fix**: the `imqfindrep` case allocated its buffers with `imalloc(sl)` while `sl` was never set in that path (it computes `fsl`/`rsl` instead), giving a garbage buffer size that varied per run. A bad-sized buffer handed `ReplaceText` an invalid `FINDREPLACE` and it failed silently. Allocate with `fsl`/`rsl`, matching the find-only path.

## Testing

- Verified each dialog through its real driver entry point (`ami_querycolor`, `ami_queryopen`, `ami_queryfindrep`) with standalone repros and screenshots:
  - Color dialog appears with white preselected; OK returns white.
  - Open dialog file list populates (`.gitmodules`, `.pem` files, `configure`, …) with "All files (\*.\*)" selected.
  - Find/replace dialog appears with "bark"/"sniff" defaults; verified present in 5/5 consecutive runs (was intermittent before the `sl` fix); closing via Cancel returns the strings without hanging (round-trip `commdlg_FindReplace` routing intact).

## Notes

- Pre-existing, not addressed here: the dialog-thread message loop lacks `IsDialogMessage`, so the modeless find/replace dialog takes mouse input but not keyboard (ESC/Enter/Tab). Candidate for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
