### PR TITLE
Make the windows services unix-path tolerant and stdio byte-clean

### DIFF
--- a/libc/stdio.c
+++ b/libc/stdio.c
@@ -270,7 +270,15 @@ static int wopen(
     /** open flags */      int flags,
     /** permission bits */ int perm
 )
+#ifdef __MINGW32__
+    /* The Ami stdio is unix modeled: a file is a byte stream with LF line
+       ends on every platform, so the same text (intermediate decks, error
+       files) interchanges between the windows and unix built tools. Open
+       binary so the windows C runtime does not impose CRLF translation. */
+    { return open(pathname, flags | O_BINARY, perm); }
+#else
     { return open(pathname, flags, perm); }
+#endif
 static int wclose(
     /** file descriptor */ int fd
 )

--- a/windows/services.c
+++ b/windows/services.c
@@ -1437,7 +1437,7 @@ void ami_brknam(
 {
 
     int i, s, f, t; /* string indexes */
-    char *s1, *s2;
+    char *s1, *s2, *t2;
 
     /* clear all strings */
     *p = 0;
@@ -1447,8 +1447,13 @@ void ami_brknam(
     s1 = fn; /* index file spec */
     /* skip spaces */
     while (*s1 && *s1 == ' ') s1++;
-    /* find last '/' that will mark the path */
+    /* Find the last separator that will mark the path. The windows file APIs
+       accept '/' as well as '\', so both count as separators here; this also
+       lets unix style paths pass through when the windows programs are driven
+       under an exe emulator. */
     s2 = strrchr(s1, ami_pthchr());
+    t2 = strrchr(s1, '/');
+    if (!s2 || (t2 && t2 > s2)) s2 = t2;
     if (s2) {
 
         /* there was a path, store that */
@@ -1527,10 +1532,11 @@ void ami_maknam(
 
     if (strlen(p) > fnl) error("String too large for destination");
     strcpy(fn, p); /* place path */
-    /* check path properly terminated */
+    /* check path properly terminated; a '/' terminator counts, since the
+       windows file APIs accept it as a separator (see brknam) */
     i = strlen(p);   /* find length */
     if (*p) /* not null */
-        if (p[i-1] != ami_pthchr()) {
+        if (p[i-1] != ami_pthchr() && p[i-1] != '/') {
 
         if (strlen(fn)+1 > fnl) error("String too large for destination");
         s[0] = ami_pthchr(); /* set up path character as string */
@@ -1966,12 +1972,11 @@ void ami_filchr(ami_chrset fc)
     /* clear set */
     for (i = 0; i < CSETLEN; i++) fc[i] = 0;
 
-    /* add everything but control characters and space */
+    /* add everything but control characters and space, the same set as the
+       other platforms. The path characters must be included so that full
+       pathnames parse as filenames, including unix style paths when the
+       windows programs are driven under an exe emulator. */
     for (i = ' '+1; i <= 0x7e; i++) ADDCSET(fc, i);
-    SUBCSET(fc, ami_optchr()); /* remove option character */
-    SUBCSET(fc, ami_pthchr()); /* remove path character */
-    SUBCSET(fc, '"'); /* remove quote characters */
-    SUBCSET(fc, '\'');
 
 }
 


### PR DESCRIPTION
## Summary

The windows Ami services and stdio are driven under an exe emulator (wine/binfmt) when the cross-built Pascal-P6 toolchain runs on a unix host. Three fixes let the windows-built programs interoperate with the unix side:

- **`windows/services.c` — path parsing**: `ami_brknam` accepts `/` as a path separator alongside `\`, and `ami_maknam` treats a trailing `/` as a proper terminator, so unix-style pathnames parse and reassemble correctly. `ami_filchr` no longer removes the path/option/quote characters from the valid filename set (it now matches the other platforms), so full pathnames parse as filenames.
- **`libc/stdio.c` — byte-clean I/O**: `wopen` ORs `O_BINARY` under `__MINGW32__`, so the Ami stdio stays unix-modeled — files are LF byte streams on every platform. Intermediate P-code decks and error files then interchange between the windows-built and unix-built tools (e.g. a deck written by `pcom.exe` loads in native `pint`).

## Context

Part of bringing up `pc -windowsexe` / `regress --windowsexe` in Pascal-P6, where the win64 toolchain executables run under wine to build and test native products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)