### PR TITLE
macOS: implement the widget set and query dialogs

### DIFF
--- a/macosx/graphics.c
+++ b/macosx/graphics.c
@@ -936,10 +936,10 @@ static void clear_window(winptr win)
 *******************************************************************************/
 
 /* Scroll window content up by one text line.
- * Uses raw bitmap memmove: row 0 in the bitmap data is the top of the screen
- * (because CGBitmapContextCreateImage + flipped NSView compose to that).
- * Shifts physical rows toward lower addresses (upward), then redraws the
- * cleared bottom strip with the background color. */
+ * Uses raw bitmap memmove: the bitmap context is CG y-up, so row 0 of the
+ * data is the BOTTOM of the screen. Shifts physical rows toward higher
+ * addresses (visually upward), then redraws the freed bottom strip with
+ * the background color. */
 static void scroll_up(winptr win)
 {
     CGContextRef ctx = pa_cocoa_get_context(win->han);
@@ -957,8 +957,11 @@ static void scroll_up(winptr win)
     if (physLS == 0 || physLS >= height) return;
     (void)width; /* not needed for row-wise memmove */
 
-    /* move rows up */
-    memmove(data, data + physLS * rowbytes, (height - physLS) * rowbytes);
+    /* Move the content up one text line. The bitmap is CG y-up: data row 0
+       is the BOTTOM of the screen (drawing flips logical coordinates via
+       PY()), so shifting visual content up means moving data rows toward
+       higher addresses. */
+    memmove(data + physLS * rowbytes, data, (height - physLS) * rowbytes);
 
     /* fill the freed rows at the bottom with the background color using CG */
     scnptr sc = curscn(win);
@@ -1317,6 +1320,69 @@ static void translate_event(const pa_rawevent* raw, ami_evtrec* er)
 
     case PA_EVT_NORM:
         er->etype = ami_etnorm;
+        break;
+
+    case PA_EVT_WIDGET:
+        switch (raw->widget.act) {
+        case PA_WIDGET_BUTTON:
+            er->etype = ami_etbutton;
+            er->butid = raw->widget.id;
+            break;
+        case PA_WIDGET_CHECKBOX:
+            er->etype  = ami_etchkbox;
+            er->ckbxid = raw->widget.id;
+            break;
+        case PA_WIDGET_RADIO:
+            er->etype  = ami_etradbut;
+            er->radbid = raw->widget.id;
+            break;
+        case PA_WIDGET_SCROLL_PAGEUP:
+            er->etype  = ami_etsclulp;
+            er->sclupid = raw->widget.id;
+            break;
+        case PA_WIDGET_SCROLL_PAGEDN:
+            er->etype  = ami_etscldrp;
+            er->scldpid = raw->widget.id;
+            break;
+        case PA_WIDGET_SCROLL_POS:
+            er->etype  = ami_etsclpos;
+            er->sclpid = raw->widget.id;
+            er->sclpos = raw->widget.pos;
+            break;
+        case PA_WIDGET_SLIDER_POS:
+            er->etype  = ami_etsldpos;
+            er->sldpid = raw->widget.id;
+            er->sldpos = raw->widget.pos;
+            break;
+        case PA_WIDGET_EDIT_DONE:
+            er->etype  = ami_etedtbox;
+            er->edtbid = raw->widget.id;
+            break;
+        case PA_WIDGET_NUM_DONE:
+            er->etype  = ami_etnumbox;
+            er->numbid = raw->widget.id;
+            er->numbsl = raw->widget.pos;
+            break;
+        case PA_WIDGET_LIST_SEL:
+            er->etype  = ami_etlstbox;
+            er->lstbid = raw->widget.id;
+            er->lstbsl = raw->widget.pos;
+            break;
+        case PA_WIDGET_DROP_SEL:
+            er->etype  = ami_etdrpbox;
+            er->drpbid = raw->widget.id;
+            er->drpbsl = raw->widget.pos;
+            break;
+        case PA_WIDGET_DROPED_DONE:
+            er->etype  = ami_etdrebox;
+            er->drebid = raw->widget.id;
+            break;
+        case PA_WIDGET_TAB_SEL:
+            er->etype  = ami_ettabbar;
+            er->tabid  = raw->widget.id;
+            er->tabsel = raw->widget.pos;
+            break;
+        }
         break;
 
     default:
@@ -2859,97 +2925,193 @@ void ami_backwidget(FILE* f, int id)                { /* stub */ }
 void ami_frontwidget(FILE* f, int id)               { /* stub */ }
 void ami_focuswidget(FILE* f, int id)               { /* stub */ }
 
-void ami_buttonsiz(FILE* f, char* s, int* w, int* h)
+/* The plain widget calls take CHARACTER coordinates/sizes; the -g calls
+   take pixels. Character rects convert to pixel rects covering the full
+   character cells (Windows semantics), and pixel sizes convert to
+   character sizes rounding up. */
+
+static void chr2grrect(winptr win, int* x1, int* y1, int* x2, int* y2)
+{
+    *x1 = (*x1 - 1) * win->charspace + 1;
+    *y1 = (*y1 - 1) * win->linespace + 1;
+    *x2 = (*x2) * win->charspace;
+    *y2 = (*y2) * win->linespace;
+}
+
+static void gr2chrsiz(winptr win, int* w, int* h)
+{
+    *w = (*w - 1) / win->charspace + 1;
+    *h = (*h - 1) / win->linespace + 1;
+}
+
+void ami_buttonsizg(FILE* f, char* s, int* w, int* h)
 {
     *w = ami_strsiz(f, s) + 20;
     *h = ami_chrsizy(f) + 8;
 }
 
-void ami_buttonsizg(FILE* f, char* s, int* w, int* h) { ami_buttonsiz(f, s, w, h); }
+void ami_buttonsiz(FILE* f, char* s, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_buttonsizg(f, s, w, h);
+    gr2chrsiz(win, w, h);
+}
 
-void ami_button(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_buttong(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
     winptr win = f2win(f); if (!win || !s) return;
     pa_cocoa_button(win->han, x1, y1, x2-x1+1, y2-y1+1, s, id);
 }
 
-void ami_buttong(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_button(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
-    ami_button(f, x1, y1, x2, y2, s, id);
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_buttong(f, x1, y1, x2, y2, s, id);
 }
 
-void ami_checkboxsiz(FILE* f, char* s, int* w, int* h)
+void ami_checkboxsizg(FILE* f, char* s, int* w, int* h)
 {
     *w = ami_strsiz(f, s) + 24;
     *h = ami_chrsizy(f) + 4;
 }
 
-void ami_checkboxsizg(FILE* f, char* s, int* w, int* h) { ami_checkboxsiz(f, s, w, h); }
+void ami_checkboxsiz(FILE* f, char* s, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_checkboxsizg(f, s, w, h);
+    gr2chrsiz(win, w, h);
+}
 
-void ami_checkbox(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_checkboxg(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
     winptr win = f2win(f); if (!win || !s) return;
     pa_cocoa_checkbox(win->han, x1, y1, x2-x1+1, y2-y1+1, s, id);
 }
 
-void ami_checkboxg(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_checkbox(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
-    ami_checkbox(f, x1, y1, x2, y2, s, id);
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_checkboxg(f, x1, y1, x2, y2, s, id);
 }
 
-void ami_radiobuttonsiz(FILE* f, char* s, int* w, int* h)
+void ami_radiobuttonsizg(FILE* f, char* s, int* w, int* h)
 {
     *w = ami_strsiz(f, s) + 24;
     *h = ami_chrsizy(f) + 4;
 }
 
-void ami_radiobuttonsizg(FILE* f, char* s, int* w, int* h) { ami_radiobuttonsiz(f, s, w, h); }
+void ami_radiobuttonsiz(FILE* f, char* s, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_radiobuttonsizg(f, s, w, h);
+    gr2chrsiz(win, w, h);
+}
 
-void ami_radiobutton(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_radiobuttong(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
     winptr win = f2win(f); if (!win || !s) return;
     pa_cocoa_radiobutton(win->han, x1, y1, x2-x1+1, y2-y1+1, s, id);
 }
 
-void ami_radiobuttong(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+void ami_radiobutton(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
 {
-    ami_radiobutton(f, x1, y1, x2, y2, s, id);
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_radiobuttong(f, x1, y1, x2, y2, s, id);
 }
 
 void ami_groupsizg(FILE* f, char* s, int cw, int ch, int* w, int* h, int* ox, int* oy)
-{ *w = cw + 10; *h = ch + 20; *ox = 5; *oy = 15; }
+{
+    /* the group must be at least wide enough for its title as NSBox
+       renders it, and tall enough for the title plus the client area */
+    int tw, th;
+    pa_cocoa_group_title_size(s, &tw, &th);
+    *w = tw + 7 * 2;
+    if (cw + 7 * 2 > *w) *w = cw + 7 * 2;
+    *h  = th + ch + 5 * 2;
+    *ox = 5;
+    *oy = th;
+}
 
 void ami_groupsiz(FILE* f, char* s, int cw, int ch, int* w, int* h, int* ox, int* oy)
-{ ami_groupsizg(f, s, cw, ch, w, h, ox, oy); }
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; *ox = *oy = 0; return; }
+    ami_groupsizg(f, s, cw * win->charspace, ch * win->linespace, w, h, ox, oy);
+    gr2chrsiz(win, w, h);
+    gr2chrsiz(win, ox, oy);
+}
 
-void ami_group(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)   { /* stub */ }
-void ami_groupg(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)  { /* stub */ }
-void ami_background(FILE* f, int x1, int y1, int x2, int y2, int id)       { /* stub */ }
-void ami_backgroundg(FILE* f, int x1, int y1, int x2, int y2, int id)      { /* stub */ }
+void ami_groupg(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+{
+    winptr win = f2win(f); if (!win || !s) return;
+    pa_cocoa_group(win->han, x1, y1, x2-x1+1, y2-y1+1, s, id);
+}
+
+void ami_group(FILE* f, int x1, int y1, int x2, int y2, char* s, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_groupg(f, x1, y1, x2, y2, s, id);
+}
+
+void ami_backgroundg(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    pa_cocoa_background(win->han, x1, y1, x2-x1+1, y2-y1+1, id);
+}
+
+void ami_background(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_backgroundg(f, x1, y1, x2, y2, id);
+}
 
 void ami_scrollvertsizg(FILE* f, int* w, int* h)  { *w = 16; *h = 100; }
-void ami_scrollvertsiz(FILE* f, int* w, int* h)   { ami_scrollvertsizg(f, w, h); }
 
-void ami_scrollvert(FILE* f, int x1, int y1, int x2, int y2, int id)
+void ami_scrollvertsiz(FILE* f, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_scrollvertsizg(f, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_scrollvertg(FILE* f, int x1, int y1, int x2, int y2, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_scrollvert(win->han, x1, y1, x2-x1+1, y2-y1+1, id);
 }
 
-void ami_scrollvertg(FILE* f, int x1, int y1, int x2, int y2, int id)
-{ ami_scrollvert(f, x1, y1, x2, y2, id); }
+void ami_scrollvert(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_scrollvertg(f, x1, y1, x2, y2, id);
+}
 
 void ami_scrollhorizsizg(FILE* f, int* w, int* h)  { *w = 100; *h = 16; }
-void ami_scrollhorizsiz(FILE* f, int* w, int* h)   { ami_scrollhorizsizg(f, w, h); }
 
-void ami_scrollhoriz(FILE* f, int x1, int y1, int x2, int y2, int id)
+void ami_scrollhorizsiz(FILE* f, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_scrollhorizsizg(f, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_scrollhorizg(FILE* f, int x1, int y1, int x2, int y2, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_scrollhoriz(win->han, x1, y1, x2-x1+1, y2-y1+1, id);
 }
 
-void ami_scrollhorizg(FILE* f, int x1, int y1, int x2, int y2, int id)
-{ ami_scrollhoriz(f, x1, y1, x2, y2, id); }
+void ami_scrollhoriz(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_scrollhorizg(f, x1, y1, x2, y2, id);
+}
 
 void ami_scrollpos(FILE* f, int id, int r)
 {
@@ -2964,35 +3126,70 @@ void ami_scrollsiz(FILE* f, int id, int r)
 }
 
 void ami_numselboxsizg(FILE* f, int l, int u, int* w, int* h) { *w = 80; *h = 24; }
-void ami_numselboxsiz(FILE* f, int l, int u, int* w, int* h)  { ami_numselboxsizg(f, l, u, w, h); }
-void ami_numselbox(FILE* f, int x1, int y1, int x2, int y2, int l, int u, int id) { /* stub */ }
-void ami_numselboxg(FILE* f, int x1, int y1, int x2, int y2, int l, int u, int id) { /* stub */ }
+
+void ami_numselboxsiz(FILE* f, int l, int u, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_numselboxsizg(f, l, u, w, h);
+    gr2chrsiz(win, w, h);
+}
+void ami_numselboxg(FILE* f, int x1, int y1, int x2, int y2, int l, int u, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    pa_cocoa_numselbox(win->han, x1, y1, x2-x1+1, y2-y1+1, l, u, id);
+}
+
+void ami_numselbox(FILE* f, int x1, int y1, int x2, int y2, int l, int u, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_numselboxg(f, x1, y1, x2, y2, l, u, id);
+}
 
 void ami_editboxsizg(FILE* f, char* s, int* w, int* h)
 { *w = ami_strsiz(f, s) + 20; *h = ami_chrsizy(f) + 8; }
 
-void ami_editboxsiz(FILE* f, char* s, int* w, int* h) { ami_editboxsizg(f, s, w, h); }
+void ami_editboxsiz(FILE* f, char* s, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_editboxsizg(f, s, w, h);
+    gr2chrsiz(win, w, h);
+}
 
-void ami_editbox(FILE* f, int x1, int y1, int x2, int y2, int id)
+void ami_editboxg(FILE* f, int x1, int y1, int x2, int y2, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_editbox(win->han, x1, y1, x2-x1+1, y2-y1+1, id);
 }
 
-void ami_editboxg(FILE* f, int x1, int y1, int x2, int y2, int id)
-{ ami_editbox(f, x1, y1, x2, y2, id); }
+void ami_editbox(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_editboxg(f, x1, y1, x2, y2, id);
+}
 
 void ami_progbarsizg(FILE* f, int* w, int* h) { *w = 200; *h = 20; }
-void ami_progbarsiz(FILE* f, int* w, int* h)  { ami_progbarsizg(f, w, h); }
 
-void ami_progbar(FILE* f, int x1, int y1, int x2, int y2, int id)
+void ami_progbarsiz(FILE* f, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_progbarsizg(f, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_progbarg(FILE* f, int x1, int y1, int x2, int y2, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_progressbar(win->han, x1, y1, x2-x1+1, y2-y1+1, id);
 }
 
-void ami_progbarg(FILE* f, int x1, int y1, int x2, int y2, int id)
-{ ami_progbar(f, x1, y1, x2, y2, id); }
+void ami_progbar(FILE* f, int x1, int y1, int x2, int y2, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_progbarg(f, x1, y1, x2, y2, id);
+}
 
 void ami_progbarpos(FILE* f, int id, int pos)
 {
@@ -3000,68 +3197,254 @@ void ami_progbarpos(FILE* f, int id, int pos)
     pa_cocoa_progressbar_pos(win->han, id, pos);
 }
 
-void ami_listboxsizg(FILE* f, ami_strptr sp, int* w, int* h) { *w = 150; *h = 100; }
-void ami_listboxsiz(FILE* f, ami_strptr sp, int* w, int* h)  { ami_listboxsizg(f, sp, w, h); }
-void ami_listbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)   { /* stub */ }
-void ami_listboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)  { /* stub */ }
+void ami_listboxsizg(FILE* f, ami_strptr sp, int* w, int* h)
+{
+    /* wide enough for the longest entry plus scroller and border, tall
+       enough for all entries at the native ~18px row height */
+    int mw = 0, n = 0;
+    for (ami_strptr p = sp; p; p = p->next) {
+        int sw = ami_strsiz(f, p->str);
+        if (sw > mw) mw = sw;
+        n++;
+    }
+    *w = mw + 40;
+    *h = n * 18 + 6;
+}
+
+void ami_listboxsiz(FILE* f, ami_strptr sp, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_listboxsizg(f, sp, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_listboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    int n = 0;
+    for (ami_strptr p = sp; p; p = p->next) n++;
+    if (!n) return;
+    const char** strs = malloc(n * sizeof(char*));
+    if (!strs) return;
+    int i = 0;
+    for (ami_strptr p = sp; p; p = p->next) strs[i++] = p->str;
+    pa_cocoa_listbox(win->han, x1, y1, x2-x1+1, y2-y1+1, strs, n, id);
+    free(strs);
+}
+
+void ami_listbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_listboxg(f, x1, y1, x2, y2, sp, id);
+}
 
 void ami_dropboxsizg(FILE* f, ami_strptr sp, int* cw, int* ch, int* ow, int* oh)
 { *cw = 150; *ch = 24; *ow = 150; *oh = 100; }
 
 void ami_dropboxsiz(FILE* f, ami_strptr sp, int* cw, int* ch, int* ow, int* oh)
-{ ami_dropboxsizg(f, sp, cw, ch, ow, oh); }
+{
+    winptr win = f2win(f); if (!win) { *cw = *ch = *ow = *oh = 1; return; }
+    ami_dropboxsizg(f, sp, cw, ch, ow, oh);
+    gr2chrsiz(win, cw, ch);
+    gr2chrsiz(win, ow, oh);
+}
 
-void ami_dropbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)   { /* stub */ }
-void ami_dropboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)  { /* stub */ }
+void ami_dropboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    int n = 0;
+    for (ami_strptr p = sp; p; p = p->next) n++;
+    if (!n) return;
+    const char** strs = malloc(n * sizeof(char*));
+    if (!strs) return;
+    int i = 0;
+    for (ami_strptr p = sp; p; p = p->next) strs[i++] = p->str;
+    pa_cocoa_dropbox(win->han, x1, y1, x2-x1+1, y2-y1+1, strs, n, id);
+    free(strs);
+}
+
+void ami_dropbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_dropboxg(f, x1, y1, x2, y2, sp, id);
+}
 
 void ami_dropeditboxsizg(FILE* f, ami_strptr sp, int* cw, int* ch, int* ow, int* oh)
 { ami_dropboxsizg(f, sp, cw, ch, ow, oh); }
 
 void ami_dropeditboxsiz(FILE* f, ami_strptr sp, int* cw, int* ch, int* ow, int* oh)
-{ ami_dropeditboxsizg(f, sp, cw, ch, ow, oh); }
+{
+    winptr win = f2win(f); if (!win) { *cw = *ch = *ow = *oh = 1; return; }
+    ami_dropeditboxsizg(f, sp, cw, ch, ow, oh);
+    gr2chrsiz(win, cw, ch);
+    gr2chrsiz(win, ow, oh);
+}
 
-void ami_dropeditbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id) { /* stub */ }
-void ami_dropeditboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id) { /* stub */ }
+void ami_dropeditboxg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    int n = 0;
+    for (ami_strptr p = sp; p; p = p->next) n++;
+    if (!n) return;
+    const char** strs = malloc(n * sizeof(char*));
+    if (!strs) return;
+    int i = 0;
+    for (ami_strptr p = sp; p; p = p->next) strs[i++] = p->str;
+    pa_cocoa_dropeditbox(win->han, x1, y1, x2-x1+1, y2-y1+1, strs, n, id);
+    free(strs);
+}
+
+void ami_dropeditbox(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_dropeditboxg(f, x1, y1, x2, y2, sp, id);
+}
 
 void ami_slidehorizsizg(FILE* f, int* w, int* h) { *w = 150; *h = 20; }
-void ami_slidehorizsiz(FILE* f, int* w, int* h)  { ami_slidehorizsizg(f, w, h); }
 
-void ami_slidehoriz(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
+void ami_slidehorizsiz(FILE* f, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_slidehorizsizg(f, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_slidehorizg(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_slider_horiz(win->han, x1, y1, x2-x1+1, y2-y1+1, mark, id);
 }
 
-void ami_slidehorizg(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
-{ ami_slidehoriz(f, x1, y1, x2, y2, mark, id); }
+void ami_slidehoriz(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_slidehorizg(f, x1, y1, x2, y2, mark, id);
+}
 
 void ami_slidevertsizg(FILE* f, int* w, int* h) { *w = 20; *h = 150; }
-void ami_slidevertsiz(FILE* f, int* w, int* h)  { ami_slidevertsizg(f, w, h); }
 
-void ami_slidevert(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
+void ami_slidevertsiz(FILE* f, int* w, int* h)
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; return; }
+    ami_slidevertsizg(f, w, h);
+    gr2chrsiz(win, w, h);
+}
+
+void ami_slidevertg(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
 {
     winptr win = f2win(f); if (!win) return;
     pa_cocoa_slider_vert(win->han, x1, y1, x2-x1+1, y2-y1+1, mark, id);
 }
 
-void ami_slidevertg(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
-{ ami_slidevert(f, x1, y1, x2, y2, mark, id); }
+void ami_slidevert(FILE* f, int x1, int y1, int x2, int y2, int mark, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    ami_slidevertg(f, x1, y1, x2, y2, mark, id);
+}
 
+/* tab bar height, matching the shim's PATabBar bar strip */
+#define TABBAR_H 24
+
+/* size of a tab panel for the given client size: the bar adds its height
+   on the oriented side; (ox,oy) is the client offset within the panel */
 void ami_tabbarsizg(FILE* f, ami_tabori tor, int cw, int ch, int* w, int* h, int* ox, int* oy)
-{ *w = cw + 10; *h = ch + 30; *ox = 5; *oy = 25; }
+{
+    switch (tor) {
+    case ami_totop:
+        *w = cw; *h = ch + TABBAR_H; *ox = 0; *oy = TABBAR_H; break;
+    case ami_tobottom:
+        *w = cw; *h = ch + TABBAR_H; *ox = 0; *oy = 0; break;
+    case ami_toleft:
+        *w = cw + TABBAR_H; *h = ch; *ox = TABBAR_H; *oy = 0; break;
+    default: /* ami_toright */
+        *w = cw + TABBAR_H; *h = ch; *ox = 0; *oy = 0; break;
+    }
+}
 
 void ami_tabbarsiz(FILE* f, ami_tabori tor, int cw, int ch, int* w, int* h, int* ox, int* oy)
-{ ami_tabbarsizg(f, tor, cw, ch, w, h, ox, oy); }
+{
+    winptr win = f2win(f); if (!win) { *w = *h = 1; *ox = *oy = 0; return; }
+    ami_tabbarsizg(f, tor, cw * win->charspace, ch * win->linespace,
+                   w, h, ox, oy);
+    gr2chrsiz(win, w, h);
+    /* offsets round up to whole cells so the client clears the bar */
+    *ox = (*ox + win->charspace - 1) / win->charspace;
+    *oy = (*oy + win->linespace - 1) / win->linespace;
+}
 
 void ami_tabbarclientg(FILE* f, ami_tabori tor, int w, int h, int* cw, int* ch, int* ox, int* oy)
-{ *cw = w - 10; *ch = h - 30; *ox = 5; *oy = 25; }
+{
+    switch (tor) {
+    case ami_totop:
+        *cw = w; *ch = h - TABBAR_H; *ox = 0; *oy = TABBAR_H; break;
+    case ami_tobottom:
+        *cw = w; *ch = h - TABBAR_H; *ox = 0; *oy = 0; break;
+    case ami_toleft:
+        *cw = w - TABBAR_H; *ch = h; *ox = TABBAR_H; *oy = 0; break;
+    default: /* ami_toright */
+        *cw = w - TABBAR_H; *ch = h; *ox = 0; *oy = 0; break;
+    }
+    if (*cw < 1) *cw = 1;
+    if (*ch < 1) *ch = 1;
+}
 
 void ami_tabbarclient(FILE* f, ami_tabori tor, int w, int h, int* cw, int* ch, int* ox, int* oy)
-{ ami_tabbarclientg(f, tor, w, h, cw, ch, ox, oy); }
+{
+    winptr win = f2win(f); if (!win) { *cw = *ch = 1; *ox = *oy = 0; return; }
+    ami_tabbarclientg(f, tor, w * win->charspace, h * win->linespace,
+                      cw, ch, ox, oy);
+    gr2chrsiz(win, cw, ch);
+    *ox = (*ox + win->charspace - 1) / win->charspace;
+    *oy = (*oy + win->linespace - 1) / win->linespace;
+}
 
-void ami_tabbar(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, ami_tabori tor, int id)  { /* stub */ }
-void ami_tabbarg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, ami_tabori tor, int id) { /* stub */ }
-void ami_tabsel(FILE* f, int id, int tn) { /* stub */ }
+static void tabbar_common(winptr win, int x1, int y1, int x2, int y2,
+                          ami_strptr sp, ami_tabori tor, int barh, int id)
+{
+    int n = 0;
+    for (ami_strptr p = sp; p; p = p->next) n++;
+    if (!n) return;
+    const char** strs = malloc(n * sizeof(char*));
+    if (!strs) return;
+    int i = 0;
+    for (ami_strptr p = sp; p; p = p->next) strs[i++] = p->str;
+    pa_cocoa_tabbar(win->han, x1, y1, x2-x1+1, y2-y1+1, strs, n,
+                    (int)tor, barh, id);
+    free(strs);
+}
+
+void ami_tabbarg(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, ami_tabori tor, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    tabbar_common(win, x1, y1, x2, y2, sp, tor, TABBAR_H, id);
+}
+
+void ami_tabbar(FILE* f, int x1, int y1, int x2, int y2, ami_strptr sp, ami_tabori tor, int id)
+{
+    winptr win = f2win(f); if (!win) return;
+    /* character metrics rounded the bar up to whole cells; use that same
+       thickness so the client area lands exactly on character cells */
+    int barh;
+    if (tor == ami_totop || tor == ami_tobottom)
+        barh = (TABBAR_H + win->linespace - 1) / win->linespace
+               * win->linespace;
+    else
+        barh = (TABBAR_H + win->charspace - 1) / win->charspace
+               * win->charspace;
+    chr2grrect(win, &x1, &y1, &x2, &y2);
+    tabbar_common(win, x1, y1, x2, y2, sp, tor, barh, id);
+}
+
+void ami_tabsel(FILE* f, int id, int tn)
+{
+    winptr win = f2win(f); if (!win) return;
+    pa_cocoa_tabbar_sel(win->han, id, tn);
+}
 
 /*******************************************************************************
 *                                                                              *
@@ -3076,16 +3459,47 @@ void ami_alert(char* title, char* message)
 
 void ami_querycolor(int* r, int* g, int* b)
 {
-    /* stub — NSColorPanel could be added */
-    *r = *g = *b = 0;
+    pa_cocoa_query_color(r, g, b);
 }
 
 void ami_queryopen(char* s, int sl)  { pa_cocoa_query_open(s, sl); }
 void ami_querysave(char* s, int sl)  { pa_cocoa_query_save(s, sl); }
 
-void ami_queryfind(char* s, int sl, ami_qfnopts* opt)         { if (sl>0) s[0]=0; }
-void ami_queryfindrep(char* s, int sl, char* r, int rl,
-                      ami_qfropts* opt)                       { if (sl>0) s[0]=0; if (rl>0) r[0]=0; }
+void ami_queryfind(char* s, int sl, ami_qfnopts* opt)
+{
+    pa_cocoa_query_find(s, sl, opt);
+}
+
+void ami_queryfindrep(char* s, int sl, char* r, int rl, ami_qfropts* opt)
+{
+    pa_cocoa_query_findrep(s, sl, r, rl, opt);
+}
+
 void ami_queryfont(FILE* f, int* fc, int* s, int* fr, int* fg,
                    int* fb, int* br, int* bg, int* bb,
-                   ami_qfteffects* effect)                    { /* stub */ }
+                   ami_qfteffects* effect)
+{
+    char family[128] = "";
+    int  n;
+
+    /* seed the dialog with the current font code's family name */
+    n = 1;
+    for (fontptr fp = fntlst; fp; fp = fp->next, n++)
+        if (n == *fc && fp->name) {
+            strncpy(family, fp->name, sizeof(family) - 1);
+            break;
+        }
+
+    pa_cocoa_query_font(family, sizeof(family), s,
+                        fr, fg, fb, br, bg, bb);
+
+    /* map the returned family name back to a PA font code; if the family
+       is not in the font list, leave the code unchanged */
+    n = 1;
+    for (fontptr fp = fntlst; fp; fp = fp->next, n++)
+        if (fp->name && !strcasecmp(fp->name, family)) {
+            *fc = n;
+            break;
+        }
+    (void)effect; /* text effects unchanged */
+}

--- a/macosx/graphics_cocoa.m
+++ b/macosx/graphics_cocoa.m
@@ -1678,12 +1678,46 @@ void pa_cocoa_kill_timer(pa_winhan win, int id)
  * Widgets
  *----------------------------------------------------------------------------*/
 
-/* Helper: find a subview by tag */
+/* Opaque backing for a widget. Win32 widgets are child windows that fully
+   cover their rectangle; Cocoa controls can be translucent (e.g. a disabled
+   button), letting window content show through. Each control sits in one
+   of these, painted with the window background color. */
+@interface PAWidgetBox : NSView {
+@public
+    float r, g, b;
+}
+@end
+
+@implementation PAWidgetBox
+- (BOOL)isFlipped { return YES; }
+- (void)drawRect:(NSRect)dirtyRect
+{
+    [[NSColor colorWithRed:r green:g blue:b alpha:1.0] setFill];
+    NSRectFill(self.bounds);
+}
+@end
+
+/* wrap a control in an opaque backing box and add it to the window */
+static void add_widget_boxed(PAWindow* pw, NSView* ctl, NSRect rect)
+{
+    PAWidgetBox* box = [[PAWidgetBox alloc] initWithFrame:rect];
+    box->r = pw->view->bgR;
+    box->g = pw->view->bgG;
+    box->b = pw->view->bgB;
+    ctl.frame = NSMakeRect(0, 0, rect.size.width, rect.size.height);
+    [box addSubview:ctl];
+    [pw->view addSubview:box];
+}
+
+/* Helper: find a control by tag (controls live inside PAWidgetBox) */
 static NSView* find_widget(pa_winhan win, int id)
 {
     PAWindow* pw = (__bridge PAWindow*)win;
-    for (NSView* v in pw->view.subviews)
+    for (NSView* v in pw->view.subviews) {
         if (pa_get_tag(v) == id) return v;
+        for (NSView* s in v.subviews)
+            if (pa_get_tag(s) == id) return s;
+    }
     return nil;
 }
 
@@ -1694,12 +1728,15 @@ void pa_cocoa_button(pa_winhan win, int x, int y, int w, int h,
         PAWindow* pw = (__bridge PAWindow*)win;
         NSButton* b  = [[NSButton alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
         b.title      = [NSString stringWithUTF8String:label];
-        b.bezelStyle = NSBezelStyleRounded;
+        /* the standard rounded bezel has a fixed height; oversized buttons
+           need a bezel that stretches to fill the frame */
+        b.bezelStyle = (h > 32) ? NSBezelStyleRegularSquare
+                                : NSBezelStyleRounded;
         b.buttonType = NSButtonTypeMomentaryPushIn;
         b.tag        = id;
         b.target     = pw;
-        b.action     = @selector(widgetAction:);
-        [pw->view addSubview:b];
+        b.action     = @selector(buttonAction:);
+        add_widget_boxed(pw, b, NSMakeRect(x-1, y-1, w, h));
     });
 }
 
@@ -1713,8 +1750,8 @@ void pa_cocoa_checkbox(pa_winhan win, int x, int y, int w, int h,
         b.buttonType = NSButtonTypeSwitch;
         b.tag        = id;
         b.target     = pw;
-        b.action     = @selector(widgetAction:);
-        [pw->view addSubview:b];
+        b.action     = @selector(checkboxAction:);
+        add_widget_boxed(pw, b, NSMakeRect(x-1, y-1, w, h));
     });
 }
 
@@ -1728,8 +1765,54 @@ void pa_cocoa_radiobutton(pa_winhan win, int x, int y, int w, int h,
         b.buttonType = NSButtonTypeRadio;
         b.tag        = id;
         b.target     = pw;
-        b.action     = @selector(widgetAction:);
-        [pw->view addSubview:b];
+        b.action     = @selector(radioAction:);
+        add_widget_boxed(pw, b, NSMakeRect(x-1, y-1, w, h));
+    });
+}
+
+/* size of a group box title as NSBox will render it (11pt system font) */
+void pa_cocoa_group_title_size(const char* s, int* w, int* h)
+{
+    __block int rw, rh;
+    run_on_main(^{
+        NSString* str = [NSString stringWithUTF8String:s ? s : ""];
+        NSDictionary* at = @{ NSFontAttributeName:
+                                  [NSFont systemFontOfSize:11] };
+        NSSize sz = [str sizeWithAttributes:at];
+        rw = (int)(sz.width + 0.5);
+        rh = (int)(sz.height + 0.5);
+    });
+    *w = rw;
+    *h = rh;
+}
+
+void pa_cocoa_group(pa_winhan win, int x, int y, int w, int h,
+                    const char* label, int id)
+{
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        NSBox* box = [[NSBox alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
+        box.title = [NSString stringWithUTF8String:label ? label : ""];
+        box.titlePosition = (label && label[0]) ? NSAtTop : NSNoTitle;
+        box.titleFont = [NSFont systemFontOfSize:11];
+        pa_set_tag(box, id);
+        /* a group box is an outline only — no opaque backing, so widgets
+           and window content inside it stay visible (Win32 semantics) */
+        [pw->view addSubview:box];
+    });
+}
+
+void pa_cocoa_background(pa_winhan win, int x, int y, int w, int h, int id)
+{
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        PAWidgetBox* bg =
+            [[PAWidgetBox alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
+        bg->r = pw->view->bgR;
+        bg->g = pw->view->bgG;
+        bg->b = pw->view->bgB;
+        pa_set_tag(bg, id);
+        [pw->view addSubview:bg];
     });
 }
 
@@ -1738,26 +1821,456 @@ void pa_cocoa_editbox(pa_winhan win, int x, int y, int w, int h, int id)
     run_on_main(^{
         PAWindow*    pw = (__bridge PAWindow*)win;
         NSTextField* tf = [[NSTextField alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
-        tf.tag = id;
-        [pw->view addSubview:tf];
+        tf.tag    = id;
+        tf.target = pw;
+        tf.action = @selector(editAction:);
+        add_widget_boxed(pw, tf, NSMakeRect(x-1, y-1, w, h));
+    });
+}
+
+/* PAScroller — Ami-drawn scrollbar. NSScroller draws only at the fixed
+   system girth and refuses scaled coordinate systems, but PA scrollbars
+   can be any size ("fat and skinny bars"), so we draw our own: a rounded
+   track with a draggable knob, in the style of the legacy macOS scroller.
+   Knob drags report positions; trough clicks report page up/down. */
+
+@interface PAWindow (Actions)
+- (void)pushWidget:(int)act wid:(int)wid pos:(int)pos;
+@end
+
+@interface PAScroller : NSView {
+@public
+    __weak PAWindow* owner;
+    int    wid;        /* PA widget id */
+    int    vertical;
+    double value;      /* 0..1 */
+    double knobProp;   /* knob proportion 0..1 */
+    int    dragging;
+    double dragOff;    /* grab offset from knob start, in pixels */
+}
+@end
+
+@implementation PAScroller
+
+- (BOOL)isFlipped { return YES; }
+
+- (NSRect)knobRect
+{
+    NSRect b = self.bounds;
+    if (vertical) {
+        CGFloat kh = b.size.height * knobProp;
+        if (kh < 20) kh = 20;
+        if (kh > b.size.height) kh = b.size.height;
+        return NSMakeRect(2, value * (b.size.height - kh),
+                          b.size.width - 4, kh);
+    } else {
+        CGFloat kw = b.size.width * knobProp;
+        if (kw < 20) kw = 20;
+        if (kw > b.size.width) kw = b.size.width;
+        return NSMakeRect(value * (b.size.width - kw), 2,
+                          kw, b.size.height - 4);
+    }
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    NSRect b = self.bounds;
+    /* track */
+    [[NSColor colorWithWhite:0.96 alpha:1.0] setFill];
+    NSRectFill(b);
+    [[NSColor colorWithWhite:0.85 alpha:1.0] setStroke];
+    NSBezierPath* edge = [NSBezierPath bezierPathWithRect:
+                             NSInsetRect(b, 0.5, 0.5)];
+    [edge setLineWidth:1.0];
+    [edge stroke];
+    /* knob */
+    NSRect k = [self knobRect];
+    CGFloat r = (vertical ? k.size.width : k.size.height) / 2;
+    if (r > 8) r = 8;
+    NSBezierPath* knob = [NSBezierPath bezierPathWithRoundedRect:k
+                                                         xRadius:r
+                                                         yRadius:r];
+    [[NSColor colorWithWhite:0.55 alpha:1.0] setFill];
+    [knob fill];
+}
+
+- (void)pushPos
+{
+    [owner pushWidget:PA_WIDGET_SCROLL_POS wid:wid
+                  pos:(int)(value * INT_MAX)];
+}
+
+- (void)mouseDown:(NSEvent*)e
+{
+    NSPoint p = [self convertPoint:e.locationInWindow fromView:nil];
+    NSRect  k = [self knobRect];
+    if (NSPointInRect(p, k)) {
+        dragging = 1;
+        dragOff  = vertical ? p.y - k.origin.y : p.x - k.origin.x;
+        return;
+    }
+    /* trough click: page toward the click */
+    int before = vertical ? (p.y < k.origin.y) : (p.x < k.origin.x);
+    [owner pushWidget:(before ? PA_WIDGET_SCROLL_PAGEUP
+                              : PA_WIDGET_SCROLL_PAGEDN)
+                  wid:wid pos:0];
+}
+
+- (void)mouseDragged:(NSEvent*)e
+{
+    if (!dragging) return;
+    NSPoint p = [self convertPoint:e.locationInWindow fromView:nil];
+    NSRect  b = self.bounds;
+    NSRect  k = [self knobRect];
+    double range = vertical ? b.size.height - k.size.height
+                            : b.size.width  - k.size.width;
+    if (range <= 0) return;
+    double v = ((vertical ? p.y : p.x) - dragOff) / range;
+    if (v < 0) v = 0;
+    if (v > 1) v = 1;
+    value = v;
+    [self setNeedsDisplay:YES];
+    [self pushPos];
+}
+
+- (void)mouseUp:(NSEvent*)e
+{
+    dragging = 0;
+}
+
+@end
+
+static void make_scroller(PAWindow* pw, int vertical, NSRect rect, int id)
+{
+    PAScroller* s = [[PAScroller alloc] initWithFrame:rect];
+    s->owner    = pw;
+    s->wid      = id;
+    s->vertical = vertical;
+    s->value    = 0.0;
+    s->knobProp = 0.1;
+    pa_set_tag(s, id);
+    add_widget_boxed(pw, s, rect);
+}
+
+/* PANumSel — number select box: an edit field paired with a stepper,
+   the macOS equivalent of the Win32 up-down control. */
+@interface PANumSel : NSView {
+@public
+    __weak PAWindow* owner;
+    int          wid;
+    NSTextField* field;
+    NSStepper*   stepper;
+}
+@end
+
+@implementation PANumSel
+
+- (BOOL)isFlipped { return YES; }
+
+- (void)pushValue:(int)v
+{
+    [owner pushWidget:PA_WIDGET_NUM_DONE wid:wid pos:v];
+}
+
+- (void)stepperAct:(id)sender
+{
+    /* the arrows only adjust the displayed number; the selection event
+       fires when the user commits with return in the field */
+    field.intValue = stepper.intValue;
+}
+
+- (void)fieldAct:(id)sender
+{
+    int v = field.intValue;
+    if (v < stepper.minValue) v = (int)stepper.minValue;
+    if (v > stepper.maxValue) v = (int)stepper.maxValue;
+    field.intValue   = v;
+    stepper.intValue = v;
+    [self pushValue:v];
+}
+
+@end
+
+void pa_cocoa_numselbox(pa_winhan win, int x, int y, int w, int h,
+                        int l, int u, int id)
+{
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        PANumSel* ns = [[PANumSel alloc] initWithFrame:NSMakeRect(0, 0, w, h)];
+        ns->owner = pw;
+        ns->wid   = id;
+
+        CGFloat stepw = 19;
+        ns->field = [[NSTextField alloc]
+                        initWithFrame:NSMakeRect(0, 0, w - stepw - 2, h)];
+        ns->field.intValue = l;
+        ns->field.target   = ns;
+        ns->field.action   = @selector(fieldAct:);
+        [ns addSubview:ns->field];
+
+        ns->stepper = [[NSStepper alloc]
+                          initWithFrame:NSMakeRect(w - stepw, (h - 27) / 2,
+                                                   stepw, 27)];
+        ns->stepper.minValue  = l;
+        ns->stepper.maxValue  = u;
+        ns->stepper.intValue  = l;
+        ns->stepper.increment = 1;
+        ns->stepper.valueWraps = NO; /* stall at the ends, don't wrap */
+        ns->stepper.target    = ns;
+        ns->stepper.action    = @selector(stepperAct:);
+        [ns addSubview:ns->stepper];
+
+        pa_set_tag(ns, id);
+        add_widget_boxed(pw, ns, NSMakeRect(x-1, y-1, w, h));
+    });
+}
+
+/* PAListBox — list box as a single-column table in a scroll view */
+@interface PAListBox : NSScrollView <NSTableViewDataSource, NSTableViewDelegate> {
+@public
+    __weak PAWindow*    owner;
+    int                 wid;
+    NSArray<NSString*>* items;
+    NSTableView*        table;
+}
+@end
+
+@implementation PAListBox
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView*)tv
+{
+    return items.count;
+}
+
+- (NSView*)tableView:(NSTableView*)tv
+  viewForTableColumn:(NSTableColumn*)col
+                 row:(NSInteger)row
+{
+    NSTextField* tf = [tv makeViewWithIdentifier:@"cell" owner:self];
+    if (!tf) {
+        tf = [[NSTextField alloc] init];
+        tf.identifier      = @"cell";
+        tf.bordered        = NO;
+        tf.editable        = NO;
+        tf.drawsBackground = NO;
+    }
+    tf.stringValue = items[row];
+    return tf;
+}
+
+- (void)tableViewSelectionDidChange:(NSNotification*)n
+{
+    NSInteger r = table.selectedRow;
+    if (r >= 0)
+        [owner pushWidget:PA_WIDGET_LIST_SEL wid:wid pos:(int)r + 1];
+}
+
+@end
+
+void pa_cocoa_listbox(pa_winhan win, int x, int y, int w, int h,
+                      const char** strs, int count, int id)
+{
+    /* copy the strings before crossing to the main thread */
+    NSMutableArray<NSString*>* arr = [NSMutableArray arrayWithCapacity:count];
+    for (int i = 0; i < count; i++)
+        [arr addObject:[NSString stringWithUTF8String:strs[i] ? strs[i] : ""]];
+
+    run_on_main(^{
+        PAWindow*  pw = (__bridge PAWindow*)win;
+        PAListBox* lb = [[PAListBox alloc]
+                            initWithFrame:NSMakeRect(0, 0, w, h)];
+        lb->owner = pw;
+        lb->wid   = id;
+        lb->items = arr;
+
+        NSTableView* t = [[NSTableView alloc]
+                             initWithFrame:NSMakeRect(0, 0, w, h)];
+        NSTableColumn* c = [[NSTableColumn alloc] initWithIdentifier:@"c"];
+        c.width = w;
+        [t addTableColumn:c];
+        t.headerView = nil;
+        /* fixed row metrics so ami_listboxsiz's 18px-per-entry holds;
+           plain style avoids the macOS 11 automatic inset padding */
+        if (@available(macOS 11.0, *)) t.style = NSTableViewStylePlain;
+        t.rowHeight        = 15;
+        t.intercellSpacing = NSMakeSize(3, 3);
+        t.dataSource = lb;
+        t.delegate   = lb;
+        lb->table    = t;
+
+        lb.documentView          = t;
+        lb.hasVerticalScroller   = YES;
+        lb.autohidesScrollers    = YES; /* only appears if entries overflow */
+        lb.borderType            = NSBezelBorder;
+
+        pa_set_tag(lb, id);
+        add_widget_boxed(pw, lb, NSMakeRect(x-1, y-1, w, h));
+        [t reloadData];
+    });
+}
+
+void pa_cocoa_dropbox(pa_winhan win, int x, int y, int w, int h,
+                      const char** strs, int count, int id)
+{
+    NSMutableArray<NSString*>* arr = [NSMutableArray arrayWithCapacity:count];
+    for (int i = 0; i < count; i++)
+        [arr addObject:[NSString stringWithUTF8String:strs[i] ? strs[i] : ""]];
+
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        /* the PA rect reserves room for the dropped-down list; the control
+           itself occupies only the closed height at the top */
+        int ch = h < 25 ? h : 25;
+        NSPopUpButton* b = [[NSPopUpButton alloc]
+                               initWithFrame:NSMakeRect(0, 0, w, ch)
+                                   pullsDown:NO];
+        for (NSString* t in arr) [b addItemWithTitle:t];
+        b.tag    = id;
+        b.target = pw;
+        b.action = @selector(dropboxAction:);
+        add_widget_boxed(pw, b, NSMakeRect(x-1, y-1, w, ch));
+    });
+}
+
+void pa_cocoa_dropeditbox(pa_winhan win, int x, int y, int w, int h,
+                          const char** strs, int count, int id)
+{
+    NSMutableArray<NSString*>* arr = [NSMutableArray arrayWithCapacity:count];
+    for (int i = 0; i < count; i++)
+        [arr addObject:[NSString stringWithUTF8String:strs[i] ? strs[i] : ""]];
+
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        /* as with the drop box, only the closed height is the control */
+        int ch = h < 24 ? h : 24;
+        NSComboBox* b = [[NSComboBox alloc]
+                            initWithFrame:NSMakeRect(0, 0, w, ch)];
+        [b addItemsWithObjectValues:arr];
+        b.completes = YES;
+        b.tag    = id;
+        b.target = pw;
+        b.action = @selector(dropeditAction:);
+        add_widget_boxed(pw, b, NSMakeRect(x-1, y-1, w, ch));
+    });
+}
+
+/* PATabBar — a tabbed panel: segment bar on the oriented edge plus an
+   opaque, outlined client area filling the rest of the PA rect, matching
+   the Win32 tab control's appearance. */
+@interface PATabBar : NSView {
+@public
+    int   ori;   /* 0 top, 1 right, 2 bottom, 3 left */
+    int   barH;
+    float r, g, b; /* client background */
+}
+@end
+
+@implementation PATabBar
+
+- (BOOL)isFlipped { return YES; }
+
+- (NSRect)clientRect
+{
+    NSRect bo = self.bounds;
+    switch (ori) {
+    case 0:  return NSMakeRect(0, barH, bo.size.width, bo.size.height - barH);
+    case 2:  return NSMakeRect(0, 0, bo.size.width, bo.size.height - barH);
+    case 3:  return NSMakeRect(barH, 0, bo.size.width - barH, bo.size.height);
+    default: return NSMakeRect(0, 0, bo.size.width - barH, bo.size.height);
+    }
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    /* the whole panel is opaque, bar strip included, like a Win32 tab
+       control; the client area gets an outline */
+    [[NSColor colorWithRed:r green:g blue:b alpha:1.0] setFill];
+    NSRectFill(self.bounds);
+    [[NSColor colorWithWhite:0.65 alpha:1.0] setStroke];
+    NSBezierPath* edge = [NSBezierPath bezierPathWithRect:
+                             NSInsetRect([self clientRect], 0.5, 0.5)];
+    [edge setLineWidth:1.0];
+    [edge stroke];
+}
+
+@end
+
+void pa_cocoa_tabbar(pa_winhan win, int x, int y, int w, int h,
+                     const char** strs, int count, int ori, int barh,
+                     int id)
+{
+    NSMutableArray<NSString*>* arr = [NSMutableArray arrayWithCapacity:count];
+    for (int i = 0; i < count; i++)
+        [arr addObject:[NSString stringWithUTF8String:strs[i] ? strs[i] : ""]];
+
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        /* the PA rect is the whole tabbed panel: bar strip of the given
+           thickness on the oriented edge, framed client area filling the
+           remainder */
+        const int ctlH = 24; /* natural segmented control height */
+        int vertical = (ori == 1 || ori == 3); /* right/left */
+
+        PATabBar* tb = [[PATabBar alloc]
+                           initWithFrame:NSMakeRect(x-1, y-1, w, h)];
+        tb->ori  = ori;
+        tb->barH = barh;
+        tb->r = pw->view->bgR;
+        tb->g = pw->view->bgG;
+        tb->b = pw->view->bgB;
+
+        NSSegmentedControl* sc = [[NSSegmentedControl alloc]
+                                     initWithFrame:NSMakeRect(0, 0,
+                                        vertical ? h : w, ctlH)];
+        sc.segmentCount = arr.count;
+        for (NSInteger i = 0; i < (NSInteger)arr.count; i++)
+            [sc setLabel:arr[i] forSegment:i];
+        sc.selectedSegment = 0;
+        sc.tag    = id;
+        sc.target = pw;
+        sc.action = @selector(tabbarAction:);
+
+        /* the control sits in the strip against the client edge */
+        if (vertical) {
+            /* a segmented control is horizontal-only: place it in the side
+               strip and rotate it upright; hit testing follows */
+            CGFloat sx = (ori == 3) ? barh - ctlH : w - barh;
+            sc.frame = NSMakeRect(sx + (ctlH - h) / 2.0,
+                                  (h - ctlH) / 2.0, h, ctlH);
+            sc.frameCenterRotation = 90; /* first item at top on both sides */
+        } else {
+            CGFloat sy = (ori == 0) ? barh - ctlH : h - barh;
+            sc.frame = NSMakeRect(0, sy, w, ctlH);
+        }
+        [tb addSubview:sc];
+        pa_set_tag(tb, id);
+        [pw->view addSubview:tb];
+    });
+}
+
+void pa_cocoa_tabbar_sel(pa_winhan win, int id, int tn)
+{
+    run_on_main(^{
+        NSView* v = find_widget(win, id);
+        if (v && [v isKindOfClass:[NSSegmentedControl class]])
+            [(NSSegmentedControl*)v setSelectedSegment:tn - 1];
     });
 }
 
 void pa_cocoa_scrollvert(pa_winhan win, int x, int y, int w, int h, int id)
 {
     run_on_main(^{
-        PAWindow*  pw = (__bridge PAWindow*)win;
-        NSScroller* s = [[NSScroller alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
-        s.tag = id;
-        s.target  = pw;
-        s.action  = @selector(scrollAction:);
-        [pw->view addSubview:s];
+        PAWindow* pw = (__bridge PAWindow*)win;
+        make_scroller(pw, 1, NSMakeRect(x-1, y-1, w, h), id);
     });
 }
 
 void pa_cocoa_scrollhoriz(pa_winhan win, int x, int y, int w, int h, int id)
 {
-    pa_cocoa_scrollvert(win, x, y, w, h, id);
+    run_on_main(^{
+        PAWindow* pw = (__bridge PAWindow*)win;
+        make_scroller(pw, 0, NSMakeRect(x-1, y-1, w, h), id);
+    });
 }
 
 void pa_cocoa_slider_horiz(pa_winhan win, int x, int y, int w, int h,
@@ -1768,11 +2281,14 @@ void pa_cocoa_slider_horiz(pa_winhan win, int x, int y, int w, int h,
         NSSlider* s  = [[NSSlider alloc] initWithFrame:NSMakeRect(x-1, y-1, w, h)];
         s.minValue   = 0;
         s.maxValue   = INT_MAX;
-        s.intValue   = mark;
+        s.doubleValue = 0;
+        /* mark is the tick frequency on the Windows 0..100 trackbar scale;
+           0 disables tick marks */
+        s.numberOfTickMarks = (mark > 0) ? 100 / mark + 1 : 0;
         s.tag        = id;
         s.target     = pw;
         s.action     = @selector(sliderAction:);
-        [pw->view addSubview:s];
+        add_widget_boxed(pw, s, NSMakeRect(x-1, y-1, w, h));
     });
 }
 
@@ -1785,11 +2301,12 @@ void pa_cocoa_slider_vert(pa_winhan win, int x, int y, int w, int h,
         s.vertical   = YES;
         s.minValue   = 0;
         s.maxValue   = INT_MAX;
-        s.intValue   = mark;
+        s.doubleValue = 0;
+        s.numberOfTickMarks = (mark > 0) ? 100 / mark + 1 : 0;
         s.tag        = id;
         s.target     = pw;
         s.action     = @selector(sliderAction:);
-        [pw->view addSubview:s];
+        add_widget_boxed(pw, s, NSMakeRect(x-1, y-1, w, h));
     });
 }
 
