### PR TITLE
Windows environment name lookup is case insensitive

### DIFF
--- a/windows/services.c
+++ b/windows/services.c
@@ -915,7 +915,9 @@ static void fndenv(
     *ep = NULL; /* set no string found */
     while (p && *ep == NULL) {  /* traverse */
 
-        if (!strcmp(esn, p->name)) *ep = p; /* found */
+        /* windows environment names are case insensitive: a program run from
+           cmd sees "Path", one run from an msys/cygwin shell sees "PATH" */
+        if (!_stricmp(esn, p->name)) *ep = p; /* found */
         else p = p->next;/* next string */
 
     }


### PR DESCRIPTION
## Summary

`fndenv` compared environment names with `strcmp`, but Windows environment names are case-insensitive by OS convention and arrive with different capitalizations depending on the launcher: a program run from cmd/PowerShell sees `Path`, one run from an msys/cygwin shell (git bash — the Pascal-P6 regression scripts) sees `PATH`.

`services.c` loads the execution path with `ami_getenv("Path")`, so under bash the path came up empty and every `ami_exec`/`ami_execw` failed with "Command does not exist" — silently ending the Pascal-P6 `pc` build driver on Windows (the message is also lost; see the note below). Fixed by comparing with `_stricmp`.

Verified on native Windows: with this change (rebuilt into Pascal-P6's win64 `services.a`) plus a `Path` export compatibility shim in the test scripts, the Pascal-P6 regression's pgen tests go from universal "compile/run fail" to passing.

Note while here: `winerr()`/`error()` messages to stderr are frequently lost when the process is piped — the failure above was completely silent. An `fflush(stderr)` before `exit(1)` (or routing through the caller's error machinery) would make these diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)