### PR TITLE
windows network: map SSL_get_peer_certificate to the OpenSSL 3.0 name

### DIFF
--- a/windows/network.c
+++ b/windows/network.c
@@ -89,6 +89,16 @@
 #include <openssl/hmac.h>
 #include <openssl/x509v3.h>
 
+/* OpenSSL 3.0 renamed SSL_get_peer_certificate to SSL_get1_peer_certificate.
+   The old name survives only as a deprecated alias, which mingw's OpenSSL 3.x
+   build compiles out, so map it to the current name. Both return a reference
+   the caller must X509_free. */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#ifndef SSL_get_peer_certificate
+#define SSL_get_peer_certificate SSL_get1_peer_certificate
+#endif
+#endif
+
 /* Petit-Ami definitions */
 #include <localdefs.h>
 #include <network.h>


### PR DESCRIPTION
## Summary

OpenSSL 3.0 renamed `SSL_get_peer_certificate` → `SSL_get1_peer_certificate`, keeping the old name only as a deprecated macro alias. mingw's OpenSSL 3.x build compiles that alias out (the alias is guarded and not active in this configuration), so linking the windows network model fails:

```
network.o: undefined reference to `SSL_get_peer_certificate'   (sockfil, ami_certmsg)
```

Fix maps the old name to the current one for OpenSSL >= 3.0, after the openssl includes, so the two call sites and the OpenSSL 1.1.x build stay unchanged. `SSL_get1_peer_certificate` has the same `get1` ownership semantics (caller `X509_free`s), matching existing usage.

## Verification (native Windows, mingw OpenSSL 3.6)

- `network.a` rebuilds with the object now referencing `SSL_get1_peer_certificate` (resolvable) instead of the absent `SSL_get_peer_certificate`.
- `pc libs/tests/network_test` links to an executable (previously failed at link).

Found while bringing up the windows network model. Note this only fixes the **link**; the model's server/message/DTLS/cert paths are still `enotimp` stubs — network_test runs but exercises only what's implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)