@@ -1804,7 +2321,7 @@ void pa_cocoa_progressbar(pa_winhan win, int x, int y, int w, int h, int id)
         p.minValue       = 0;
         p.maxValue       = INT_MAX;
         pa_set_tag(p, id);
-        [pw->view addSubview:p];
+        add_widget_boxed(pw, p, NSMakeRect(x-1, y-1, w, h));
     });
 }
 
@@ -1812,7 +2329,10 @@ void pa_cocoa_kill_widget(pa_winhan win, int id)
 {
     run_on_main(^{
         NSView* v = find_widget(win, id);
-        if (v) [v removeFromSuperview];
+        if (!v) return;
+        /* remove the opaque backing box along with the control */
+        if ([v.superview isKindOfClass:[PAWidgetBox class]]) v = v.superview;
+        [v removeFromSuperview];
     });
 }
 
@@ -1862,8 +2382,10 @@ void pa_cocoa_scrollbar_pos(pa_winhan win, int id, int pos)
 {
     run_on_main(^{
         NSView* v = find_widget(win, id);
-        if (v && [v isKindOfClass:[NSScroller class]])
-            [(NSScroller*)v setFloatValue:(float)pos / INT_MAX];
+        if (v && [v isKindOfClass:[PAScroller class]]) {
+            ((PAScroller*)v)->value = (double)pos / INT_MAX;
+            [v setNeedsDisplay:YES];
+        }
     });
 }
 
