### PR TITLE
macOS: buffer resize, system bar, frame controls, unbuffered redraw

### DIFF
--- a/macosx/graphics.c
+++ b/macosx/graphics.c
@@ -1562,8 +1562,24 @@ void ami_wrtstrn(FILE* f, char* s, int n)
     fwrite(s, 1, n, f);
 }
 
-void ami_sizbuf(FILE* f, int x, int y)   { /* stub */ }
-void ami_sizbufg(FILE* f, int x, int y)  { /* stub */ }
+void ami_sizbufg(FILE* f, int x, int y)
+{
+    winptr win = f2win(f); if (!win) return;
+    if (x < 1 || y < 1) return;
+    pa_cocoa_resize_bitmap(win->han, x, y);
+    win->maxxg = x;
+    win->maxyg = y;
+    win->maxx  = x / win->charspace;
+    win->maxy  = y / win->linespace;
+    if (win->maxx < 1) win->maxx = 1;
+    if (win->maxy < 1) win->maxy = 1;
+}
+
+void ami_sizbuf(FILE* f, int x, int y)
+{
+    winptr win = f2win(f); if (!win) return;
+    ami_sizbufg(f, x * win->charspace, y * win->linespace);
+}
 
 void ami_title(FILE* f, char* ts)
 {
@@ -2521,7 +2537,12 @@ void ami_sizable(FILE* f, int e)
     pa_cocoa_set_sizable(win->han, e);
 }
 
-void ami_sysbar(FILE* f, int e)       { /* stub */ }
+void ami_sysbar(FILE* f, int e)
+{
+    winptr win = f2win(f); if (!win) return;
+    win->sysbar = e;
+    pa_cocoa_set_sysbar(win->han, e);
+}
 void ami_menu(FILE* f, ami_menuptr m) { /* stub */ }
 void ami_menuena(FILE* f, int id, int onoff) { /* stub */ }
 void ami_menusel(FILE* f, int id, int select) { /* stub */ }

--- a/macosx/graphics_cocoa.m
+++ b/macosx/graphics_cocoa.m
@@ -194,6 +194,16 @@ static int evt_empty(void) { return evt_head == evt_tail; }
     e.resize.w   = (int)s.width;
     e.resize.h   = (int)s.height;
     evt_push(&e);
+    if (!bufmod) {
+        pa_rawevent r = {0};
+        r.type     = PA_EVT_REDRAW;
+        r.win      = owner;
+        r.redraw.x = 0;
+        r.redraw.y = 0;
+        r.redraw.w = (int)s.width;
+        r.redraw.h = (int)s.height;
+        evt_push(&r);
+    }
     [self setNeedsDisplay:YES];
 }
 
@@ -500,9 +510,25 @@ void pa_cocoa_focus(pa_winhan win)
 void pa_cocoa_set_frame(pa_winhan win, int on)
 {
     PAWindow*       pw    = (__bridge PAWindow*)win;
+    NSWindowStyleMask all = NSWindowStyleMaskTitled |
+                            NSWindowStyleMaskClosable |
+                            NSWindowStyleMaskMiniaturizable |
+                            NSWindowStyleMaskResizable;
     NSWindowStyleMask m   = pw->window.styleMask;
-    if (on) m |=  NSWindowStyleMaskTitled;
-    else    m &= ~NSWindowStyleMaskTitled;
+    if (on) m |=  all;
+    else    m &= ~all;
+    pw->window.styleMask = m;
+}
+
+void pa_cocoa_set_sysbar(pa_winhan win, int on)
+{
+    PAWindow*       pw  = (__bridge PAWindow*)win;
+    NSWindowStyleMask bar = NSWindowStyleMaskTitled |
+                            NSWindowStyleMaskClosable |
+                            NSWindowStyleMaskMiniaturizable;
+    NSWindowStyleMask m = pw->window.styleMask;
+    if (on) m |=  bar;
+    else    m &= ~bar;
     pw->window.styleMask = m;
 }
 
@@ -546,6 +572,51 @@ void pa_cocoa_set_cursor(pa_winhan win, int visible, int x, int y, int w, int h)
     v->curW = w;
     v->curH = h;
     if (changed) [v setNeedsDisplay:YES];
