### PR TITLE
network_test: silence empty-body warning on ignored response read

### DIFF
--- a/tests/network_test.c
+++ b/tests/network_test.c
@@ -294,10 +294,11 @@ static void tcert(void)
     r = ami_certnet(f, 1, cert, sizeof(cert));
     result("certnet raw certificate", strlen(cert) > 0);
 
-    /* complete the exchange so the server exits */
+    /* complete the exchange so the server exits; the response content is
+       not checked here, only consumed */
     fputs("Hello, server\n", f);
     fflush(f);
-    if (fgets(buff, BUFLEN, f)) ; /* response */
+    if (!fgets(buff, BUFLEN, f)) buff[0] = 0;
     fclose(f);
     clientdone();
     finish();


### PR DESCRIPTION
## Summary

Fixes the `-Wempty-body` warning at `tests/network_test.c:300`: the certificate test consumes the server response without checking it, and the bare `if (fgets(...)) ;` tripped the warning. The failure case now clears the buffer explicitly.

## Test plan

- [x] Build produces no `-Wempty-body` warning
- [x] `bin/network_test`: 8 passes, 0 fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)