### PR TITLE
macOS: font point sizing, buffered mode resize, cursor fix

### DIFF
--- a/macosx/graphics.c
+++ b/macosx/graphics.c
@@ -127,7 +127,8 @@ typedef struct winrec {
 
     /* font */
     fontptr     cfont;         /* current font */
-    CGFloat     fontsz;        /* font size in points */
+    CGFloat     fontsz;        /* font size in pixels (CTFont logical size) */
+    float       gfpoint;       /* current font size in typographic points */
 
     /* event handler */
     ami_pevthan evthan;
@@ -570,6 +571,7 @@ static void win_init(winptr win, int wid, int parwid, int w, int h)
     int spx_h  = pa_cocoa_screen_h();
     win->dpmx  = (smm_w > 0) ? spx_w * 1000 / smm_w : 3780; /* ~96 dpi */
     win->dpmy  = (smm_h > 0) ? spx_h * 1000 / smm_h : 3780;
+    win->gfpoint = win->fontsz * 2835.0f / (float)win->dpmy;
 
     /* character cell size from font metrics */
     CTFontRef f = fntlst ? fntlst->ctfont : NULL;
@@ -796,6 +798,8 @@ static void pa_graphics_init(void)
         win->han   = han;
         win->focus = TRUE;
         opnfil[1]  = 1; /* mark slot in use */
+        pa_cocoa_set_bufmod(han, win->bufmod);
+        pa_cocoa_set_background(han, 1.0f, 1.0f, 1.0f);
         clear_window(win);
         pa_cocoa_show_window(han);
         pa_cocoa_flush(han);
@@ -1023,12 +1027,11 @@ static void plcchr(winptr win, char c)
         /* newline: CR+LF — move to column 1 on next row */
         sc->curx  = 1;
         sc->curxg = 1;
-        if (sc->cury >= win->maxy) {
-            if (sc->autof) scroll_up(win);
-            /* else: cursor stays, no scroll */
+        if (sc->cury >= win->maxy && sc->autof) {
+            scroll_up(win);
         } else {
             sc->cury++;
-            sc->curyg = (sc->cury - 1) * win->linespace + 1;
+            sc->curyg += win->linespace;
         }
     } else if (c == '\r') {
         sc->curx  = 1;
@@ -1068,7 +1071,7 @@ static void plcchr(winptr win, char c)
                     scroll_up(win);
                 } else {
                     sc->cury++;
-                    sc->curyg = (sc->cury - 1) * win->linespace + 1;
+                    sc->curyg += win->linespace;
                 }
             }
         }
@@ -1198,19 +1201,22 @@ static void translate_event(const pa_rawevent* raw, ami_evtrec* er)
         er->etype  = ami_etresize;
         er->rszxg  = raw->resize.w;
         er->rszyg  = raw->resize.h;
-        /* update char dimensions */
+        er->rszx   = raw->resize.w;
+        er->rszy   = raw->resize.h;
         {
             winptr win = NULL;
             for (int i = 0; i < MAXFIL; i++)
                 if (opnfil[i] && wintbl[i].han == raw->win)
                     { win = &wintbl[i]; break; }
             if (win) {
-                win->maxxg = raw->resize.w;
-                win->maxyg = raw->resize.h;
-                win->maxx  = win->maxxg / win->charspace;
-                win->maxy  = win->maxyg / win->linespace;
-                er->rszx   = win->maxx;
-                er->rszy   = win->maxy;
+                er->rszx = raw->resize.w / win->charspace;
+                er->rszy = raw->resize.h / win->linespace;
+                if (!win->bufmod) {
+                    win->maxxg = raw->resize.w;
+                    win->maxyg = raw->resize.h;
+                    win->maxx  = er->rszx;
+                    win->maxy  = er->rszy;
+                }
             }
         }
         break;
@@ -1425,7 +1431,9 @@ void ami_fcolor(FILE* f, ami_color c)
 void ami_bcolor(FILE* f, ami_color c)
 {
     winptr win = f2win(f); if (!win) return;
-    curscn(win)->bc = ami2rgba(c);
+    pa_rgba bc = ami2rgba(c);
+    curscn(win)->bc = bc;
+    if (win->han) pa_cocoa_set_background(win->han, bc.r, bc.g, bc.b);
 }
 
 void ami_auto(FILE* f, int e)