+}
+
+void pa_cocoa_resize_bitmap(pa_winhan win, int w, int h)
+{
+    PAWindow* pw = (__bridge PAWindow*)win;
+    PAView*   v  = pw->view;
+
+    int oldW = v->bmpW;
+    int oldH = v->bmpH;
+
+    /* save old display screen bitmap */
+    CGContextRef oldCtx = v->screens[v->dspscr];
+    CGImageRef oldImg = oldCtx ? CGBitmapContextCreateImage(oldCtx) : NULL;
+
+    /* release all screen bitmaps except detach the display one */
+    v->screens[v->dspscr] = NULL;
+    for (int i = 0; i < 10; i++) {
+        if (v->screens[i]) { CGContextRelease(v->screens[i]); v->screens[i] = NULL; }
+    }
+    if (oldCtx) CGContextRelease(oldCtx);
+
+    /* create new bitmaps at new size */
+    v->bmpW = w;
+    v->bmpH = h;
+    v->screens[v->dspscr] = [v createOneBitmapWidth:w height:h];
+    v->bitmap = v->screens[v->dspscr];
+    if (v->updscr != v->dspscr) {
+        v->screens[v->updscr] = [v createOneBitmapWidth:w height:h];
+    }
+
+    /* copy intersection of old content into new display bitmap */
+    if (oldImg) {
+        int copyW = oldW < w ? oldW : w;
+        int copyH = oldH < h ? oldH : h;
+        if (copyW > 0 && copyH > 0) {
+            CGContextRef dst = v->screens[v->dspscr];
+            CGContextSaveGState(dst);
+            CGContextClipToRect(dst, CGRectMake(0, 0, copyW, copyH));
+            CGContextDrawImage(dst, CGRectMake(0, 0, oldW, oldH), oldImg);
+            CGContextRestoreGState(dst);
+        }
+        CGImageRelease(oldImg);
+    }
+
+    [v setNeedsDisplay:YES];
 }
 
 void pa_cocoa_set_bufmod(pa_winhan win, int on)

--- a/macosx/pa_cocoa.h
+++ b/macosx/pa_cocoa.h
@@ -118,6 +118,7 @@ void pa_cocoa_back(pa_winhan win);
 void pa_cocoa_focus(pa_winhan win);
 /* window chrome */
 void pa_cocoa_set_frame(pa_winhan win, int on);
+void pa_cocoa_set_sysbar(pa_winhan win, int on);
 void pa_cocoa_set_sizable(pa_winhan win, int on);
 
 /*----------------------------------------------------------------------------
@@ -133,6 +134,7 @@ CGContextRef pa_cocoa_get_context(pa_winhan win);
 void         pa_cocoa_flush(pa_winhan win);       /* blit offscreen → screen */
 void         pa_cocoa_select_screens(pa_winhan win, int upd, int dsp); /* 0-based */
 void         pa_cocoa_set_cursor(pa_winhan win, int visible, int x, int y, int w, int h);
+void         pa_cocoa_resize_bitmap(pa_winhan win, int w, int h);
 void         pa_cocoa_set_bufmod(pa_winhan win, int on);
 void         pa_cocoa_set_background(pa_winhan win, float r, float g, float b);
 


### PR DESCRIPTION
## Summary
- **Implement `ami_sizbuf`/`ami_sizbufg`**: Resize the offscreen bitmap, copying intersection of old content into the new buffer. `ami_sizbuf` converts character dimensions to pixels and delegates to `ami_sizbufg`.
- **Implement `ami_sysbar`**: Toggle title bar (titled + closable + miniaturizable) independently of the resize handle.
- **Fix `ami_frame`**: Now toggles all window chrome (titled, closable, miniaturizable, resizable) instead of only the title.
- **Fix unbuffered resize blanking**: Inject a `PA_EVT_REDRAW` event after resize in unbuffered mode so the program can repaint into the new bitmap.

## Test plan
- [ ] `bin/management_test` frame 5: buffer resize should show 50x50 characters
- [ ] Frame 6: buffer resize graphical should show correct pixel dimensions
- [ ] Frame 13: frame off should remove all chrome including resize handle
- [ ] Frame 14: system bar off should remove title bar but keep resize handle
- [ ] Frame 17+: unbuffered frame controls — resizing should repaint, not blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)