### PR TITLE
management_test: cap resize loops to WM-granted maximum size

### DIFF
--- a/tests/management_test.c
+++ b/tests/management_test.c
@@ -53,6 +53,7 @@ static int        maxcnt;       /* maximize counter */
 static int        nrmcnt;       /* normalize counter */
 static int        i;
 static int        xs, ys;
+static int        mxs, mys;      /* maximum window size the WM will grant */
 static int        cs;
 static long       t, et;
 static ami_color   c1, c2, c3;
@@ -483,7 +484,14 @@ int main(void)
     ox = ami_maxxg(stdout);
     oy = ami_maxyg(stdout);
     sqrrat(&xs, &ys, 1.5); /* find square ratio */
-    for (x = xs; x <= xs*4; x += xs/64) {
+    /* Find the maximum size the window manager will grant, which can be less
+       than the screen size (windows are typically limited to a single monitor,
+       less any panels). Requests past this limit are silently clamped, so cap
+       the resize loops to it. */
+    ami_scnsizg(stdout, &mxs, &mys);
+    ami_setsizg(stdout, mxs, mys);
+    ami_getsizg(stdout, &mxs, &mys);
+    for (x = xs; x <= xs*4 && x <= mxs; x += xs/64) {
 
         ami_setsizg(stdout, x, ys);
         ami_getsizg(stdout, &x2, &y2);
@@ -509,7 +517,7 @@ int main(void)
     printf("\n");
     printf("Complete\n");
     waitnext();
-    for (y = ys; y <= ys*4; y += ys/64) {
+    for (y = ys; y <= ys*4 && y <= mys; y += ys/64) {
 
         ami_setsizg(stdout, xs, y);
         ami_getsizg(stdout, &x2, &y2);
@@ -518,7 +526,7 @@ int main(void)
             ami_setsiz(stdout, 80, 25);
             putchar('\f');
             printf("*** Getsiz does not match setsiz, x: %d y: %d vs. x: %d y: %d\n",
-                   x2, y2, 300, y);
+                   x2, y2, xs, y);
             printf("*** Getsiz does ! match setsiz\n");
             waitnext();
             longjmp(terminate_buf, 1);


### PR DESCRIPTION
## Problem

`management_test` frame 10 aborted with:

```
*** Getsiz does not match setsiz, x: 570 y: 2178 vs. x: 300 y: 2186
```

The buffered pixel resize loops grow the window to 4x a base square (~2280px tall for a 2160px monitor). GNOME's mutter silently clamps any resize taller than a single monitor (verified with a standalone Xlib probe: requests of 2186/2300/4000px all came back at the same clamped height), so `getsizg` legitimately disagrees with `setsizg` once the loop crosses the monitor limit, and the test fails on any monitor shorter than the 4x target. The driver is behaving correctly — it already adopts the WM-granted size by design.

## Fix

- Probe the real grantable maximum once before the pixel resize loops: request a screen-sized window and read back what the WM grants (`ami_scnsizg` alone is not enough — it returns the full multi-monitor desktop, while the WM clamps to one monitor less panels). Cap both the x and y loops there.
- Fix the y-loop failure message, which printed a hardcoded `300` instead of the actual requested width.

## Verification

Rebuilt and drove the test with synthetic key events past the failing section: previously aborted at frame 10, now runs frames 10-12 cleanly with all setsiz/getsiz checks inside tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)