@@ -1499,8 +1507,28 @@ void ami_viewscale(FILE* f, float x, float y)
     settrans(win);
 }
 void ami_linestyle(FILE* f, ami_lstyle style)     { /* stub */ }
-void ami_setpoints(FILE* f, float ps)             { /* stub */ }
-float ami_points(FILE* f)                         { return 11.0; }
+void ami_setpoints(FILE* f, float ps)
+{
+    winptr win = f2win(f); if (!win) return;
+    int pixsiz = (int)(ps * (float)win->dpmy / 2835.0f + 0.5f);
+    if (pixsiz < 1) pixsiz = 1;
+    win->fontsz  = (CGFloat)pixsiz;
+    win->gfpoint = ps;
+    scnptr sc = curscn(win);
+    if (sc->font && sc->font->name) {
+        if (sc->font->ctfont) CFRelease(sc->font->ctfont);
+        sc->font->ctfont = make_ctfont(sc->font->name, win->fontsz,
+                                       sc->bold, sc->italic);
+        sc->font->size   = win->fontsz;
+        update_metrics(win);
+    }
+}
+
+float ami_points(FILE* f)
+{
+    winptr win = f2win(f);
+    return win ? win->gfpoint : 11.0f;
+}
 
 int  ami_funkey(FILE* f)         { return 12; /* F1-F12 */ }
 
@@ -1938,6 +1966,7 @@ void ami_fontsiz(FILE* f, int s)
 {
     winptr win = f2win(f); if (!win) return;
     win->fontsz = (CGFloat)(s > 0 ? s : DEF_FONT_H);
+    win->gfpoint = win->fontsz * 2835.0f / (float)win->dpmy;
     /* rebuild current font at new size */
     scnptr sc = curscn(win);
     if (sc->font && sc->font->name) {
@@ -2142,6 +2171,7 @@ void ami_bcolorg(FILE* f, int r, int g, int b)
     winptr win = f2win(f); if (!win) return;
     pa_rgba c = { r/(double)INT_MAX, g/(double)INT_MAX, b/(double)INT_MAX, 1.0 };
     curscn(win)->bc = c;
+    if (win->han) pa_cocoa_set_background(win->han, c.r, c.g, c.b);
 }
 
 void ami_bcolorc(FILE* f, int r, int g, int b) { ami_bcolorg(f, r, g, b); }
@@ -2365,6 +2395,8 @@ void ami_openwin(FILE** infile, FILE** outfile, FILE* parent, int wid)
     win->infile  = inf;
     win->outfile = outf;
     opnfil[ofn]  = 1;
+    pa_cocoa_set_bufmod(han, win->bufmod);
+    pa_cocoa_set_background(han, 1.0f, 1.0f, 1.0f);
 
     pa_cocoa_show_window(han);
     clear_window(win);
@@ -2378,6 +2410,7 @@ void ami_buffer(FILE* f, int e)
 {
     winptr win = f2win(f); if (!win) return;
     win->bufmod = e;
+    if (win->han) pa_cocoa_set_bufmod(win->han, e);
 }
 
 void ami_getsiz(FILE* f, int* x, int* y)

--- a/macosx/graphics_cocoa.m
+++ b/macosx/graphics_cocoa.m
@@ -77,6 +77,8 @@ static int evt_empty(void) { return evt_head == evt_tail; }
     int           curVisible;  /* cursor visible flag */
     int           curX, curY;  /* cursor position (0-based pixels) */
     int           curW, curH;  /* cursor size (pixels) */
+    int           bufmod;      /* buffered mode flag */
+    float         bgR, bgG, bgB; /* background color for margins */
 }
 - (void)createBitmapWidth:(int)w height:(int)h;
 - (void)destroyBitmap;
@@ -145,8 +147,31 @@ static int evt_empty(void) { return evt_head == evt_tail; }
     if (!dsp) return;
     CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
     CGImageRef   img = CGBitmapContextCreateImage(dsp);
-    CGContextDrawImage(ctx, NSRectToCGRect(self.bounds), img);
+
+    int viewW = (int)self.bounds.size.width;
+    int viewH = (int)self.bounds.size.height;
+
+    /* draw bitmap at 1:1, clipped to view bounds (view is flipped) */
+    CGContextSaveGState(ctx);
+    if (viewW < bmpW || viewH < bmpH) {
+        int clipW = viewW < bmpW ? viewW : bmpW;
+        int clipH = viewH < bmpH ? viewH : bmpH;
+        CGContextClipToRect(ctx, CGRectMake(0, 0, clipW, clipH));
+    }
+    CGContextDrawImage(ctx, CGRectMake(0, 0, bmpW, bmpH), img);
+    CGContextRestoreGState(ctx);
     CGImageRelease(img);
