### PR TITLE
windows: share a connection across duplicated descriptors

### DIFF
--- a/windows/network.c
+++ b/windows/network.c
@@ -1119,6 +1119,42 @@ static FILE* sockfil(SOCKET sock, int secure, int server)
 
 }
 
+/*******************************************************************************
+
+Share a connection with a duplicated descriptor
+
+The read and write sides of a network pair are separate descriptors dup'd
+from one connection. The connection state is indexed by descriptor here, so
+the duplicate must be entered as well or its I/O would fall through the
+interdictions to the parked nul device. The sharers reference one socket and
+ssl; the close path tears the connection down when the last sharer closes.
+
+*******************************************************************************/
+
+void ami_netshare(int fd, int fd2)
+
+{
+
+    filptr sp; /* source file entry */
+    filptr dp; /* duplicate file entry */
+
+    if (fd < 0 || fd >= MAXFIL || !opnfil[fd] || !opnfil[fd]->net) return;
+    if (fd2 < 0 || fd2 >= MAXFIL) return;
+    newfil(fd2); /* get/renew the duplicate's entry */
+    sp = opnfil[fd]; /* index entries */
+    dp = opnfil[fd2];
+    dp->sock = sp->sock; /* share the connection */
+    dp->sock2 = sp->sock2;
+    dp->ssl = sp->ssl;
+    dp->bio = sp->bio;
+    dp->cert = sp->cert;
+    dp->sec = sp->sec;
+    dp->msg = sp->msg;
+    dp->sudp = sp->sudp;
+    dp->net = TRUE; /* set as network file */
+
+}
+
 FILE* ami_opennet(/* IP address */      unsigned long addr,
                  /* port */            int port,
                  /* link is secured */ int secure
@@ -2091,17 +2127,30 @@ static int iclose(int fd)
 {
 
     filptr fp;
+    int    i;
+    int    shared;
 
     if (fd >= 0 && fd < MAXFIL && opnfil[fd] && opnfil[fd]->net) {
 
         fp = opnfil[fd]; /* index that */
-        if (fp->ssl) SSL_free(fp->ssl); /* free the ssl */
+        /* A connection can be shared across descriptors (the read and
+           write sides of a network pair are dups of one socket). Tear the
+           connection down only when the last sharer closes. */
+        shared = FALSE;
+        for (i = 0; i < MAXFIL; i++)
+            if (i != fd && opnfil[i] && opnfil[i]->net &&
+                opnfil[i]->sock == fp->sock) shared = TRUE;
+        if (!shared) {
+
+            if (fp->ssl) SSL_free(fp->ssl); /* free the ssl */
+            if (fp->cert) X509_free(fp->cert); /* free certificate */
+            if (fp->sock != INVALID_SOCKET) closesocket(fp->sock);
+            if (fp->sock2 != INVALID_SOCKET) closesocket(fp->sock2);
+
+        }
         fp->ssl = NULL;
         fp->bio = NULL; /* freed with the ssl */
-        if (fp->cert) X509_free(fp->cert); /* free certificate */
         fp->cert = NULL;
-        if (fp->sock != INVALID_SOCKET) closesocket(fp->sock);
-        if (fp->sock2 != INVALID_SOCKET) closesocket(fp->sock2);
         fp->sock = INVALID_SOCKET;
         fp->sock2 = INVALID_SOCKET;
         fp->net = FALSE;

--- a/windows/services.c
+++ b/windows/services.c
@@ -1612,7 +1612,19 @@ void ami_getpgm(
     char   path[MAXPTH]; /* execution path */
     int    i;            /* index for path */
     int    f;            /* path found */
+    DWORD  r;            /* return length */
 
+    /* The module filename is the true program path, independent of how the
+       command line spelled the program (a bare name resolved through PATH
+       carries no path at all, which broke self-spawning programs). Fall
+       back to the command line parse only if the direct call fails. */
+    r = GetModuleFileNameA(NULL, cb, MAXSTR);
+    if (r > 0 && r < MAXSTR) {
+
+        ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */
+        if (*p) return; /* have the path */
+
+    }
     cp = GetCommandLine(); /* get the command line */
     fstwrd(cp, cb, MAXSTR); /* get command */
     ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */


### PR DESCRIPTION
windows: share a connection across duplicated descriptors

The read and write sides of a network pair are separate descriptors
dup'd from one connection. The connection state here is indexed by
descriptor (the descriptor itself is parked on the nul device; a
winsock SOCKET is not a CRT descriptor as on linux), and the duplicate
was never entered -- so the write side's I/O fell through the
interdictions to the nul device and the client/server exchange
deadlocked. This is what kept network_test disabled in the regression.

Add ami_netshare(fd, fd2), which enters the duplicate as a sharer of
the connection (same socket, ssl, certificate), and make the close path
tear the connection down only when the last sharer closes, so either
side can close independently without double-freeing the ssl or the
socket.

Note: ami_netshare must be called by the pascal-p6 bridge
(network_support.c) after it dups the write side; the companion
pascal-p6 PR adds that call. Without it the write side still lands on
the nul device and the exchange hangs.

Also: getpgm reports the true program path via the module filename.
ami_getpgm parsed the program path out of the command line, so a
program invoked as a bare name resolved through PATH carried no path at
all. That broke self-spawning programs: the pascal network_test builds
its loopback server command from getpgm, and the servers never started
when the test itself was run as a bare name. Ask Windows for the module
filename instead, falling back to the command line parse only if the
direct call fails.

Verified with the pascal network_test on windows, both invoked with a
path and as a bare name through PATH: 7 passes, 0 fails, output matches
the golden file -- including the TCP clear exchange that previously
deadlocked, and the DTLS secured message exchange.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
https://claude.ai/code/session_01BrN32wzcoB4S6uHZkMrLqM