@@ -1871,8 +2393,10 @@ void pa_cocoa_scrollbar_siz(pa_winhan win, int id, int range)
 {
     run_on_main(^{
         NSView* v = find_widget(win, id);
-        if (v && [v isKindOfClass:[NSScroller class]])
-            [(NSScroller*)v setKnobProportion:(float)range / INT_MAX];
+        if (v && [v isKindOfClass:[PAScroller class]]) {
+            ((PAScroller*)v)->knobProp = (double)range / INT_MAX;
+            [v setNeedsDisplay:YES];
+        }
     });
 }
 
@@ -1891,25 +2415,79 @@ void pa_cocoa_progressbar_pos(pa_winhan win, int id, int pos)
 
 @implementation PAWindow (Actions)
 
-- (void)widgetAction:(id)sender
+- (void)pushWidget:(int)act wid:(int)wid pos:(int)pos
 {
-    NSControl*  ctrl = (NSControl*)sender;
-    pa_rawevent e    = {0};
-    e.win            = (__bridge pa_winhan)self;
-
-    e.type   = PA_EVT_CHAR; /* TODO: map to proper PA widget events */
-    e.key.ch = (uint32_t)ctrl.tag; /* carry widget id */
+    pa_rawevent e = {0};
+    e.type       = PA_EVT_WIDGET;
+    e.win        = (__bridge pa_winhan)self;
+    e.widget.id  = wid;
+    e.widget.act = act;
+    e.widget.pos = pos;
     evt_push(&e);
+}
+
+- (void)buttonAction:(id)sender
+{
+    [self pushWidget:PA_WIDGET_BUTTON wid:(int)[(NSControl*)sender tag] pos:0];
+}
+
+- (void)checkboxAction:(id)sender
+{
+    [self pushWidget:PA_WIDGET_CHECKBOX wid:(int)[(NSControl*)sender tag] pos:0];
+}
+
+- (void)radioAction:(id)sender
+{
+    [self pushWidget:PA_WIDGET_RADIO wid:(int)[(NSControl*)sender tag] pos:0];
+}
+
+- (void)editAction:(id)sender
+{
+    [self pushWidget:PA_WIDGET_EDIT_DONE wid:(int)[(NSControl*)sender tag] pos:0];
 }
 
 - (void)scrollAction:(id)sender
 {
-    /* TODO: translate scroller position to PA scroll events */
+    NSScroller* sc = (NSScroller*)sender;
+    int wid = (int)sc.tag;
+    switch (sc.hitPart) {
+    case NSScrollerDecrementPage:
+        [self pushWidget:PA_WIDGET_SCROLL_PAGEUP wid:wid pos:0];
+        break;
+    case NSScrollerIncrementPage:
+        [self pushWidget:PA_WIDGET_SCROLL_PAGEDN wid:wid pos:0];
+        break;
+    default: /* knob / knob slot: report the new position */
+        [self pushWidget:PA_WIDGET_SCROLL_POS wid:wid
+                     pos:(int)(sc.floatValue * INT_MAX)];
+        break;
+    }
 }
 
 - (void)sliderAction:(id)sender
 {
-    /* TODO: translate slider position to PA slider events */
+    NSSlider* sl = (NSSlider*)sender;
+    [self pushWidget:PA_WIDGET_SLIDER_POS wid:(int)sl.tag pos:sl.intValue];
+}
+
+- (void)dropboxAction:(id)sender
+{
+    NSPopUpButton* b = (NSPopUpButton*)sender;
+    [self pushWidget:PA_WIDGET_DROP_SEL wid:(int)b.tag
+                 pos:(int)b.indexOfSelectedItem + 1];
+}
+
+- (void)dropeditAction:(id)sender
+{
+    [self pushWidget:PA_WIDGET_DROPED_DONE wid:(int)[(NSControl*)sender tag]
+                 pos:0];
+}
+
+- (void)tabbarAction:(id)sender
+{
+    NSSegmentedControl* sc = (NSSegmentedControl*)sender;
+    [self pushWidget:PA_WIDGET_TAB_SEL wid:(int)sc.tag
+                 pos:(int)sc.selectedSegment + 1];
 }
 
 @end