+
+    /* fill margins with background color if window is larger than buffer */
+    if (bmpW < viewW || bmpH < viewH) {
+        CGContextSetRGBFillColor(ctx, bgR, bgG, bgB, 1.0);
+        if (bmpW < viewW)
+            CGContextFillRect(ctx, CGRectMake(bmpW, 0,
+                                              viewW - bmpW, viewH));
+        if (bmpH < viewH)
+            CGContextFillRect(ctx, CGRectMake(0, bmpH,
+                                              bmpW, viewH - bmpH));
+    }
 
     if (curVisible && curW > 0 && curH > 0) {
         CGContextSetBlendMode(ctx, kCGBlendModeDifference);
@@ -159,7 +184,10 @@ static int evt_empty(void) { return evt_head == evt_tail; }
 {
     [super viewDidEndLiveResize];
     NSSize s = self.bounds.size;
-    [self createBitmapWidth:(int)s.width height:(int)s.height];
+    if (!bufmod) {
+        /* unbuffered: resize the bitmap to match the new window */
+        [self createBitmapWidth:(int)s.width height:(int)s.height];
+    }
     pa_rawevent e = {0};
     e.type       = PA_EVT_RESIZE;
     e.win        = owner;
@@ -518,6 +546,20 @@ void pa_cocoa_set_cursor(pa_winhan win, int visible, int x, int y, int w, int h)
     v->curW = w;
     v->curH = h;
     if (changed) [v setNeedsDisplay:YES];
+}
+
+void pa_cocoa_set_bufmod(pa_winhan win, int on)
+{
+    PAWindow* pw = (__bridge PAWindow*)win;
+    pw->view->bufmod = on;
+}
+
+void pa_cocoa_set_background(pa_winhan win, float r, float g, float b)
+{
+    PAWindow* pw = (__bridge PAWindow*)win;
+    pw->view->bgR = r;
+    pw->view->bgG = g;
+    pw->view->bgB = b;
 }
 
 void pa_cocoa_select_screens(pa_winhan win, int upd, int dsp)

--- a/macosx/pa_cocoa.h
+++ b/macosx/pa_cocoa.h
@@ -133,6 +133,8 @@ CGContextRef pa_cocoa_get_context(pa_winhan win);
 void         pa_cocoa_flush(pa_winhan win);       /* blit offscreen → screen */
 void         pa_cocoa_select_screens(pa_winhan win, int upd, int dsp); /* 0-based */
 void         pa_cocoa_set_cursor(pa_winhan win, int visible, int x, int y, int w, int h);
+void         pa_cocoa_set_bufmod(pa_winhan win, int on);
+void         pa_cocoa_set_background(pa_winhan win, float r, float g, float b);
 
 /*----------------------------------------------------------------------------
  * Event polling — single-threaded poll model.


### PR DESCRIPTION
## Summary
- **Implement `ami_setpoints`/`ami_points`**: Convert between typographic points and pixels using `dpmy / 2835` (matching Linux). Track current point size in `win->gfpoint`, kept in sync by both `ami_setpoints` and `ami_fontsiz`.
- **Fix buffered mode window resize**: Draw bitmap at 1:1 with clipping (not scaling), fill margins with background color when window exceeds buffer, only recreate bitmap in unbuffered mode. Propagate `bufmod` and background color to Cocoa layer.
- **Fix newline cursor advancement**: Use incremental `curyg += linespace` instead of recomputing from grid row (broken with variable font sizes). Allow cursor to advance past `maxy` when auto-scroll is off (prevents all lines drawing at same position when font size changes shrink `maxy`).

## Test plan
- [ ] Run `bin/graphics_test`, verify frame 128 (Font sizing test) shows smoothly increasing font sizes with contiguous background bands
- [ ] Verify frame 129 (Font point sizing test) shows increasing point sizes with correct `chrsizy` and `points` values
- [ ] Verify buffered mode resize: enlarging window shows margins in background color, shrinking clips the buffer at 1:1
- [ ] Verify normal text output (auto mode on) still scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)