### PR TITLE
macOS: preserve the outer rect when toggling child window chrome

### DIFF
--- a/macosx/graphics_cocoa.m
+++ b/macosx/graphics_cocoa.m
@@ -1371,14 +1371,18 @@ static void set_style_mask(PAWindow* pw, NSWindowStyleMask m)
     });
 }
 
-/* toggle a chrome flag on a child frame, preserving the client size */
+/* Toggle a chrome flag on a child frame. The OUTER rect is preserved
+   and the client re-insets within it (Windows semantics: turning the
+   frame off grows the client to fill the window rect, so adjacent
+   frameless children tile edge to edge). */
 static void child_chrome(PAChildFrame* cf, int* flag, int on)
 {
-    NSSize client = cf->client.frame.size;
     *flag = on;
-    [cf setClientSize:client];
+    [cf layoutClient];
+    [cf pushResize]; /* report the new client size to the program */
     [cf.window invalidateCursorRectsForView:cf];
     [cf setNeedsDisplay:YES];
+    [cf.superview setNeedsDisplay:YES];
 }
 
 void pa_cocoa_set_frame(pa_winhan win, int on)


### PR DESCRIPTION
## Summary

management_test frame 19: frameless child windows showed gaps between them, unlike Windows/Linux. Toggling chrome (`ami_frame`/`ami_sysbar`/`ami_sizable`) on a child preserved the client size and shrank the outer container by the vacated border width. Windows semantics keep the **outer** rect invariant and grow the client into the freed space, so 20-char-wide children stay 20 chars wide and tile edge to edge.

The chrome toggle now keeps the container frame fixed, re-insets the client within it, and pushes a resize event so the program sees the new client size.

## Test plan

- [x] Reproducer with three 20-char children at columns 1/21/41, frames turned off: children tile with no gaps (screenshot-verified)
- [ ] management_test frames 18-19 visual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)