### PR TITLE
windows: getpgm reports the true program path via the module filename

### DIFF
--- a/windows/services.c
+++ b/windows/services.c
@@ -1612,7 +1612,19 @@ void ami_getpgm(
     char   path[MAXPTH]; /* execution path */
     int    i;            /* index for path */
     int    f;            /* path found */
+    DWORD  r;            /* return length */
 
+    /* The module filename is the true program path, independent of how the
+       command line spelled the program (a bare name resolved through PATH
+       carries no path at all, which broke self-spawning programs). Fall
+       back to the command line parse only if the direct call fails. */
+    r = GetModuleFileNameA(NULL, cb, MAXSTR);
+    if (r > 0 && r < MAXSTR) {
+
+        ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */
+        if (*p) return; /* have the path */
+
+    }
     cp = GetCommandLine(); /* get the command line */
     fstwrd(cp, cb, MAXSTR); /* get command */
     ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */


### PR DESCRIPTION
getpgm reported the program path by parsing the command line's first
word. That does not reliably yield a usable path (a bare-name launch
resolved through PATH carries no directory at all), which breaks any
program that re-spawns itself by building a command from getpgm.

network_test does exactly that -- it spawns its own server role -- so
this fix is required for network_test to run, including under the
regression, where it is launched as ./libs/tests/network_test. Take the
true image path from GetModuleFileName, which is correct regardless of
how the program was invoked; fall back to the old command-line parse
only if that call fails.

Companion to the network file-bond redesign (Pascal-P6 #590). Note the
redesign's network MODEL needs no change here -- master's network.c is
byte-for-byte what the bonded single-close pair needs (verified:
network_test passes 7/7 against unchanged network.c). This getpgm fix is
the one amitk-side change the redesign's tests depend on.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
