### PR TITLE
windows getusr: honor HOME, fix inverted USERNAME fallback

### DIFF
--- a/windows/services.c
+++ b/windows/services.c
@@ -1685,6 +1685,10 @@ void ami_getusr(
     bufstr b, b1; /* buffer for result */
 
     ami_getenv("USERPROFILE", b, MAXSTR);
+    /* HOME is the unix convention, but is commonly set on windows (msys,
+       cygwin, git bash), and a program can set it to relocate the user
+       path; honor it next */
+    if (!*b) ami_getenv("HOME", b, MAXSTR);
     if (!*b) { /* not found */
 
         ami_getenv("HOMEPATH", b, MAXSTR);
@@ -1698,7 +1702,7 @@ void ami_getusr(
         if (!*b) { /* not found */
 
             ami_getenv("USERNAME", b, MAXSTR);
-            if (!*b) { /* path that */
+            if (*b) { /* path that */
 
                 strcpy(b1, b); /* copy */
                 strcpy(b, "\\users\\"); /* set prefix */


### PR DESCRIPTION
## Summary

Two fixes to `ami_getusr` in the windows services model:

1. **Honor `HOME`** (after `USERPROFILE`, before `HOMEDRIVE`/`HOMEPATH`). HOME is the unix convention but is commonly set on windows (msys, cygwin, git bash), and a program can set it to relocate the user path — Pascal-P6's services_test does exactly that (clears the environment, sets `home=/home/testuser`, expects getusr to return it). Note the lowercase `home` works because env lookup is now case-insensitive (#131).

2. **The `USERNAME` fallback was inverted:** it built `\users\` + name when USERNAME was **not** found — yielding a bare `\users\` from the empty string — and fell through to the program path when it **was** found.

Verified on native Windows via Pascal-P6's services_test: tests 40/41 now return `/home/testuser` (previously the mangled `\users\`), and the full test passes against its new windows golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)