### PR TITLE
system_event: deliver signal events with the correct type on macOS (fixes resize tracking)

### DIFF
--- a/macosx/system_event.c
+++ b/macosx/system_event.c
@@ -271,7 +271,7 @@ int system_event_addsesig(int sig)
 
     pthread_mutex_lock(&evtlock); /* take the event lock */
     sid = getsys(); /* get a new system event id */
-    systab[sid-1]->typ = se_inp; /* set type */
+    systab[sid-1]->typ = se_sig; /* set type */
     systab[sid-1]->sig = sig; /* set signal */
 
     /* add this signal to mask set */


### PR DESCRIPTION
## Summary

Terminal window resizes were not tracked on macOS (the terminal buffer follow test never followed), even though Terminal.app sends `SIGWINCH` normally — vi tracks fine.

The bug: `system_event_addsesig` in the macOS `system_event.c` registered signal entries with type `se_inp` (input file) instead of `se_sig`, and the kqueue dispatch only matches incoming `EVFILT_SIGNAL` events against entries typed `se_sig`. Any signal registered through the API — including the terminal library's `SIGWINCH` — was therefore never delivered.

One-line fix. Verified with a standalone harness: a registered `SIGWINCH` now arrives as an `se_sig` event with the correct logical id (previously blocked forever).

## Test plan

- [x] Standalone test: register SIGWINCH via `system_event_addsesig`, raise it, `system_event_getsevt` returns `se_sig` with the registered id
- [ ] terminal_test buffer follow frame tracks Terminal.app window resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
