### PR TITLE
windows: complete the graphics call set; add terminal titlen

### DIFF
--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -16773,3 +16773,182 @@ static void ami_deinit_graph(void)
     SetConsoleCtrlHandler(NULL, FALSE);
 
 }
+
+/** ****************************************************************************
+
+Graphics call set completions
+
+These complete the windows implementation of the graphics call set so the
+full API links. The widget related calls (the anonymous window/widget id
+allocators and the widget geometry calls) are part of the portable "build
+your own widgets and dialogs" support API: windows carries its own native
+widget set, and the portable widget package over these calls is not yet
+ported here, so they are placeholders pending that port. The remainder are
+graphics calls not yet implemented in this port; as with the other
+unimplemented calls in this file, they are no-ops or return neutral values
+until implemented.
+
+*******************************************************************************/
+
+/* write string with explicit length (not NUL terminated) */
+void ami_wrtstrn(FILE* f, char* s, int n)
+
+{
+
+    char* p;
+
+    p = (char*)imalloc(n+1); /* space for terminator */
+    memcpy(p, s, n);
+    p[n] = 0; /* terminate */
+    ami_wrtstr(f, p); /* write as a standard string */
+    free(p);
+
+}
+
+/* send event into the input queue: not implemented */
+void ami_sendevent(FILE* f, ami_evtrec* er)
+
+{
+
+   /* not implemented */
+
+}
+
+/* foreground/background raster op selections: not implemented */
+void ami_fand(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+void ami_band(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+void ami_for(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+void ami_bor(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+/* scale coordinates: no scaling in this port, identity */
+int ami_scalex(FILE* f, int x)
+
+{
+
+   return (x); /* identity */
+
+}
+
+int ami_scaley(FILE* f, int y)
+
+{
+
+   return (y); /* identity */
+
+}
+
+/* drag window: not implemented */
+void ami_dragwin(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+/* find screen center, character and graphical: not implemented */
+void ami_scncen(FILE* f, int* x, int* y)
+
+{
+
+   *x = 1; /* neutral (home) position */
+   *y = 1;
+
+}
+
+void ami_scnceng(FILE* f, int* x, int* y)
+
+{
+
+   *x = 1; /* neutral (home) position */
+   *y = 1;
+
+}
+
+/* set focus to window: not implemented */
+void ami_focus(FILE* f)
+
+{
+
+   /* not implemented */
+
+}
+
+/* Anonymous window and widget id allocators, for the portable widget and
+   dialog support. Anonymous window ids are negative (never 0), so they can
+   never collide with the client program's own ids. This allocator hands out
+   distinct ids; tracking them through the window equivalence table (which on
+   windows does not yet carry the negative id range linux does) comes with
+   the portable widget port. */
+int ami_getwinid(void)
+
+{
+
+   static int anonwid = 0; /* last anonymous window id given out */
+
+   if (anonwid <= -MAXFIL) error(ewinuse); /* out of anonymous ids */
+   anonwid--; /* next anonymous id */
+
+   return (anonwid);
+
+}
+
+int ami_getwigid(FILE* f)
+
+{
+
+   return (0); /* no widget id allocated: pending the portable widget port */
+
+}
+
+/* widget geometry management: not implemented */
+void ami_sizwidget(FILE* f, int id, int x, int y)
+
+{
+
+   /* not implemented */
+
+}
+
+void ami_poswidget(FILE* f, int id, int x, int y)
+
+{
+
+   /* not implemented */
+
+}
+
+void ami_focuswidget(FILE* f, int id)
+
+{
+
+   /* not implemented */
+
+}

--- a/windows/terminal.c
+++ b/windows/terminal.c
@@ -59,6 +59,8 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <limits.h>
 #include <windows.h>
 #include <terminal.h>
@@ -2716,14 +2718,38 @@ Sets the title of the current window.
 *******************************************************************************/
 
 void ami_title(FILE* f, char* ts)
-    
-{ 
+
+{
 
     int r;
 
     r = SetConsoleTitle(ts);
     if (!r) winerr();
-    
+
+}
+
+/** ****************************************************************************
+
+Set window title, with length
+
+Sets the title of the current window. The string carries an explicit length
+and is not NUL terminated.
+
+*******************************************************************************/
+
+void ami_titlen(FILE* f, char* ts, int n)
+
+{
+
+    char* p;
+
+    p = (char*)malloc(n+1); /* space for terminator */
+    if (!p) error(enomem);
+    memcpy(p, ts, n);
+    p[n] = 0; /* terminate */
+    ami_title(f, p); /* set as a standard title string */
+    free(p);
+
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Problem

The windows graphics port was missing 17 calls of the graphics API, so any program built against the full wrapper (Pascal-P6 `graphics_wrapper.c`) failed to link — `graphics_test` and all the graph games. The windows terminal port was missing `ami_titlen`.

## Changes

**windows/graphics.c** — a "graphics call set completions" section:
- `wrtstrn` — write string with explicit length, implemented over `wrtstr`.
- `scalex`/`scaley` — identity (no scaling in this port).
- `getwinid` — anonymous window id allocator for the portable **build-your-own widgets and dialogs** support: hands out distinct negative ids (never colliding with client ids). Full tracking through the window equivalence table (which on windows does not yet carry the negative id range linux does) comes with the portable widget port.
- `getwigid`, `sizwidget`, `poswidget`, `focuswidget` — portable widget support placeholders pending that port.
- `sendevent`, `fand`/`band`/`for`/`bor`, `dragwin`, `focus`, `scncen`/`scnceng` — not yet implemented; no-ops or neutral returns, matching the file's existing convention.

**windows/terminal.c** — `ami_titlen` (title with explicit length, over `ami_title`), plus explicit stdlib/string includes.

## Verification

With the corresponding Pascal-P6 changes (win64 graphics archive gains `config.o`; pc links `-lwinmm` and skips gnome_widgets on windows), **all 19 programs in the build script link clean** on windows: graphics_test, widget_test, terminal_test, management_test, all 7 graph games, and the sound/network/services tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA