### PR TITLE
libc/stdio.c: provide stdio_rename for the windows bypass build

### DIFF
--- a/libc/stdio.c
+++ b/libc/stdio.c
@@ -1965,6 +1965,23 @@ int rename(
 }
 #endif
 
+/* On Windows the portable link()/unlink() rename() above is unavailable (no
+   POSIX link()). A non-STDIO_BYPASS build simply uses the native CRT rename()
+   in its place, so nothing is needed. A STDIO_BYPASS consumer, however, has its
+   rename() calls coined to stdio_rename() (see stdio.h), so that funnel entry
+   must exist: provide it for the Windows bypass build, mapping to the CRT
+   rename(). The coining macro is suspended only around the call, so the coined
+   name is defined in terms of the real one. */
+#if defined(__MINGW32__) && defined(STDIO_BYPASS)
+int stdio_rename(const char *oldname, const char *newname)
+{
+#undef rename
+    extern int rename(const char *oldname, const char *newname);
+    return rename(oldname, newname); /* native CRT rename */
+#define rename(...) stdio_rename(__VA_ARGS__)
+}
+#endif
+
 /** **************************************************************************
 
 Function tmpdir


### PR DESCRIPTION
## Summary

The portable `link()`/`unlink()`-based `rename()` in the bypass stdio is unavailable on Windows (no POSIX `link()`), so it is compiled out under `__MINGW32__`. That's correct for a **non**-`STDIO_BYPASS` build, which uses the native CRT `rename()` directly.

But a `-DSTDIO_BYPASS` consumer has its `rename()` calls coined to `stdio_rename()` (the funnel name, per stdio.h), so that funnel entry must exist. On Windows it didn't — so linking any Windows `STDIO_BYPASS` program failed with `undefined reference to stdio_rename`.

This adds `stdio_rename` for the Windows bypass build (`__MINGW32__ && STDIO_BYPASS`), mapping straight to the CRT `rename()`. The coining macro is suspended only around the call, so the funnel name is defined in terms of the real one.

## Context

Found bringing up the Pascal-P6 `cmach` interpreter on native Windows — the first Windows `STDIO_BYPASS` consumer. `rename` is part of the stdio call set, so its funnel entry belongs here alongside `stdio_remove`/`stdio_fopen`/etc., rather than being shimmed in each consumer.

## Verified

Rebuilt the bypass stdio from this source (mingw, `-DSTDIO_BYPASS`): the object now exports `T stdio_rename`, and cmach links against it with no shim and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)