@@ -2065,9 +2643,315 @@ void pa_cocoa_alert(const char* title, const char* message)
         NSAlert* a    = [[NSAlert alloc] init];
         a.messageText = [NSString stringWithUTF8String:title   ? title   : ""];
         a.informativeText = [NSString stringWithUTF8String:message ? message : ""];
+        /* unbundled programs have no app icon, which renders as a generic
+           folder; use the standard caution badge instead */
+        a.icon = [NSImage imageNamed:NSImageNameCaution];
         [a addButtonWithTitle:@"OK"];
         [a runModal];
     });
+}
+
+/*--- modal query panels ---*/
+
+/* ends a modal session from OK/Cancel buttons */
+@interface PAModalEnd : NSObject
+@end
+
+@implementation PAModalEnd
+- (void)ok:(id)s     { [NSApp stopModalWithCode:NSModalResponseOK]; }
+- (void)cancel:(id)s { [NSApp stopModalWithCode:NSModalResponseCancel]; }
+@end
+
+static PAModalEnd* modal_end(void)
+{
+    static PAModalEnd* me = nil;
+    if (!me) me = [[PAModalEnd alloc] init];
+    return me;
+}
+
+/* create an empty titled modal panel of the given content size */
+static NSWindow* modal_panel(NSString* title, int w, int h)
+{
+    NSWindow* p = [[NSWindow alloc]
+                      initWithContentRect:NSMakeRect(0, 0, w, h)
+                                styleMask:NSWindowStyleMaskTitled
+                                  backing:NSBackingStoreBuffered
+                                    defer:NO];
+    p.releasedWhenClosed = NO;
+    p.title = title;
+    [p center];
+    return p;
+}
+
+/* add OK and Cancel buttons along the bottom of a panel */
+static void modal_buttons(NSWindow* p)
+{
+    NSRect  b  = [p.contentView bounds];
+    NSButton* ok = [[NSButton alloc]
+                       initWithFrame:NSMakeRect(b.size.width - 90, 10, 80, 28)];
+    ok.title = @"OK";
+    ok.bezelStyle = NSBezelStyleRounded;
+    ok.keyEquivalent = @"\r";
+    ok.target = modal_end();
+    ok.action = @selector(ok:);
+    [p.contentView addSubview:ok];
+
+    NSButton* ca = [[NSButton alloc]
+                       initWithFrame:NSMakeRect(b.size.width - 180, 10, 80, 28)];
+    ca.title = @"Cancel";
+    ca.bezelStyle = NSBezelStyleRounded;
+    ca.keyEquivalent = @"\033";
+    ca.target = modal_end();
+    ca.action = @selector(cancel:);
+    [p.contentView addSubview:ca];
+}
+
+static NSTextField* modal_label(NSWindow* p, NSString* text, NSRect r)
+{
+    NSTextField* l = [[NSTextField alloc] initWithFrame:r];
+    l.stringValue     = text;
+    l.bordered        = NO;
+    l.editable        = NO;
+    l.drawsBackground = NO;
+    [p.contentView addSubview:l];
+    return l;
+}
+
+static NSButton* modal_check(NSWindow* p, NSString* text, NSRect r, int on)
+{
+    NSButton* c = [[NSButton alloc] initWithFrame:r];
+    c.buttonType = NSButtonTypeSwitch;
+    c.title      = text;
+    c.state      = on ? NSControlStateValueOn : NSControlStateValueOff;
+    [p.contentView addSubview:c];
+    return c;
+}
+
+void pa_cocoa_query_color(int* r, int* g, int* b)
+{
+    __block int rr = *r, rg = *g, rb = *b;
+    run_on_main(^{
+        NSWindow* p = modal_panel(@"Select Color", 260, 130);
+        NSColorWell* well = [[NSColorWell alloc]
+                                initWithFrame:NSMakeRect(80, 55, 100, 60)];
+        well.color = [NSColor colorWithRed:(CGFloat)rr / INT_MAX
+                                     green:(CGFloat)rg / INT_MAX
+                                      blue:(CGFloat)rb / INT_MAX
+                                     alpha:1.0];
+        [p.contentView addSubview:well];
+        modal_buttons(p);
+        /* the well/color-panel link is unreliable inside a modal session;
+           track the shared color panel directly and mirror it in the well */
+        NSColorPanel* cp = NSColorPanel.sharedColorPanel;
+        id obs = [[NSNotificationCenter defaultCenter]
+                     addObserverForName:NSColorPanelColorDidChangeNotification
+                                 object:cp
+                                  queue:nil
+                             usingBlock:^(NSNotification* n) {
+                                 well.color = cp.color;
+                             }];
+        NSModalResponse rc = [NSApp runModalForWindow:p];
+        [[NSNotificationCenter defaultCenter] removeObserver:obs];
+        [cp orderOut:nil];
+        [p orderOut:nil];
+        if (rc == NSModalResponseOK) {
+            NSColor* c = [well.color
+                colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+            rr = (int)(c.redComponent   * INT_MAX);
+            rg = (int)(c.greenComponent * INT_MAX);
+            rb = (int)(c.blueComponent  * INT_MAX);
+        }
+    });
+    *r = rr;
+    *g = rg;
+    *b = rb;
+}
+
+void pa_cocoa_query_find(char* s, int sl, int* opt)
+{
+    __block int ropt = *opt;
+    __block NSString* rstr = nil;
+    NSString* init = [NSString stringWithUTF8String:s ? s : ""];
+    run_on_main(^{
+        NSWindow* p = modal_panel(@"Find", 340, 165);
+        modal_label(p, @"Find:", NSMakeRect(15, 130, 60, 20));
+        NSTextField* tf = [[NSTextField alloc]
+                              initWithFrame:NSMakeRect(75, 127, 250, 24)];
+        tf.stringValue = init;
+        [p.contentView addSubview:tf];
+        NSButton* ccase = modal_check(p, @"Case sensitive",
+                                      NSMakeRect(15, 100, 200, 20),
+                                      ropt & PA_QF_CASE);
+        NSButton* cup   = modal_check(p, @"Search up",
+                                      NSMakeRect(15, 78, 200, 20),
+                                      ropt & PA_QF_UP);
+        NSButton* cre   = modal_check(p, @"Regular expression",
+                                      NSMakeRect(15, 56, 200, 20),
+                                      ropt & PA_QF_RE);
+        modal_buttons(p);
+        [p makeFirstResponder:tf];
+        NSModalResponse rc = [NSApp runModalForWindow:p];
+        [p orderOut:nil];
+        if (rc == NSModalResponseOK) {
+            rstr = tf.stringValue;
+            ropt = 0;
+            if (ccase.state == NSControlStateValueOn) ropt |= PA_QF_CASE;
+            if (cup.state   == NSControlStateValueOn) ropt |= PA_QF_UP;
+            if (cre.state   == NSControlStateValueOn) ropt |= PA_QF_RE;
+        } else
+            rstr = @"";
+    });
+    if (sl > 0) {
+        strncpy(s, rstr.UTF8String, sl - 1);
+        s[sl - 1] = 0;
+    }
+    *opt = ropt;
+}
+
+void pa_cocoa_query_findrep(char* s, int sl, char* r, int rl, int* opt)
+{
+    __block int ropt = *opt;
+    __block NSString* fstr = nil;
+    __block NSString* rstr = nil;
+    NSString* finit = [NSString stringWithUTF8String:s ? s : ""];
+    NSString* rinit = [NSString stringWithUTF8String:r ? r : ""];
+    run_on_main(^{
+        NSWindow* p = modal_panel(@"Find and Replace", 360, 235);
+        modal_label(p, @"Find:", NSMakeRect(15, 200, 70, 20));
+        NSTextField* ff = [[NSTextField alloc]
+                              initWithFrame:NSMakeRect(90, 197, 250, 24)];
+        ff.stringValue = finit;
+        [p.contentView addSubview:ff];
+        modal_label(p, @"Replace:", NSMakeRect(15, 172, 70, 20));
+        NSTextField* rf = [[NSTextField alloc]
+                              initWithFrame:NSMakeRect(90, 169, 250, 24)];
+        rf.stringValue = rinit;
+        [p.contentView addSubview:rf];
+        NSButton* ccase = modal_check(p, @"Case sensitive",
+                                      NSMakeRect(15, 142, 160, 20),
+                                      ropt & PA_QF_CASE);
+        NSButton* cup   = modal_check(p, @"Search up",
+                                      NSMakeRect(15, 120, 160, 20),
+                                      ropt & PA_QF_UP);
+        NSButton* cre   = modal_check(p, @"Regular expression",
+                                      NSMakeRect(15, 98, 160, 20),
+                                      ropt & PA_QF_RE);
+        NSButton* cfnd  = modal_check(p, @"Find only",
+                                      NSMakeRect(185, 142, 160, 20),
+                                      ropt & PA_QF_FIND);
+        NSButton* cfil  = modal_check(p, @"All in file",
+                                      NSMakeRect(185, 120, 160, 20),
+                                      ropt & PA_QF_ALLFIL);
+        NSButton* clin  = modal_check(p, @"All on line(s)",
+                                      NSMakeRect(185, 98, 160, 20),
+                                      ropt & PA_QF_ALLLIN);
+        modal_buttons(p);
+        [p makeFirstResponder:ff];
+        NSModalResponse rc = [NSApp runModalForWindow:p];
+        [p orderOut:nil];
+        if (rc == NSModalResponseOK) {
+            fstr = ff.stringValue;
+            rstr = rf.stringValue;
+            ropt = 0;
+            if (ccase.state == NSControlStateValueOn) ropt |= PA_QF_CASE;
+            if (cup.state   == NSControlStateValueOn) ropt |= PA_QF_UP;
+            if (cre.state   == NSControlStateValueOn) ropt |= PA_QF_RE;
+            if (cfnd.state  == NSControlStateValueOn) ropt |= PA_QF_FIND;
+            if (cfil.state  == NSControlStateValueOn) ropt |= PA_QF_ALLFIL;
+            if (clin.state  == NSControlStateValueOn) ropt |= PA_QF_ALLLIN;
+        } else {
+            fstr = @"";
+            rstr = @"";
+        }
+    });
+    if (sl > 0) { strncpy(s, fstr.UTF8String, sl - 1); s[sl - 1] = 0; }
+    if (rl > 0) { strncpy(r, rstr.UTF8String, rl - 1); r[rl - 1] = 0; }
+    *opt = ropt;
+}
+
+void pa_cocoa_query_font(char* family, int famlen, int* size,
+                         int* fr, int* fg, int* fb,
+                         int* br, int* bg, int* bb)
+{
+    __block int rsize = *size;
+    __block int rfr = *fr, rfg = *fg, rfb = *fb;
+    __block int rbr = *br, rbg = *bg, rbb = *bb;
+    __block NSString* rfam = nil;
+    NSString* finit = [NSString stringWithUTF8String:family ? family : ""];
+    run_on_main(^{
+        NSWindow* p = modal_panel(@"Select Font", 360, 215);
+        modal_label(p, @"Font:", NSMakeRect(15, 180, 60, 20));
+        NSPopUpButton* fpop = [[NSPopUpButton alloc]
+                                  initWithFrame:NSMakeRect(75, 176, 265, 26)
+                                      pullsDown:NO];
+        NSArray<NSString*>* fams =
+            [[NSFontManager sharedFontManager] availableFontFamilies];
+        fams = [fams sortedArrayUsingSelector:
+                         @selector(caseInsensitiveCompare:)];
+        for (NSString* f in fams) [fpop addItemWithTitle:f];
+        if (finit.length) [fpop selectItemWithTitle:finit];
+        [p.contentView addSubview:fpop];
+
+        modal_label(p, @"Size:", NSMakeRect(15, 148, 60, 20));
+        NSTextField* sf = [[NSTextField alloc]
+                              initWithFrame:NSMakeRect(75, 145, 60, 24)];
+        sf.intValue = rsize;
+        [p.contentView addSubview:sf];
+
+        modal_label(p, @"Foreground:", NSMakeRect(15, 110, 100, 20));
+        NSColorWell* fwell = [[NSColorWell alloc]
+                                 initWithFrame:NSMakeRect(115, 100, 60, 32)];
+        fwell.color = [NSColor colorWithRed:(CGFloat)rfr / INT_MAX
+                                      green:(CGFloat)rfg / INT_MAX
+                                       blue:(CGFloat)rfb / INT_MAX
+                                      alpha:1.0];
+        [p.contentView addSubview:fwell];
+
+        modal_label(p, @"Background:", NSMakeRect(185, 110, 100, 20));
+        NSColorWell* bwell = [[NSColorWell alloc]
+                                 initWithFrame:NSMakeRect(285, 100, 60, 32)];
+        bwell.color = [NSColor colorWithRed:(CGFloat)rbr / INT_MAX
+                                      green:(CGFloat)rbg / INT_MAX
+                                       blue:(CGFloat)rbb / INT_MAX
+                                      alpha:1.0];
+        [p.contentView addSubview:bwell];
+
+        modal_buttons(p);
+        NSColorPanel* cp = NSColorPanel.sharedColorPanel;
+        id obs = [[NSNotificationCenter defaultCenter]
+                     addObserverForName:NSColorPanelColorDidChangeNotification
+                                 object:cp
+                                  queue:nil
+                             usingBlock:^(NSNotification* n) {
+                                 if (fwell.isActive) fwell.color = cp.color;
+                                 if (bwell.isActive) bwell.color = cp.color;
+                             }];
+        NSModalResponse rc = [NSApp runModalForWindow:p];
+        [[NSNotificationCenter defaultCenter] removeObserver:obs];
+        [cp orderOut:nil];
+        [p orderOut:nil];
+        if (rc == NSModalResponseOK) {
+            rfam = fpop.titleOfSelectedItem;
+            rsize = sf.intValue > 0 ? sf.intValue : rsize;
+            NSColor* c = [fwell.color
+                colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+            rfr = (int)(c.redComponent   * INT_MAX);
+            rfg = (int)(c.greenComponent * INT_MAX);
+            rfb = (int)(c.blueComponent  * INT_MAX);
+            c = [bwell.color
+                colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+            rbr = (int)(c.redComponent   * INT_MAX);
+            rbg = (int)(c.greenComponent * INT_MAX);
+            rbb = (int)(c.blueComponent  * INT_MAX);
+        }
+    });
+    if (rfam && famlen > 0) {
+        strncpy(family, rfam.UTF8String, famlen - 1);
+        family[famlen - 1] = 0;
+    }
+    *size = rsize;
+    *fr = rfr; *fg = rfg; *fb = rfb;
+    *br = rbr; *bg = rbg; *bb = rbb;
 }
 
 void pa_cocoa_query_open(char* path, int pathlen)

--- a/macosx/pa_cocoa.h
+++ b/macosx/pa_cocoa.h
@@ -40,8 +40,26 @@ typedef enum {
     PA_EVT_MENU,        /* menu item selected */
     PA_EVT_MIN,         /* window minimized */
     PA_EVT_MAX,         /* window maximized/zoomed/fullscreen */
-    PA_EVT_NORM         /* window restored to normal */
+    PA_EVT_NORM,        /* window restored to normal */
+    PA_EVT_WIDGET       /* widget activated (see pa_widgetact) */
 } pa_evttype;
+
+/* widget activation kinds for PA_EVT_WIDGET */
+typedef enum {
+    PA_WIDGET_BUTTON = 1,    /* push button pressed */
+    PA_WIDGET_CHECKBOX,      /* checkbox toggled */
+    PA_WIDGET_RADIO,         /* radio button selected */
+    PA_WIDGET_SCROLL_PAGEUP, /* scroll page up/left */
+    PA_WIDGET_SCROLL_PAGEDN, /* scroll page down/right */
+    PA_WIDGET_SCROLL_POS,    /* scroll thumb moved; pos 0..INT_MAX */
+    PA_WIDGET_SLIDER_POS,    /* slider moved; pos 0..INT_MAX */
+    PA_WIDGET_EDIT_DONE,     /* edit box completed (return pressed) */
+    PA_WIDGET_NUM_DONE,      /* number select box changed; pos = value */
+    PA_WIDGET_LIST_SEL,      /* list box selection; pos = 1-based index */
+    PA_WIDGET_DROP_SEL,      /* drop box selection; pos = 1-based index */
+    PA_WIDGET_DROPED_DONE,   /* drop edit box completed */
+    PA_WIDGET_TAB_SEL        /* tab bar selection; pos = 1-based index */
+} pa_widgetact;
 
 /* Special key codes */
 typedef enum {
@@ -78,6 +96,7 @@ typedef struct {
         struct { int jn; int ax[6]; }                  joymove;
         struct { int jn; int btn; }                    joybtn;
         struct { int id; }                             menu;
+        struct { int id; int act; int pos; }           widget;
     };
 } pa_rawevent;
 
@@ -186,9 +205,25 @@ void pa_cocoa_checkbox(pa_winhan win, int x, int y, int w, int h,
                        const char* label, int id);
 void pa_cocoa_radiobutton(pa_winhan win, int x, int y, int w, int h,
                           const char* label, int id);
+void pa_cocoa_group_title_size(const char* s, int* w, int* h);
+void pa_cocoa_group(pa_winhan win, int x, int y, int w, int h,
+                    const char* label, int id);
+void pa_cocoa_background(pa_winhan win, int x, int y, int w, int h, int id);
 void pa_cocoa_editbox(pa_winhan win, int x, int y, int w, int h, int id);
+void pa_cocoa_numselbox(pa_winhan win, int x, int y, int w, int h,
+                        int l, int u, int id);
 void pa_cocoa_listbox(pa_winhan win, int x, int y, int w, int h,
                       const char** items, int count, int id);
+void pa_cocoa_dropbox(pa_winhan win, int x, int y, int w, int h,
+                      const char** items, int count, int id);
+void pa_cocoa_dropeditbox(pa_winhan win, int x, int y, int w, int h,
+                          const char** items, int count, int id);
+/* ori: 0 = top, 1 = right, 2 = bottom, 3 = left (matches ami_tabori);
+   barh is the bar strip thickness in pixels (client = rect minus strip) */
+void pa_cocoa_tabbar(pa_winhan win, int x, int y, int w, int h,
+                     const char** items, int count, int ori, int barh,
+                     int id);
+void pa_cocoa_tabbar_sel(pa_winhan win, int id, int tn);
 void pa_cocoa_scrollvert(pa_winhan win, int x, int y, int w, int h, int id);
 void pa_cocoa_scrollhoriz(pa_winhan win, int x, int y, int w, int h, int id);
 void pa_cocoa_slider_horiz(pa_winhan win, int x, int y, int w, int h,
@@ -221,6 +256,23 @@ void pa_cocoa_menu_check(pa_winhan win, int id, int on);
 void pa_cocoa_alert(const char* title, const char* message);
 void pa_cocoa_query_open(char* path, int pathlen);
 void pa_cocoa_query_save(char* path, int pathlen);
+/* find/find-replace option bits, matching BIT(ami_qfnopt)/BIT(ami_qfropt) */
+#define PA_QF_CASE   (1 << 0) /* case sensitive */
+#define PA_QF_UP     (1 << 1) /* search up */
+#define PA_QF_RE     (1 << 2) /* regular expression */
+#define PA_QF_FIND   (1 << 3) /* find only (find/replace dialog) */
+#define PA_QF_ALLFIL (1 << 4) /* replace all in file */
+#define PA_QF_ALLLIN (1 << 5) /* replace all on line(s) */
+
+/* color components are 0..INT_MAX (PA scale); in/out */
+void pa_cocoa_query_color(int* r, int* g, int* b);
+/* find/find-replace dialogs; opt bits per ami_qfnopt/ami_qfropt */
+void pa_cocoa_query_find(char* s, int sl, int* opt);
+void pa_cocoa_query_findrep(char* s, int sl, char* r, int rl, int* opt);
+/* font dialog: family name in/out, size in points, fg/bg 0..INT_MAX */
+void pa_cocoa_query_font(char* family, int famlen, int* size,
+                         int* fr, int* fg, int* fb,
+                         int* br, int* bg, int* bb);
 
 /*----------------------------------------------------------------------------
  * Miscellaneous


### PR DESCRIPTION
## Summary

Implements the macOS widget set and query dialogs, driven by widget_test frames 2-44.

### Coordinates and events
- Plain widget calls take **character** coordinates, `-g` calls pixels; character rects now convert to full-cell pixel rects (Windows semantics). Previously both were treated as pixels, crushing widgets into the top-left corner.
- Proper `PA_EVT_WIDGET` raw event with per-type action selectors, translated to the full PA widget event set (button/checkbox/radio/scroll/slider/edit/numsel/list/drop/dropedit/tabbar). The old handler pushed a bogus character event, so widgets produced no actions.
- Widgets sit on an opaque backing (`PAWidgetBox`) so they fully cover their rectangle like Win32 child windows — disabled Cocoa buttons are otherwise translucent.

### Widgets
- **Buttons/checkboxes/radios**: native, with a stretching bezel for oversized buttons (20×10-char layered button).
- **Group box**: `NSBox`, outline-only interior; minimum size measures the title as actually rendered, fixing the dead right margin.
- **Scrollbars**: custom `PAScroller` (any size, Linux-style) — `NSScroller` only draws at the fixed system girth and refuses scaled coordinate systems, so fat/skinny bars were invisible. Knob drags stream `etsclpos`, trough clicks page.
- **Number select box**: field + stepper; arrows adjust without wrapping, event on return.
- **List box**: single-column `NSTableView` with row metrics matching the sizing function and an auto-hiding scroller.
- **Drop box / drop edit box**: `NSPopUpButton`/`NSComboBox`, docked at closed height inside the PA rect that reserves the open list area.
- **Sliders**: `mark` = tick frequency on the Windows 0-100 scale (0 = none); initial position fixed.
- **Tab bar**: full tabbed panel — segment bar docked to the oriented edge (rotated 90° for left/right with working hit-testing), opaque panel, outlined client area. Orientation-aware `ami_tabbarsiz`/`tabbarclient` metrics with the bar thickness passed through so character-mode overlaid panels align exactly.

### Fixed along the way
- **`scroll_up` direction**: the bitmap is CG y-up (data row 0 = bottom), so the memmove was shifting content *down*, replicating the top text row on every scroll — the "repeated title" corruption seen during scrollbar events.

### Dialogs
- Alert uses the caution icon (unbundled binaries have no app icon, which rendered as a generic folder).
- Color, find, find/replace, and font queries implemented as modal panels. Color wells observe `NSColorPanelColorDidChangeNotification` because the well↔panel link doesn't function inside modal sessions. Find dialogs return the PA option bits; the font dialog maps the chosen family back to a PA font code.

## Test plan

- [x] widget_test frames 2-3: buttons placed/sized per character coords, events fire, disabled button occludes text
- [x] frames 8-9: group boxes sized to title/client, layered oversize button fills its rect
- [x] frames 12-17: scrollbars visible, draggable, fat/skinny render, positions print without display corruption
- [x] frames 20-21: number select boxes, arrows stall at ends, event on return
- [x] frames 26-27: list boxes with correct 1-based selections
- [x] frames 28-31: drop and dropedit boxes at closed height
- [x] frames 32-33: slider ticks on the marked sliders only
- [x] frames 34-37: tab bars all four orientations, client areas, overlaid panels aligned (char and pixel)
- [x] frames 38-44: alert icon, color/find/replace/font dialogs functional
- [x] standalone reproducers for each widget family pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
