### PR TITLE
Critical string output buffers throughout the API

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -9,6 +9,11 @@
 * Describes the full Petit-ami graphical subsystem, including terminal level,  *
 * graphics level, windowing, and widgets.                                      *
 *                                                                              *
+* String output buffers are "critical": a result may occupy the entire        *
+* buffer, in which case the terminating zero is left off. Results shorter     *
+* than the buffer are zero terminated. C callers should use length limited    *
+* reads of such buffers (see strnlen and similar).                            *
+*                                                                              *
 *******************************************************************************/
 
 #ifndef __GRAPHICS_H__

--- a/include/network.h
+++ b/include/network.h
@@ -14,6 +14,11 @@
 * performance computing and applications that need to determine their own      *
 * reliable delivery protocols like audio and video data.                       *
 *                                                                              *
+* String output buffers are "critical": a result may occupy the entire        *
+* buffer, in which case the terminating zero is left off. Results shorter     *
+* than the buffer are zero terminated. C callers should use length limited    *
+* reads of such buffers (see strnlen and similar).                            *
+*                                                                              *
 * The Linux version, and in fact probably all versions, rely on stacking atop  *
 * openssl.                                                                     *
 *                                                                              *

--- a/include/services.h
+++ b/include/services.h
@@ -6,6 +6,11 @@
 *                                                                              *
 *                               S. A. MOORE                                    *
 *                                                                              *
+* String output buffers are "critical": a result may occupy the entire        *
+* buffer, in which case the terminating zero is left off. Results shorter     *
+* than the buffer are zero terminated. C callers should use length limited    *
+* reads of such buffers (see strnlen and similar).                            *
+*                                                                              *
 *******************************************************************************/
 
 #ifndef __SERVICES_H__

--- a/include/sound.h
+++ b/include/sound.h
@@ -24,6 +24,11 @@
 * built into it, which could affect start time. A logical preload/cache        *
 * model would give this package the ability to do something about that.        *
 *                                                                              *
+* String output buffers are "critical": a result may occupy the entire        *
+* buffer, in which case the terminating zero is left off. Results shorter     *
+* than the buffer are zero terminated. C callers should use length limited    *
+* reads of such buffers (see strnlen and similar).                             *
+*                                                                              *
 *******************************************************************************/
 
 #ifndef __SOUND_H__

--- a/linux/dumpsynthplug.c
+++ b/linux/dumpsynthplug.c
@@ -39,6 +39,30 @@ static void error(string es)
 
 /*******************************************************************************
 
+Copy string to critical output buffer
+
+Copies the given source string to a caller supplied output buffer. Output
+buffers follow the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
+
+*******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l;
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* terminate if shorter than buffer */
+
+}
+
+/*******************************************************************************
+
 Open Liquidsynth MIDI device
 
 Opens a Liquidsynth MIDI port for use. Does nothing at present, since we open
@@ -244,7 +268,9 @@ long setparamdump(long p, string name, string value)
 Get parameter
 
 Get plug in parameter from the given name and value. Not implemented at present.
-Always returns empty string.
+Always returns empty string. The value is returned by the critical buffer
+convention: a result that fills the entire buffer is not zero terminated, a
+shorter result is zero terminated, and it is an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -252,7 +278,7 @@ void getparamdump(long p, string name, string value, long len)
 
 {
 
-    *value = 0; /* clear output string */
+    cpycrit(value, len, ""); /* return empty string */
 
 }
 

--- a/linux/fluidsynthplug.c
+++ b/linux/fluidsynthplug.c
@@ -12,6 +12,7 @@ Petit_ami sound system.
 
 #include <fluidsynth.h>
 #include <stdlib.h>
+#include <string.h>
 #include <limits.h>
 #include <localdefs.h>
 #include <sound.h>
@@ -48,6 +49,30 @@ static void error(string es)
     fprintf(stderr, "\nError: Fluidsynth: %s\n", es);
 
     exit(1);
+
+}
+
+/*******************************************************************************
+
+Copy string to critical output buffer
+
+Copies the given source string to a caller supplied output buffer. Output
+buffers follow the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
+
+*******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l;
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* terminate if shorter than buffer */
 
 }
 
@@ -229,7 +254,9 @@ long setparamfluid(long p, string name, string value)
 Get parameter
 
 Get plug in parameter from the given name and value. Not implemented at present.
-Always returns empty string.
+Always returns empty string. The value is returned by the critical buffer
+convention: a result that fills the entire buffer is not zero terminated, a
+shorter result is zero terminated, and it is an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -237,7 +264,7 @@ void getparamfluid(long p, string name, string value, long len)
 
 {
 
-    *value = 0; /* clear output string */
+    cpycrit(value, len, ""); /* return empty string */
 
 }
 

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -1655,6 +1655,34 @@ static void error(errcod e)
 
 }
 
+/** ****************************************************************************
+
+Copy string to critical buffer
+
+Copies a string to a "critical" output buffer of the given length. If the
+string is longer than the buffer, an error results. If the string exactly
+fills the buffer, the terminating zero is left off. Otherwise, the result is
+zero terminated.
+
+Note that the only critical string output implemented in this module at
+present is the font name, so the "font name too large" error is issued on
+overflow.
+
+*******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l; /* length of source string */
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error(eftntl); /* string too large for buffer */
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* zero terminate if buffer not entirely filled */
+
+}
+
 /******************************************************************************
 
 XWindow error handler
@@ -10945,7 +10973,9 @@ static void font_ivf(FILE* f, long fc)
 
 Find name of font
 
-Returns the name of a font by number.
+Returns the name of a font by number. The name is returned in a critical
+buffer: if the name exactly fills the buffer, the terminating zero is left
+off, and it is an error if the name cannot fit in the buffer.
 
 *******************************************************************************/
 
@@ -10959,7 +10989,6 @@ static void fontnam_ivf(FILE* f, long fc, char* fns, long fnsl)
 {
 
     fontptr fp; /* pointer to font entries */
-    int i; /* string index */
 
     if (fc <= 0) error(einvftn); /* invalid number */
     fp = fntlst; /* index top of list */
@@ -10970,8 +10999,7 @@ static void fontnam_ivf(FILE* f, long fc, char* fns, long fnsl)
        if (!fp) error(einvftn); /* check null */
 
     }
-    if (strlen(fp->fn) > fnsl+1) error(eftntl);
-    strcpy(fns, fp->fn);
+    cpycrit(fns, fnsl, fp->fn); /* copy name to critical result buffer */
 
 }
 

--- a/linux/network.c
+++ b/linux/network.c
@@ -1924,6 +1924,10 @@ or both may be used to break up lines in the certificate.
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
 
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
+
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.
 
@@ -1986,6 +1990,10 @@ long ami_certmsg(long fn, long which, string buff, long len)
 
     }
 
+    /* the certificate buffer is a critical buffer: terminate the result
+       only if it does not fill the entire buffer */
+    if (r < len) buff[r] = 0;
+
     return (r);
 
 }
@@ -2011,6 +2019,10 @@ or both may be used to break up lines in the certificate.
 
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
+
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
 
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.

--- a/linux/services.c
+++ b/linux/services.c
@@ -396,6 +396,37 @@ static void cpstrl2z(
 
 /********************************************************************************
 
+Copy string to critical buffer
+
+Copies a zero terminated string to a caller supplied buffer using the critical
+buffer convention: the result is allowed to occupy the entire buffer, in which
+case the terminating zero is left off. If the result is shorter than the
+buffer, it is zero terminated. It is an error if the result cannot fit in the
+buffer. This convention exists because callers from languages without zero
+terminated strings pass fixed size buffers with no room reserved for a
+terminator (this follows the strncpy() precedent).
+
+********************************************************************************/
+
+static void cpycrit(
+    /** destination buffer */        char* d,
+    /** destination buffer length */ long dl,
+    /** source string */             const char* s
+)
+
+{
+
+    long l;
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for buffer");
+    memcpy(d, s, l); /* copy characters */
+    if (l < dl) d[l] = 0; /* terminate if room remains */
+
+}
+
+/********************************************************************************
+
 Create file list
 
 Accepts a filename, that may include wildcards. All of the matching files are
@@ -534,7 +565,8 @@ void ami_list(
 
 Get time string
 
-Converts the given time into a string.
+Converts the given time into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -551,9 +583,9 @@ void ami_times(
     int sec; /* second */
     int  am;  /* am flag */
     int  pm;  /* pm flag */
+    bufstr buf; /* buffer to build result in */
+    char* bp;   /* pointer into build buffer */
 
-    if (sl < 11-(!ami_time24hour()*3)) /* string to small to hold result */
-        error("String buffer to small to hold time");
     /* because leap adjustments are made in terms of days, we just remove
        the days to find the time of day in seconds. this is completely
        independent of leap adjustments */
@@ -573,31 +605,33 @@ void ami_times(
 
     }
     /* place hour:miniute:second */
+    bp = buf; /* index build buffer */
+    *bp = 0; /* clear in case no format matches */
     switch (ami_timeorder()) {
 
         case 1:
-            s += sprintf(s, "%02d%c%02d%c%02d", h, ami_timesep(), m, ami_timesep(), sec);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", h, ami_timesep(), m, ami_timesep(), sec);
             break;
         case 2:
-            s += sprintf(s, "%02d%c%02d%c%02d", h, ami_timesep(), sec, ami_timesep(), m);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", h, ami_timesep(), sec, ami_timesep(), m);
             break;
         case 3:
-            s += sprintf(s, "%02d%c%02d%c%02d", m, ami_timesep(), h, ami_timesep(), sec);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", m, ami_timesep(), h, ami_timesep(), sec);
             break;
         case 4:
-            s += sprintf(s, "%02d%c%02d%c%02d", m, ami_timesep(), sec, ami_timesep(), h);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", m, ami_timesep(), sec, ami_timesep(), h);
             break;
         case 5:
-            s += sprintf(s, "%02d%c%02d%c%02d", sec, ami_timesep(), h, ami_timesep(), m);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", sec, ami_timesep(), h, ami_timesep(), m);
             break;
         case 6:
-            s += sprintf(s, "%02d%c%02d%c%02d", sec, ami_timesep(), m, ami_timesep(), h);
+            bp += sprintf(bp, "%02d%c%02d%c%02d", sec, ami_timesep(), m, ami_timesep(), h);
             break;
 
     }
-    if (pm) strcat(s, " pm");
-    if (am) strcat(s, " am");
-    *s = 0; /* terminate string */
+    if (pm) strcat(bp, " pm");
+    if (am) strcat(bp, " am");
+    cpycrit(s, sl, buf); /* copy result to critical buffer */
 
 }
 
@@ -605,7 +639,8 @@ void ami_times(
 
 Get date string
 
-Converts the given date into a string.
+Converts the given date into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -631,6 +666,8 @@ void ami_dates(
     short yd;   /* years in day holder */
     int done;   /* loop complete flag */
     int days[12];   /* days in months */
+    bufstr buf; /* buffer to build result in */
+    char* bp;   /* pointer into build buffer */
 
     days[0] = 31;   /* january */
     days[1] = 28;   /* february-leap day */
@@ -645,8 +682,6 @@ void ami_dates(
     days[10] = 30;   /* november */
     days[11] = 31;   /* december */
 
-    if (sl < 10) /* string to small to hold result */
-        error("*** String to small to hold date");
     if (t < 0) y = 1999; else y = 2000; /* set initial year */
     done = 0;   /* set no loop exit */
     t = labs(t);   /* find seconds magnitude */
@@ -680,29 +715,31 @@ void ami_dates(
 
     }
     /* place year/month/day */
+    bp = buf; /* index build buffer */
+    *bp = 0; /* clear in case no format matches */
     switch (ami_dateorder()) { /* place according to current location format */
 
         case 1:
-            s += sprintf(s, "%04d%c%02d%c%02d", y, ami_datesep(), m, ami_datesep(), d);
+            bp += sprintf(bp, "%04d%c%02d%c%02d", y, ami_datesep(), m, ami_datesep(), d);
             break;
         case 2:
-            s += sprintf(s, "%04d%c%02d%c%02d", y, ami_datesep(), d, ami_datesep(), m);
+            bp += sprintf(bp, "%04d%c%02d%c%02d", y, ami_datesep(), d, ami_datesep(), m);
             break;
         case 3:
-            s += sprintf(s, "%02d%c%02d%c%04d", m, ami_datesep(), d, ami_datesep(), y);
+            bp += sprintf(bp, "%02d%c%02d%c%04d", m, ami_datesep(), d, ami_datesep(), y);
             break;
         case 4:
-            s += sprintf(s, "%02d%c%04d%c%02d", m, ami_datesep(), y, ami_datesep(), d);
+            bp += sprintf(bp, "%02d%c%04d%c%02d", m, ami_datesep(), y, ami_datesep(), d);
             break;
         case 5:
-            s += sprintf(s, "%02d%c%02d%c%04d", d, ami_datesep(), m, ami_datesep(), y);
+            bp += sprintf(bp, "%02d%c%02d%c%04d", d, ami_datesep(), m, ami_datesep(), y);
             break;
         case 6:
-            s += sprintf(s, "%02d%c%04d%c%02d", d, ami_datesep(), y, ami_datesep(), m);
+            bp += sprintf(bp, "%02d%c%04d%c%02d", d, ami_datesep(), y, ami_datesep(), m);
             break;
 
     }
-    *s = 0; /* terminate string */
+    cpycrit(s, sl, buf); /* copy result to critical buffer */
 
 }
 
@@ -978,7 +1015,8 @@ static void fndenv(
 
 Get environment string
 
-Returns an environment string by name.
+Returns an environment string by name. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 *******************************************************************************/
 
@@ -994,17 +1032,9 @@ void ami_getenv(
     pthread_mutex_lock(&envlck); /* lock environment list */
     *esd = 0;
     fndenv(esn, &p);
-    if (p) {
-
-        if (strlen(p->data)+1 > esdl) {
-
-            pthread_mutex_unlock(&envlck); /* unlock environment list */
-            error("String too large for destination");
-
-        }
-        if (p) strcpy(esd, p->data);
-
-    }
+    /* copy result to critical buffer (error() exits, so no unlock needed on
+       overflow) */
+    if (p) cpycrit(esd, esdl, p->data);
     pthread_mutex_unlock(&envlck); /* unlock environment list */
 
 }
@@ -1515,7 +1545,9 @@ void ami_execew(
 
 Get current path
 
-Returns the current path in the given padded string.
+Returns the current path in the given padded string. The result may occupy the
+entire buffer, in which case the terminating zero is left off (critical buffer
+convention).
 
 ********************************************************************************/
 
@@ -1526,8 +1558,10 @@ void ami_getcur(
 
 {
 
-    fn = getcwd(fn, l);   /* get the current path */
-    if (!fn) unixerr(); /* process unix error */
+    bufstr buf; /* buffer to build result in */
+
+    if (!getcwd(buf, MAXSTR)) unixerr(); /* get the current path */
+    cpycrit(fn, l, buf); /* copy result to critical buffer */
 
 }
 
@@ -1573,6 +1607,9 @@ consider "." to be a special character, but if the ami_brknam and ami_maknam pro
 are properly paired, it will effectively be treated the same as if the "."
 were a normal character.
 
+Each result may occupy its entire buffer, in which case the terminating zero
+is left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_brknam(
@@ -1584,15 +1621,15 @@ void ami_brknam(
 
 {
 
-    int i, s, f, t; /* string indexes */
     char *s1, *s2;
     char buf[MAXSTR]; /* trimmed working copy of the spec */
     int len;          /* length of the trimmed spec */
+    bufstr lp, ln, le; /* local component holders */
 
-    /* clear all strings */
-    *p = 0;
-    *n = 0;
-    *e = 0;
+    /* clear all local strings */
+    *lp = 0;
+    *ln = 0;
+    *le = 0;
     if (!strlen(fn)) error("File specification is empty");
     s1 = fn; /* index file spec */
     /* skip spaces */
@@ -1608,21 +1645,16 @@ void ami_brknam(
     memcpy(buf, s1, len);
     buf[len] = 0;
     s1 = buf;
+    /* the trimmed spec fits MAXSTR, so each component fits its local holder */
     /* find last '/' that will mark the path */
     s2 = strrchr(s1, ami_pthchr());
     if (s2) {
 
         /* there was a path, store that */
-        while (s1 <= s2) {
-
-            if (!pl) error("String to large for destination\n");
-            *p++ = *s1++;
-            pl--;
-
-        }
-        if (!nl) error("String to large for destination\n");
-        *p = 0;
-        /* now s1 points after path */
+        len = s2-s1+1;
+        memcpy(lp, s1, len);
+        lp[len] = 0;
+        s1 = s2+1; /* now s1 points after path */
 
     }
     /* keep any leading '.' characters from fooling extension finder */
@@ -1633,33 +1665,24 @@ void ami_brknam(
     if (s2) {
 
         /* there was a name, store that */
-        while (s1 < s2) {
-
-            if (!nl) error("String to large for destination\n");
-            *n++ = *s1++;
-            nl--;
-
-        }
-        if (!nl) error("String to large for destination\n");
-        *n = 0;
-        /* now s1 points to extension or nothing */
+        len = s2-s1;
+        memcpy(ln, s1, len);
+        ln[len] = 0;
+        s1 = s2; /* now s1 points to extension or nothing */
 
     } else {
 
         /* no extension */
-        if (strlen(s1)+1 > nl) error("String to large for destination\n");
-        strcpy(n, s1);
+        strcpy(ln, s1);
         while (*s1) s1++;
 
     }
-    if (*s1 == '.') {
-
-        /* there is an extension */
-        if (strlen(s1)+1 > el) error("String to large for destination\n");
-        s1++; /* skip '.' */
-        strcpy(e, s1);
-
-    }
+    /* there is an extension */
+    if (*s1 == '.') strcpy(le, s1+1);
+    /* copy components to critical buffers */
+    cpycrit(p, pl, lp);
+    cpycrit(n, nl, ln);
+    cpycrit(e, el, le);
 
 }
 
@@ -1670,6 +1693,9 @@ Make specification
 Creates a file specification from its components, the path, name and extention.
 We make sure that the path is properly terminated with ':' or '\' before
 concatenating.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1684,33 +1710,34 @@ void ami_maknam(
 {
 
     int i;   /* index for string */
-    int fsi;   /* index for output filename */
     char s[2];
+    bufstr b; /* buffer to build result in */
 
-    if (strlen(p) > fnl) error("String too large for desination");
-    strcpy(fn, p); /* place path */
+    if (strlen(p) >= MAXSTR) error("String too large for desination");
+    strcpy(b, p); /* place path */
     /* check path properly terminated */
     i = strlen(p);   /* find length */
     if (*p) /* not null */
         if (p[i-1] != ami_pthchr()) {
 
-        if (strlen(fn)+1 > fnl) error("String too large for desination");
+        if (strlen(b)+1 >= MAXSTR) error("String too large for desination");
         s[0] = ami_pthchr();
         s[1] = 0;
-        strcat(fn, s); /* add path separator */
+        strcat(b, s); /* add path separator */
 
     }
     /* terminate path */
-    if (strlen(fn)+strlen(n) > fnl) error("String too large for desination");
-    strcat(fn, n); /* place name */
+    if (strlen(b)+strlen(n) >= MAXSTR) error("String too large for desination");
+    strcat(b, n); /* place name */
     if (*e) {  /* there is an extention */
 
-        if (strlen(fn)+1+strlen(e) > fnl)
+        if (strlen(b)+1+strlen(e) >= MAXSTR)
             error("String too large for desination");
-        strcat(fn, "."); /* place '.' */
-        strcat(fn, e); /* place extension */
+        strcat(b, "."); /* place '.' */
+        strcat(b, e); /* place extension */
 
     }
+    cpycrit(fn, fnl, b); /* copy result to critical buffer */
 
 }
 
@@ -1721,6 +1748,9 @@ Make full file specification
 If the given file specification has a default path (the current path), then
 the current path is added to it. Essentially "normalizes" file specifications.
 No validity check is done. Garbage in, garbage out.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1733,6 +1763,7 @@ void ami_fulnam(
     /* file specification */
     bufstr p, n, e, ps;   /* filespec components */
 
+    /* the input fn is fully consumed here, before the result overwrites it */
     ami_brknam(fn, p, MAXSTR, n, MAXSTR, e, MAXSTR);   /* break spec down */
     /* if the path is blank, then default to current */
     if (!*p) strcpy(p, ".");
@@ -1756,6 +1787,9 @@ In Linux, the full path of the command is not available. If the command
 executing does not exist in the current directory, it must be found on path.
 
 Note: this does not work for standard CLIB programs. We need another solution.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1805,6 +1839,9 @@ should be used instead, or the current path as required. The filenames used
 with program and user paths should be unique in case they end up in the same
 directory.
 
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_getusr(
@@ -1819,11 +1856,12 @@ void ami_getusr(
                        "HOME", "USERHOME", "USERDIR", "USER", "USERNAME",
                        0 };
 
-    *fn = 0; /* clear result */
-    /* find applicable environment names, in order */
+    /* find applicable environment names, in order. We reserve a byte for the
+       terminator so that b can be read locally even if it fills */
+    b[MAXSTR-1] = 0;
     for (i = 0, f = -1; envnam[i] && f == -1; i++) {
 
-        ami_getenv(envnam[i], b, MAXSTR);
+        ami_getenv(envnam[i], b, MAXSTR-1);
         if (*b && f < 0) f = i;
 
     }
@@ -1833,6 +1871,7 @@ void ami_getusr(
         if (!strcmp(envnam[f], "user") || !strcmp(envnam[f], "USER") ||
             !strcmp(envnam[f], "username") || !strcmp(envnam[f], "USERNAME")) {
 
+            if (strlen(b)+6 >= MAXSTR) error("String too large for buffer");
             strcpy(b1, b); /* copy */
             strcpy(b, "/home/"); /* set prefix */
             strcat(b, b1); /* combine */
@@ -1841,11 +1880,12 @@ void ami_getusr(
 
     } else {
 
-        /* all fails, set to program path */
-        ami_getpgm(b, MAXSTR);
+        /* all fails, set to program path. Reserve terminator space so b can
+           be read locally */
+        ami_getpgm(b, MAXSTR-1);
 
     }
-    strcpy(fn, b); /* place result */
+    cpycrit(fn, fnl, b); /* copy result to critical buffer */
 
 }
 
@@ -2314,7 +2354,9 @@ long ami_country(void)
 Find ami_country identifier string
 
 Finds the identifier string for the given ISO 3166-1 ami_country code. If the string
-does not fit into the string provided, an error results.
+does not fit into the string provided, an error results. The result may occupy
+the entire buffer, in which case the terminating zero is left off (critical
+buffer convention).
 
 3166-1 ami_country codes are both numeric codes, 2 letter ami_country codes, and 3
 letter ami_country codes. We only use the 2 letter codes.
@@ -2600,8 +2642,7 @@ void ami_countrys(
     p = countrytab;
     while (p->countrynum && p->countrynum != c) p++;
     if (!p->countrynum) error("Country number invalid");
-    if (strlen(p->countrystr) > len) error("Country string too large for buffer");
-    strncpy(s, p->countrystr, len);
+    cpycrit(s, len, p->countrystr); /* copy result to critical buffer */
 
 }
 
@@ -2704,7 +2745,9 @@ long ami_language(void)
 Find ami_language identifier string from ami_language code
 
 Finds a ami_language identifier string from a given ami_language code. If the identifier
-string is too long for the string buffer, an error results.
+string is too long for the string buffer, an error results. The result may
+occupy the entire buffer, in which case the terminating zero is left off
+(critical buffer convention).
 
 The ami_language codes are from the ISO 639-1 standard. It describes ami_languages with
 2 and 3 letter codes. We use only the two letter codes here.
@@ -2928,8 +2971,7 @@ void ami_languages(
     p = langtab;
     while (p->langnum && p->langnum != l) p++;
     if (!p->langnum) error("Language number invalid");
-    if (strlen(p->langstr) > len) error("Language string too larg e for buffer");
-    strncpy(s, p->langstr, len);
+    cpycrit(s, len, p->langstr); /* copy result to critical buffer */
 
 }
 
@@ -3491,9 +3533,12 @@ static void ami_init_services(int argc, char* argv[])
         envlst = p1;
 
      }
-    ami_getenv("PATH", pthstr, MAXSTR); /* load up the current path */
+    /* note we reserve a byte for the terminator, since ami_getenv() leaves the
+       terminator off a result that fills the buffer (critical buffer
+       convention) and these buffers are read as zero terminated strings */
+    ami_getenv("PATH", pthstr, MAXSTR-1); /* load up the current path */
     trim(pthstr); /* make sure left aligned */
-    ami_getenv("LANG", langstr, MAXSTR); /* get locale */
+    ami_getenv("LANG", langstr, MAXSTR-1); /* get locale */
     trim(langstr); /* clean */
 
     /* set default ami_language and ami_country */

--- a/linux/sound.c
+++ b/linux/sound.c
@@ -454,6 +454,30 @@ static void error(string s)
 
 /*******************************************************************************
 
+Copy string to critical output buffer
+
+Copies the given source string to a caller supplied output buffer. Output
+buffers follow the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
+
+*******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l;
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* terminate if shorter than buffer */
+
+}
+
+/*******************************************************************************
+
 String compare unsigned to signed char with length
 
 This is the same as whitebook strncmp, but takes the first argument unsigned.
@@ -2091,6 +2115,9 @@ static long setalsaparam(long p, string name, string value)
 ALSA get parameter
 
 ALSA has no get parameter function, so this always returns an empty string.
+The value buffer follows the critical buffer convention: a result that fills
+the entire buffer is not zero terminated, a shorter result is zero terminated,
+and it is an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -2098,7 +2125,7 @@ static void getalsaparam(long p, string name, string value, long len)
 
 {
 
-    *value = 0;
+    cpycrit(value, len, ""); /* return empty string */
 
 }
 
@@ -5546,13 +5573,16 @@ long ami_rdwave(long p, byte* buff, long len)
 
 Replace \n with '-' in string
 
+The string is given by buffer and length, since critical output buffers are
+not necessarily zero terminated.
+
 *******************************************************************************/
 
-static void rplnxl(char* s)
+static void rplnxl(char* s, size_t l)
 
 {
 
-    while (*s) { if (*s == '\n') *s = '-'; s++; }
+    while (l--) { if (*s == '\n') *s = '-'; s++; }
 
 }
 
@@ -5560,7 +5590,10 @@ static void rplnxl(char* s)
 
 Find device name of synthesizer output port
 
-Returns the ALSA device name of the given synthsizer output port.
+Returns the ALSA device name of the given synthsizer output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -5568,24 +5601,26 @@ void ami_synthoutname(long p, string name, long len)
 
 {
 
-    size_t l;
+    size_t nl, tl;
 
     if (p < 1 || p > MAXMIDP) error("Invalid MIDI output port");
     if (!alsamidiout[p-1])
         error("No MIDI output device defined at logical number");
 
-    l = 0;
-    if (alsamidiout[p-1]->desc) l = strlen(alsamidiout[p-1]->desc)+1;
-    if (strlen(alsamidiout[p-1]->name)+l+1 > len)
-        error("Device name too large for destination");
-    strcpy(name, alsamidiout[p-1]->name);
+    nl = strlen(alsamidiout[p-1]->name); /* find base name length */
+    tl = nl; /* set total length */
+    if (alsamidiout[p-1]->desc) tl += strlen(alsamidiout[p-1]->desc)+1;
+    if (tl > len) error("Device name too large for destination");
+    memcpy(name, alsamidiout[p-1]->name, nl); /* place base name */
     if (alsamidiout[p-1]->desc) {
 
-        strcat(name, "-");
-        strcat(name, alsamidiout[p-1]->desc);
-        rplnxl(name);
+        name[nl] = '-'; /* place separator */
+        /* place description */
+        memcpy(name+nl+1, alsamidiout[p-1]->desc, tl-nl-1);
+        rplnxl(name, tl); /* replace any embedded \n */
 
     }
+    if (tl < len) name[tl] = 0; /* terminate if shorter than buffer */
 
 }
 
@@ -5593,7 +5628,10 @@ void ami_synthoutname(long p, string name, long len)
 
 Find device name of synthesizer input port
 
-Returns the ALSA device name of the given synthsizer input port.
+Returns the ALSA device name of the given synthsizer input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -5601,24 +5639,26 @@ void ami_synthinname(long p, string name, long len)
 
 {
 
-    size_t l;
+    size_t nl, tl;
 
     if (p < 1 || p > MAXMIDP) error("Invalid MIDI input port");
     if (!alsamidiin[p-1])
         error("No MIDI input device defined at logical number");
 
-    l = 0;
-    if (alsamidiin[p-1]->desc) l = strlen(alsamidiin[p-1]->desc)+1;
-    if (strlen(alsamidiin[p-1]->name)+l+1 > len)
-        error("Device name too large for destination");
-    strcpy(name, alsamidiin[p-1]->name);
+    nl = strlen(alsamidiin[p-1]->name); /* find base name length */
+    tl = nl; /* set total length */
+    if (alsamidiin[p-1]->desc) tl += strlen(alsamidiin[p-1]->desc)+1;
+    if (tl > len) error("Device name too large for destination");
+    memcpy(name, alsamidiin[p-1]->name, nl); /* place base name */
     if (alsamidiin[p-1]->desc) {
 
-        strcat(name, "-");
-        strcat(name, alsamidiin[p-1]->desc);
-        rplnxl(name);
+        name[nl] = '-'; /* place separator */
+        /* place description */
+        memcpy(name+nl+1, alsamidiin[p-1]->desc, tl-nl-1);
+        rplnxl(name, tl); /* replace any embedded \n */
 
     }
+    if (tl < len) name[tl] = 0; /* terminate if shorter than buffer */
 
 }
 
@@ -5626,7 +5666,10 @@ void ami_synthinname(long p, string name, long len)
 
 Find device name of wave output port
 
-Returns the ALSA device name of the given wave output port.
+Returns the ALSA device name of the given wave output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -5634,24 +5677,26 @@ void ami_waveoutname(long p, string name, long len)
 
 {
 
-    size_t l;
+    size_t nl, tl;
 
     if (p < 1 || p > MAXWAVP) error("Invalid wave output port");
     if (!alsapcmout[p-1])
         error("No wave output device defined at logical number");
 
-    l = 0;
-    if (alsapcmout[p-1]->desc) l = strlen(alsapcmout[p-1]->desc)+1;
-    if (strlen(alsapcmout[p-1]->name)+l+1 > len)
-        error("Device name too large for destination");
-    strcpy(name, alsapcmout[p-1]->name);
+    nl = strlen(alsapcmout[p-1]->name); /* find base name length */
+    tl = nl; /* set total length */
+    if (alsapcmout[p-1]->desc) tl += strlen(alsapcmout[p-1]->desc)+1;
+    if (tl > len) error("Device name too large for destination");
+    memcpy(name, alsapcmout[p-1]->name, nl); /* place base name */
     if (alsapcmout[p-1]->desc) {
 
-        strcat(name, "-");
-        strcat(name, alsapcmout[p-1]->desc);
-        rplnxl(name);
+        name[nl] = '-'; /* place separator */
+        /* place description */
+        memcpy(name+nl+1, alsapcmout[p-1]->desc, tl-nl-1);
+        rplnxl(name, tl); /* replace any embedded \n */
 
     }
+    if (tl < len) name[tl] = 0; /* terminate if shorter than buffer */
 
 }
 
@@ -5659,7 +5704,10 @@ void ami_waveoutname(long p, string name, long len)
 
 Find device name of wave input port
 
-Returns the ALSA device name of the given wave input port.
+Returns the ALSA device name of the given wave input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -5667,24 +5715,26 @@ void ami_waveinname(long p, string name, long len)
 
 {
 
-    size_t l;
+    size_t nl, tl;
 
     if (p < 1 || p > MAXWAVP) error("Invalid wave input port");
     if (!alsapcmin[p-1])
         error("No wave input device defined at logical number");
 
-    l = 0;
-    if (alsapcmin[p-1]->desc) l = strlen(alsapcmin[p-1]->desc)+1;
-    if (strlen(alsapcmin[p-1]->name)+l+1 > len)
-        error("Device name too large for destination");
-    strcpy(name, alsapcmin[p-1]->name);
+    nl = strlen(alsapcmin[p-1]->name); /* find base name length */
+    tl = nl; /* set total length */
+    if (alsapcmin[p-1]->desc) tl += strlen(alsapcmin[p-1]->desc)+1;
+    if (tl > len) error("Device name too large for destination");
+    memcpy(name, alsapcmin[p-1]->name, nl); /* place base name */
     if (alsapcmin[p-1]->desc) {
 
-        strcat(name, "-");
-        strcat(name, alsapcmin[p-1]->desc);
-        rplnxl(name);
+        name[nl] = '-'; /* place separator */
+        /* place description */
+        memcpy(name+nl+1, alsapcmin[p-1]->desc, tl-nl-1);
+        rplnxl(name, tl); /* replace any embedded \n */
 
     }
+    if (tl < len) name[tl] = 0; /* terminate if shorter than buffer */
 
 }
 
@@ -5827,7 +5877,9 @@ Get device parameter synth out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -5851,7 +5903,9 @@ Get device parameter synth in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -5875,7 +5929,9 @@ Get device parameter wave out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -5899,7 +5955,9 @@ Get device parameter wave in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.

--- a/macosx/graphics.c
+++ b/macosx/graphics.c
@@ -225,6 +225,21 @@ static void set_fill_only(CGContextRef ctx, pa_rgba c)
     CGContextSetRGBFillColor(ctx, c.r, c.g, c.b, c.a);
 }
 
+/* Copy string to critical buffer. Critical string buffers follow the package
+   convention: a result that fills the entire buffer is left without a
+   terminating zero, a shorter result is zero terminated, and it is an error
+   if the result cannot fit in the buffer. */
+static void cpycrit(char* d, long dl, const char* s)
+{
+    long l = strlen(s);
+    if (l > dl) {
+        fprintf(stderr, "\nError: Graphics: String too large for buffer\n");
+        exit(1);
+    }
+    memcpy(d, s, l);
+    if (l < dl) d[l] = 0;
+}
+
 /* Convert PA 1-based coordinate to CG 0-based */
 #define PX(x) ((x) - 1)
 #define PY(y) ((y) - 1)
@@ -2065,10 +2080,8 @@ void ami_fontnam(FILE* f, long fc, char* fns, long fnsl)
     fontptr fp = fntlst;
     int i = 1;
     while (fp && i < fc) { fp = fp->next; i++; }
-    if (fp && fp->name) {
-        strncpy(fns, fp->name, fnsl-1);
-        fns[fnsl-1] = 0;
-    } else if (fnsl > 0) fns[0] = 0;
+    /* critical buffer: a full-length result is left unterminated */
+    cpycrit(fns, fnsl, fp && fp->name ? fp->name : "");
 }
 
 void ami_fontsiz(FILE* f, long s)
@@ -2914,7 +2927,15 @@ void ami_enablewidget(FILE* f, long id, long e)
 void ami_getwidgettext(FILE* f, long id, char* s, long sl)
 {
     winptr win = f2win(f); if (!win) return;
-    pa_cocoa_widget_get_text(win->han, id, s, sl);
+    /* fetch to a terminated local, then apply the critical buffer
+       convention at the caller's buffer: a result filling the entire buffer
+       is left unterminated, overflow is an error */
+    char* buf = malloc(sl+2);
+    if (!buf) return;
+    buf[0] = 0;
+    pa_cocoa_widget_get_text(win->han, id, buf, (int)(sl+2));
+    cpycrit(s, sl, buf);
+    free(buf);
 }
 
 void ami_putwidgettext(FILE* f, long id, char* s)
@@ -3457,6 +3478,10 @@ void ami_tabsel(FILE* f, long id, long tn)
 *                                                                              *
 *                        PA API — dialogs                                      *
 *                                                                              *
+* String buffers passed to these dialogs are critical buffers: a result that  *
+* fills the entire buffer is left without a terminating zero, a shorter       *
+* result is zero terminated, and it is an error if the result cannot fit.     *
+*                                                                              *
 *******************************************************************************/
 
 void ami_alert(char* title, char* message)
@@ -3469,17 +3494,56 @@ void ami_querycolor(long* r, long* g, long* b)
     pa_cocoa_query_color(r, g, b);
 }
 
-void ami_queryopen(char* s, long sl)  { pa_cocoa_query_open(s, sl); }
-void ami_querysave(char* s, long sl)  { pa_cocoa_query_save(s, sl); }
+void ami_queryopen(char* s, long sl)
+{
+    /* the bridge fills a terminated local; the critical copy happens at the
+       caller's buffer */
+    char* buf = malloc(sl+2);
+    if (!buf) return;
+    buf[0] = 0;
+    pa_cocoa_query_open(buf, (int)(sl+2));
+    cpycrit(s, sl, buf);
+    free(buf);
+}
+
+void ami_querysave(char* s, long sl)
+{
+    char* buf = malloc(sl+2);
+    if (!buf) return;
+    buf[0] = 0;
+    pa_cocoa_query_save(buf, (int)(sl+2));
+    cpycrit(s, sl, buf);
+    free(buf);
+}
 
 void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
 {
-    pa_cocoa_query_find(s, sl, opt);
+    char* buf = malloc(sl+2);
+    long l = 0;
+    if (!buf) return;
+    /* the input seed may fill the caller's buffer without a terminator */
+    while (l < sl && s[l]) l++;
+    memcpy(buf, s, l); buf[l] = 0;
+    pa_cocoa_query_find(buf, (int)(sl+2), opt);
+    cpycrit(s, sl, buf);
+    free(buf);
 }
 
 void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
 {
-    pa_cocoa_query_findrep(s, sl, r, rl, opt);
+    char* fbuf = malloc(sl+2);
+    char* rbuf = malloc(rl+2);
+    long l;
+    if (!fbuf || !rbuf) { free(fbuf); free(rbuf); return; }
+    /* the input seeds may fill the caller's buffers without terminators */
+    l = 0; while (l < sl && s[l]) l++;
+    memcpy(fbuf, s, l); fbuf[l] = 0;
+    l = 0; while (l < rl && r[l]) l++;
+    memcpy(rbuf, r, l); rbuf[l] = 0;
+    pa_cocoa_query_findrep(fbuf, (int)(sl+2), rbuf, (int)(rl+2), opt);
+    cpycrit(s, sl, fbuf);
+    cpycrit(r, rl, rbuf);
+    free(fbuf); free(rbuf);
 }
 
 void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg,

--- a/macosx/sound.c
+++ b/macosx/sound.c
@@ -276,6 +276,18 @@ static void error(const char* s)
     exit(1);
 }
 
+/* Copy string to critical output buffer. Output buffers follow the critical
+   buffer convention: a result that fills the entire buffer is not zero
+   terminated, a shorter result is zero terminated, and it is an error if the
+   result cannot fit. */
+static void cpycrit(char* d, long dl, const char* s)
+{
+    long l = (long)strlen(s); /* find length of source */
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* terminate if shorter than buffer */
+}
+
 /*******************************************************************************
 *                                                                              *
 *                          Time helpers                                         *
@@ -739,32 +751,32 @@ long ami_synthin(void)   { return synthin_num; }
 long ami_waveout(void)   { return waveout_num; }
 long ami_wavein(void)    { return wavein_num; }
 
+/* Device names are returned by the critical buffer convention: a result that
+   fills the entire buffer is not zero terminated, a shorter result is zero
+   terminated, and it is an error if the result cannot fit. */
+
 void ami_synthoutname(long p, string name, long len)
 {
-    if (p < 1 || p > synthout_num) { if (len > 0) name[0] = 0; return; }
-    strncpy(name, synthout_tab[p - 1].name, len);
-    if (len > 0) name[len - 1] = 0;
+    if (p < 1 || p > synthout_num) { cpycrit(name, len, ""); return; }
+    cpycrit(name, len, synthout_tab[p - 1].name);
 }
 
 void ami_synthinname(long p, string name, long len)
 {
-    if (p < 1 || p > synthin_num) { if (len > 0) name[0] = 0; return; }
-    strncpy(name, synthin_tab[p - 1].name, len);
-    if (len > 0) name[len - 1] = 0;
+    if (p < 1 || p > synthin_num) { cpycrit(name, len, ""); return; }
+    cpycrit(name, len, synthin_tab[p - 1].name);
 }
 
 void ami_waveoutname(long p, string name, long len)
 {
-    if (p < 1 || p > waveout_num) { if (len > 0) name[0] = 0; return; }
-    strncpy(name, waveout_tab[p - 1].name, len);
-    if (len > 0) name[len - 1] = 0;
+    if (p < 1 || p > waveout_num) { cpycrit(name, len, ""); return; }
+    cpycrit(name, len, waveout_tab[p - 1].name);
 }
 
 void ami_waveinname(long p, string name, long len)
 {
-    if (p < 1 || p > wavein_num) { if (len > 0) name[0] = 0; return; }
-    strncpy(name, wavein_tab[p - 1].name, len);
-    if (len > 0) name[len - 1] = 0;
+    if (p < 1 || p > wavein_num) { cpycrit(name, len, ""); return; }
+    cpycrit(name, len, wavein_tab[p - 1].name);
 }
 
 /*******************************************************************************
@@ -1690,36 +1702,40 @@ long ami_rdwave(long p, byte* buff, long len)
 *                                                                              *
 *******************************************************************************/
 
+/* Parameter values are returned by the critical buffer convention: a result
+   that fills the entire buffer is not zero terminated, a shorter result is
+   zero terminated, and it is an error if the result cannot fit. */
+
 void ami_getparamsynthout(long p, string name, string value, long len)
 {
-    if (p < 1 || p > synthout_num) { if (len > 0) value[0] = 0; return; }
+    if (p < 1 || p > synthout_num) { cpycrit(value, len, ""); return; }
     synthoutdev* d = &synthout_tab[p - 1];
     if (d->getparam) { d->getparam(p, name, value, len); return; }
-    if (len > 0) value[0] = 0;
+    cpycrit(value, len, "");
 }
 
 void ami_getparamsynthin(long p, string name, string value, long len)
 {
-    if (p < 1 || p > synthin_num) { if (len > 0) value[0] = 0; return; }
+    if (p < 1 || p > synthin_num) { cpycrit(value, len, ""); return; }
     synthindev* d = &synthin_tab[p - 1];
     if (d->getparam) { d->getparam(p, name, value, len); return; }
-    if (len > 0) value[0] = 0;
+    cpycrit(value, len, "");
 }
 
 void ami_getparamwaveout(long p, string name, string value, long len)
 {
-    if (p < 1 || p > waveout_num) { if (len > 0) value[0] = 0; return; }
+    if (p < 1 || p > waveout_num) { cpycrit(value, len, ""); return; }
     waveoutdev* d = &waveout_tab[p - 1];
     if (d->getparam) { d->getparam(p, name, value, len); return; }
-    if (len > 0) value[0] = 0;
+    cpycrit(value, len, "");
 }
 
 void ami_getparamwavein(long p, string name, string value, long len)
 {
-    if (p < 1 || p > wavein_num) { if (len > 0) value[0] = 0; return; }
+    if (p < 1 || p > wavein_num) { cpycrit(value, len, ""); return; }
     waveindev* d = &wavein_tab[p - 1];
     if (d->getparam) { d->getparam(p, name, value, len); return; }
-    if (len > 0) value[0] = 0;
+    cpycrit(value, len, "");
 }
 
 long ami_setparamsynthout(long p, string name, string value)

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -535,6 +535,59 @@ static void error(
 
 }
 
+/** ****************************************************************************
+
+Copy string to critical buffer
+
+Copies a string to a "critical" output buffer of the given length. If the
+string is longer than the buffer, an error results. If the string exactly
+fills the buffer, the terminating zero is left off. Otherwise, the result is
+zero terminated.
+
+*******************************************************************************/
+
+static void cpycrit(
+    /** Destination buffer */           char*       d,
+    /** Length of destination buffer */ long        dl,
+    /** Source string */                const char* s
+)
+
+{
+
+    long l; /* length of source string */
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for result buffer");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* zero terminate if buffer not entirely filled */
+
+}
+
+/** ****************************************************************************
+
+Get widget text with guaranteed zero termination
+
+Internal helper. ami_getwidgettext() fills a critical buffer, meaning the
+terminating zero is left off when the text exactly fills the buffer. Internal
+callers that parse the result need a proper C string, so this reserves one
+byte of the buffer for the terminator and guarantees termination.
+
+*******************************************************************************/
+
+static void getwidgettextz(
+    /** Window file */             FILE* f,
+    /** Logical widget id */       long  id,
+    /** Output buffer for text */  char* s,
+    /** Size of output buffer */   long  sl
+)
+
+{
+
+    ami_getwidgettext(f, id, s, sl-1); /* get text, reserve terminator byte */
+    s[sl-1] = 0; /* guarantee termination if text exactly filled buffer */
+
+}
+
 /** ***************************************************************************
 
 Print event type
@@ -2440,7 +2493,7 @@ static void numselbox_event(
                         wg->mpx < ami_maxxg(wg->wf)-udspc) {
 
                         /* down control */
-                        ami_getwidgettext(wg->wf, wg->cw->id, buff, sizeof(buff));
+                        getwidgettextz(wg->wf, wg->cw->id, buff, sizeof(buff));
                         v = atol(buff);
                         if (wg->cw->lbnd < v && v <= wg->cw->ubnd) v--;
                         sprintf(buff, "%ld", v);
@@ -2454,7 +2507,7 @@ static void numselbox_event(
                     } else if (wg->mpx >= ami_maxxg(wg->wf)-udspc) {
 
                         /* up control */
-                        ami_getwidgettext(wg->wf, wg->cw->id, buff, sizeof(buff));
+                        getwidgettextz(wg->wf, wg->cw->id, buff, sizeof(buff));
                         v = atol(buff);
                         if (wg->cw->lbnd <= v && v < wg->cw->ubnd) v++;
                         sprintf(buff, "%ld", v);
@@ -3905,6 +3958,10 @@ Retrieves the text from a widget. The widget must be one that contains text.
 It is an error if this call is used on a widget that does not contain text.
 This error is currently unchecked.
 
+The text is returned in a critical buffer: if the text exactly fills the
+buffer, the terminating zero is left off, and it is an error if the text
+cannot fit in the buffer.
+
 *******************************************************************************/
 
 static void igetwidgettext(
@@ -3922,9 +3979,7 @@ static void igetwidgettext(
     /* check this widget can have face text read */
     if (wp->typ != wteditbox && wp->typ != wtdropeditbox)
         error("Widget content cannot be read");
-    /* check face text too large for buffer */
-    if (strlen(wp->face) >= sl) error("Face text too large for result");
-    strcpy(s, wp->face); /* copy face text to result */
+    cpycrit(s, sl, wp->face); /* copy face text to critical result buffer */
 
 }
 
@@ -6619,6 +6674,10 @@ in the current directory into a list.
 
 If the operation is cancelled, then a null string will be returned.
 
+The result is returned in a critical buffer: if it exactly fills the buffer,
+the terminating zero is left off, and it is an error if the result cannot fit
+in the buffer.
+
 *******************************************************************************/
 
 /*
@@ -6930,7 +6989,7 @@ static void qfl_dialog(char* s, long sl, const char* title) {
             case ami_etedtbox:
                 if (er.edtbid == QFL_ID_PATH) {
                     /* user pressed enter in path: reload */
-                    ami_getwidgettext(out, QFL_ID_PATH, curdir, sizeof(curdir));
+                    getwidgettextz(out, QFL_ID_PATH, curdir, sizeof(curdir));
                     if (curdir[0] == 0) { curdir[0]='.'; curdir[1]=0; }
                     ami_killwidget(out, QFL_ID_LIST);
                     listsp = build_qfl_list(curdir);
@@ -6980,17 +7039,21 @@ static void qfl_dialog(char* s, long sl, const char* title) {
         if (s && sl > 0) s[0] = 0;
     } else if (s && sl > 0) {
         /* read both edit boxes fresh */
-        ami_getwidgettext(out, QFL_ID_PATH, curdir,  sizeof(curdir));
-        ami_getwidgettext(out, QFL_ID_NAME, curfile, sizeof(curfile));
+        getwidgettextz(out, QFL_ID_PATH, curdir,  sizeof(curdir));
+        getwidgettextz(out, QFL_ID_NAME, curfile, sizeof(curfile));
         if (curfile[0] == 0) {
             s[0] = 0;                              /* no filename given */
-        } else if (curfile[0] == '/') {
-            strncpy(s, curfile, sl-1); s[sl-1] = 0;/* absolute path */
-        } else if (curdir[0] == 0 ||
-                   (curdir[0] == '.' && curdir[1] == 0)) {
-            strncpy(s, curfile, sl-1); s[sl-1] = 0;/* CWD relative */
         } else {
-            join_path(s, sl, curdir, curfile);     /* dir + name */
+            /* build the full result locally, then copy to the critical
+               result buffer */
+            if (curfile[0] == '/')
+                strcpy(tmpbuf, curfile);           /* absolute path */
+            else if (curdir[0] == 0 ||
+                     (curdir[0] == '.' && curdir[1] == 0))
+                strcpy(tmpbuf, curfile);           /* CWD relative */
+            else
+                join_path(tmpbuf, sizeof(tmpbuf), curdir, curfile);
+            cpycrit(s, sl, tmpbuf);
         }
     }
 
@@ -7025,6 +7088,10 @@ in the current directory into a list.
 
 If the operation is cancelled, then a null string will be returned.
 
+The result is returned in a critical buffer: if it exactly fills the buffer,
+the terminating zero is left off, and it is an error if the result cannot fit
+in the buffer.
+
 *******************************************************************************/
 
 static void iquerysave(
@@ -7050,6 +7117,10 @@ set the dialog.
 
 The string that is passed in is discarded without complaint. It is up to the
 caller to dispose of it properly.
+
+The search string is returned in a critical buffer: if it exactly fills the
+buffer, the terminating zero is left off, and it is an error if it cannot fit
+in the buffer.
 
 Bug: should return null string on cancel. Unlike other dialogs, windows
 provides no indication of if the cancel button was pushed. To do this, we
@@ -7279,6 +7350,10 @@ set the dialog.
 
 The string that is passed in is discarded without complaint. It is up to the
 caller to dispose of it properly.
+
+The search and replace strings are returned in critical buffers: if a result
+exactly fills its buffer, the terminating zero is left off, and it is an
+error if a result cannot fit in its buffer.
 
 Bug: See comment, queryfind.
 
@@ -7599,7 +7674,9 @@ static void iqueryfont(
     if (nfonts < 1) nfonts = 0;
     for (i = 1; i <= nfonts; i++) {
         ami_strptr e;
-        ami_fontnam(out, i, namebuf, sizeof(namebuf));
+        /* leave room for termination, ami_fontnam() fills a critical buffer */
+        ami_fontnam(out, i, namebuf, sizeof(namebuf)-1);
+        namebuf[sizeof(namebuf)-1] = 0;
         e = malloc(sizeof(ami_strrec));
         e->next = NULL;
         e->str  = strdup(namebuf);
@@ -7741,7 +7818,7 @@ static void iqueryfont(
                     /* user pressed enter in size box: parse number */
                     char sbuf[32];
                     long n, neg, j;
-                    ami_getwidgettext(out, 4, sbuf, sizeof(sbuf));
+                    getwidgettextz(out, 4, sbuf, sizeof(sbuf));
                     n = 0; neg = 0; j = 0;
                     if (sbuf[0] == '-') { neg = 1; j = 1; }
                     while (sbuf[j] >= '0' && sbuf[j] <= '9') {
@@ -7811,7 +7888,7 @@ static void iqueryfont(
         {
             char sbuf[32];
             long n, neg, j;
-            ami_getwidgettext(out, 4, sbuf, sizeof(sbuf));
+            getwidgettextz(out, 4, sbuf, sizeof(sbuf));
             n = 0; neg = 0; j = 0;
             if (sbuf[0] == '-') { neg = 1; j = 1; }
             while (sbuf[j] >= '0' && sbuf[j] <= '9') {

--- a/stub/graphics.c
+++ b/stub/graphics.c
@@ -1153,6 +1153,10 @@ Find name of font
 
 Returns the name of a font by number.
 
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
+
 *******************************************************************************/
 
 void ami_fontnam(FILE* f, long fc, char* fns, long fnsl)
@@ -2387,6 +2391,10 @@ Retrives the text from a widget. The widget must be one that contains text.
 It is an error if this call is used on a widget that does not contain text.
 This error is currently unchecked.
 
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
+
 *******************************************************************************/
 
 void ami_getwidgettext(FILE* f, long id, char* s, long sl)
@@ -3410,6 +3418,10 @@ in the current directory into a list.
 
 If the operation is cancelled, then a null string will be returned.
 
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
+
 *******************************************************************************/
 
 void ami_queryopen(char* s, long sl)
@@ -3433,6 +3445,10 @@ If a wildcard is passed as the default, this will be used to filter the files
 in the current directory into a list.
 
 If the operation is cancelled, then a null string will be returned.
+
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
 
 *******************************************************************************/
 
@@ -3467,6 +3483,10 @@ sounds very system dependent, since that could change. One method might be
 to retrive the button text, but this is still fairly system dependent. We
 table this issue until later.
 
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
+
 *******************************************************************************/
 
 void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
@@ -3491,6 +3511,10 @@ The string that is passed in is discarded without complaint. It is up to the
 caller to dispose of it properly.
 
 Bug: See comment, queryfind.
+
+The string buffers are critical buffers: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the result cannot fit in the buffer.
 
 *******************************************************************************/
 

--- a/stub/network.c
+++ b/stub/network.c
@@ -397,6 +397,10 @@ or both may be used to break up lines in the certificate.
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
 
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
+
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.
 
@@ -433,6 +437,10 @@ or both may be used to break up lines in the certificate.
 
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
+
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
 
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.

--- a/stub/services.c
+++ b/stub/services.c
@@ -99,7 +99,8 @@ void ami_list(
 
 Get time string
 
-Converts the given time into a string.
+Converts the given time into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -119,7 +120,8 @@ void ami_times(
 
 Get date string
 
-Converts the given date into a string.
+Converts the given date into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -335,7 +337,8 @@ long ami_wild(
 
 Get environment string
 
-Returns an environment string by name.
+Returns an environment string by name. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 *******************************************************************************/
 
@@ -488,7 +491,9 @@ void ami_execew(
 
 Get current path
 
-Returns the current path in the given padded string.
+Returns the current path in the given padded string. The result may occupy the
+entire buffer, in which case the terminating zero is left off (critical buffer
+convention).
 
 ********************************************************************************/
 
@@ -542,6 +547,9 @@ consider "." to be a special character, but if the brknam and maknam procedures
 are properly paired, it will effectively be treated the same as if the "."
 were a normal character.
 
+Each result may occupy its entire buffer, in which case the terminating zero
+is left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_brknam(
@@ -564,6 +572,9 @@ Make specification
 Creates a file specification from its components, the path, name and extention.
 We make sure that the path is properly terminated with ':' or '\' before
 concatenating.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -589,6 +600,9 @@ If the given file specification has a default path (the current path), then
 the current path is added to it. Essentially "normalizes" file specifications.
 No validity check is done. Garbage in, garbage out.
 
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_fulnam(
@@ -607,6 +621,9 @@ Get program path
 
 There is no direct call for program path. So we get the command line, and
 extract the program path from that.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -640,6 +657,9 @@ The caller should check if the path exists. If not, then the program path
 should be used instead, or the current path as required. The filenames used
 with program and user paths should be unique in case they end up in the same
 directory.
+
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1027,7 +1047,9 @@ long ami_country(void)
 Find country identifier string
 
 Finds the identifier string for the given ISO 3166-1 country code. If the string
-does not fit into the string provided, an error results.
+does not fit into the string provided, an error results. The result may occupy
+the entire buffer, in which case the terminating zero is left off (critical
+buffer convention).
 
 3166-1 country codes are both numeric codes, 2 letter country codes, and 3
 letter country codes. We only use the 2 letter codes.
@@ -1139,7 +1161,9 @@ long ami_language(void)
 Find language identifier string from language code
 
 Finds a language identifier string from a given language code. If the identifier
-string is too long for the string buffer, an error results.
+string is too long for the string buffer, an error results. The result may
+occupy the entire buffer, in which case the terminating zero is left off
+(critical buffer convention).
 
 The language codes are from the ISO 639-1 standard. It describes languages with
 2 and 3 letter codes. We use only the two letter codes here.

--- a/stub/sound.c
+++ b/stub/sound.c
@@ -1303,7 +1303,10 @@ long ami_rdwave(long p, byte* buff, long len)
 
 Find device name of synthesizer output port
 
-Returns the ALSA device name of the given synthsizer output port.
+Returns the device name of the given synthsizer output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -1319,7 +1322,10 @@ void ami_synthoutname(long p, string name, long len)
 
 Find device name of synthesizer input port
 
-Returns the ALSA device name of the given synthsizer input port.
+Returns the device name of the given synthsizer input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -1335,7 +1341,10 @@ void ami_synthinname(long p, string name, long len)
 
 Find device name of wave output port
 
-Returns the ALSA device name of the given wave output port.
+Returns the device name of the given wave output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -1351,7 +1360,10 @@ void ami_waveoutname(long p, string name, long len)
 
 Find device name of wave input port
 
-Returns the ALSA device name of the given wave input port.
+Returns the device name of the given wave input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -1454,7 +1466,9 @@ Get device parameter synth out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -1475,7 +1489,9 @@ Get device parameter synth in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -1496,7 +1512,9 @@ Get device parameter wave out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -1517,7 +1535,9 @@ Get device parameter wave in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.

--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -1228,6 +1228,31 @@ static void ifree(void* ptr)
 
 }
 
+/******************************************************************************
+
+Copy string to critical buffer
+
+Copies the given source string to the given destination buffer of the given
+length. Critical buffers implement the string buffer convention for this
+package: a result that fills the entire buffer is left without a terminating
+zero, a result shorter than the buffer is zero terminated, and it is an error
+if the result cannot fit in the buffer.
+
+******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l; /* length of source string */
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error(estrtl); /* string too long for destination */
+    memcpy(d, s, l); /* copy string to destination */
+    if (l < dl) d[l] = 0; /* terminate if it does not fill the buffer */
+
+}
+
 /*******************************************************************************
 
 Print message string
@@ -6488,7 +6513,9 @@ void ami_font(FILE* f, long fc)
 
 Find name of font
 
-Returns the name of a font by number.
+Returns the name of a font by number. The name buffer is a critical buffer: a
+name that fills the entire buffer is left without a terminating zero, a
+shorter name is zero terminated, and it is an error if the name cannot fit.
 
 *******************************************************************************/
 
@@ -6508,8 +6535,8 @@ static void ifontnam(winptr win, long fc, char* fns, long fnsl)
        if (!fp) error(einvftn); /* check null */
 
     }
-    if (strlen(fp->fn) > fnsl+1) error(eftntl);
-    strcpy(fns, fp->fn);
+    if (strlen(fp->fn) > fnsl) error(eftntl); /* font name too large */
+    cpycrit(fns, fnsl, fp->fn); /* copy name to critical buffer */
 
 }
 
@@ -12365,6 +12392,10 @@ Retrives the text from a widget. The widget must be one that contains text.
 It is an error if this call is used on a widget that does not contain text.
 This error is currently unchecked.
 
+The text buffer is a critical buffer: text that fills the entire buffer is
+left without a terminating zero, shorter text is zero terminated, and it is an
+error if the text cannot fit in the buffer.
+
 *******************************************************************************/
 
 static void igetwidgettext(winptr win, long id, char* s, long sl)
@@ -12374,7 +12405,6 @@ static void igetwidgettext(winptr win, long id, char* s, long sl)
     wigptr wp; /* widget pointer */
     int    ls; /* length of text */
     char*  sp; /* pointer to string */
-    int    i;  /* index for string */
     int    r;  /* return value */
 
     if (!win->visible) winvis(win); /* make sure we are displayed */
@@ -12387,8 +12417,12 @@ static void igetwidgettext(winptr win, long id, char* s, long sl)
       a zero return as being for a zero length string, but also apparently
       uses that value for errors. */
     unlockmain(); /* end exclusive access */
-    r = GetWindowText(wp->han, s, sl); /* get the text */
+    ls = GetWindowTextLength(wp->han); /* find length of widget text */
+    sp = imalloc(ls+1); /* get temporary buffer to hold text */
+    r = GetWindowText(wp->han, sp, ls+1); /* get the text */
     lockmain(); /* start exclusive access */
+    cpycrit(s, sl, sp); /* copy text to critical buffer */
+    ifree(sp); /* free the temporary buffer */
 
 }
 
@@ -15394,8 +15428,9 @@ in the current directory into a list.
 
 If the operation is cancelled, a null string will be returned.
 
-It is an error if the passed string buffer is not big enough to contain the
-result.
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
 
 *******************************************************************************/
 
@@ -15413,8 +15448,7 @@ void ami_queryopen(char* s, long sl)
     br = PostMessage(dialogwin, UM_IM, (WPARAM)ip, 0);
     if (!br) winerr(); /* process windows error */
     waitim(imqopen, &ip); /* wait for the return */
-    if (strlen(ip->opnfil) > sl) error(estrtl); /* string overflow */
-    strcpy(s, ip->opnfil); /* set output string */
+    cpycrit(s, sl, ip->opnfil); /* copy result to critical buffer */
     ifree(ip->opnfil); /* free the temp string */
     putitm(ip); /* release im */
     unlockmain(); /* end exclusive access */
@@ -15434,11 +15468,9 @@ in the current directory into a list.
 
 If the operation is cancelled, a null string will be returned.
 
-It is an error if the passed string buffer is not big enough to contain the
-result.
-
-It is an error if the passed string buffer is not big enough to contain the
-result.
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
 
 *******************************************************************************/
 
@@ -15456,8 +15488,7 @@ void ami_querysave(char* s, long sl)
     br = PostMessage(dialogwin, UM_IM, (WPARAM)ip, 0);
     if (!br)  winerr(); /* process windows error */
     waitim(imqsave, &ip); /* wait for the return */
-    if (strlen(ip->savfil) > sl) error(estrtl); /* string overflow */
-    strcpy(s, ip->savfil); /* set output string */
+    cpycrit(s, sl, ip->savfil); /* copy result to critical buffer */
     ifree(ip->savfil); /* free the temp string */
     putitm(ip); /* release im */
     unlockmain(); /* end exclusive access */
@@ -15476,6 +15507,10 @@ set the dialog.
 
 The string that is passed in is discarded without complaint. It is up to the
 caller to dispose of it properly.
+
+The string buffer is a critical buffer: a result that fills the entire buffer
+is left without a terminating zero, a shorter result is zero terminated, and
+it is an error if the result cannot fit in the buffer.
 
 Bug: should return null string on cancel. Unlike other dialogs, windows
 provides no indication of if the cancel button was pushed. To do this, we
@@ -15504,8 +15539,7 @@ void ami_queryfind(char* s, long sl, long* opt)
     br = PostMessage(dialogwin, UM_IM, (WPARAM)ip, 0);
     if (!br) winerr(); /* process windows error */
     waitim(imqfind, &ip); /* wait for the return */
-    if (strlen(ip->fndstr) > sl) error(estrtl); /* string overflow */
-    strcpy(s, ip->fndstr); /* set output string */
+    cpycrit(s, sl, ip->fndstr); /* copy result to critical buffer */
     ifree(ip->fndstr); /* free the temp string */
     *opt = ip->fndopt; /* set output options */
     putitm(ip); /* release im */
@@ -15525,6 +15559,10 @@ set the dialog.
 
 The string that is passed in is discarded without complaint. It is up to the
 caller to dispose of it properly.
+
+The find and replace string buffers are critical buffers: a result that fills
+the entire buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the result cannot fit in the buffer.
 
 Bug: See comment, queryfind.
 
@@ -15546,11 +15584,9 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, long* opt)
     br = PostMessage(dialogwin, UM_IM, (WPARAM)ip, 0);
     if (!br) winerr(); /* process windows error */
     waitim(imqfindrep, &ip); /* wait for the return */
-    if (strlen(ip->fnrsch) > sl) error(estrtl); /* string overflow */
-    strcpy(s, ip->fnrsch); /* set output find string */
+    cpycrit(s, sl, ip->fnrsch); /* copy find result to critical buffer */
     ifree(ip->fnrsch); /* free the temp string */
-    if (strlen(ip->fnrrep) > rl) error(estrtl); /* string overflow */
-    strcpy(r, ip->fnrrep);
+    cpycrit(r, rl, ip->fnrrep); /* copy replace result to critical buffer */
     ifree(ip->fnrrep); /* free the temp string */
     *opt = ip->fnropt; /* set output options */
     putitm(ip); /* release im */

--- a/windows/network.c
+++ b/windows/network.c
@@ -1887,6 +1887,10 @@ or both may be used to break up lines in the certificate.
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
 
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
+
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.
 
@@ -1951,6 +1955,10 @@ long ami_certmsg(long fn, long which, string buff, long len)
 
     }
 
+    /* the certificate buffer is a critical buffer: terminate the result
+       only if it does not fill the entire buffer */
+    if (r < len) buff[r] = 0;
+
     return (r);
 
 }
@@ -1976,6 +1984,10 @@ or both may be used to break up lines in the certificate.
 
 Certificates are normally retrieved in numerical order, that is, 1, 2, 3...N.
 Thus the end of the certificate chain must be found by traversal.
+
+The certificate buffer is a critical buffer: a result that fills the entire
+buffer is left without a terminating zero, a shorter result is zero
+terminated, and it is an error if the certificate cannot fit in the buffer.
 
 Note that this routine retrieves the peer certificate, or other end of the
 line. Servers are required to provide certificates. Clients are not.

--- a/windows/services.c
+++ b/windows/services.c
@@ -229,6 +229,31 @@ static void extract(char *d, int l, char *s, int st, int ed)
 
 /********************************************************************************
 
+Copy result to critical buffer
+
+Copies a string result into a caller supplied buffer under the critical buffer
+convention: the result may occupy the entire buffer, in which case the
+terminating zero is left off. Results shorter than the buffer are zero
+terminated. It is an error if the result cannot fit into the buffer. This
+allows callers from languages that do not use zero terminated strings to pass
+fixed size buffers with no space reserved for the terminator.
+
+********************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+{
+
+    long l;
+
+    l = strlen(s);
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l);
+    if (l < dl) d[l] = 0; /* terminate only if result is short of buffer */
+
+}
+
+/********************************************************************************
+
 Trim leading and trailing spaces off string.
 
 Removes leading and trailing spaces from a given string. Since the string will
@@ -491,7 +516,8 @@ void ami_list(
 
 Get time string
 
-Converts the given time into a string.
+Converts the given time into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -508,9 +534,8 @@ void ami_times(
     int sec; /* second */
     int  am;  /* am flag */
     int  pm;  /* pm flag */
+    bufstr buf; /* buffer to build result in */
 
-    if (sl < 11-(!ami_time24hour()*3)) /* string to small to hold result */
-        error("String buffer to small to hold time");
     /* because leap adjustments are made in terms of days, we just remove
        the days to find the time of day in seconds. this is completely
        independent of leap adjustments */
@@ -530,31 +555,32 @@ void ami_times(
 
     }
     /* place hour:miniute:second */
+    buf[0] = 0; /* clear result */
     switch (ami_timeorder()) {
 
         case 1:
-            s += sprintf(s, "%02d%c%02d%c%02d", h, ami_timesep(), m, ami_timesep(), sec);
+            sprintf(buf, "%02d%c%02d%c%02d", h, ami_timesep(), m, ami_timesep(), sec);
             break;
         case 2:
-            s += sprintf(s, "%02d%c%02d%c%02d", h, ami_timesep(), sec, ami_timesep(), m);
+            sprintf(buf, "%02d%c%02d%c%02d", h, ami_timesep(), sec, ami_timesep(), m);
             break;
         case 3:
-            s += sprintf(s, "%02d%c%02d%c%02d", m, ami_timesep(), h, ami_timesep(), sec);
+            sprintf(buf, "%02d%c%02d%c%02d", m, ami_timesep(), h, ami_timesep(), sec);
             break;
         case 4:
-            s += sprintf(s, "%02d%c%02d%c%02d", m, ami_timesep(), sec, ami_timesep(), h);
+            sprintf(buf, "%02d%c%02d%c%02d", m, ami_timesep(), sec, ami_timesep(), h);
             break;
         case 5:
-            s += sprintf(s, "%02d%c%02d%c%02d", sec, ami_timesep(), h, ami_timesep(), m);
+            sprintf(buf, "%02d%c%02d%c%02d", sec, ami_timesep(), h, ami_timesep(), m);
             break;
         case 6:
-            s += sprintf(s, "%02d%c%02d%c%02d", sec, ami_timesep(), m, ami_timesep(), h);
+            sprintf(buf, "%02d%c%02d%c%02d", sec, ami_timesep(), m, ami_timesep(), h);
             break;
 
     }
-    if (pm) strcat(s, " pm");
-    if (am) strcat(s, " am");
-    *s = 0; /* terminate string */
+    if (pm) strcat(buf, " pm");
+    if (am) strcat(buf, " am");
+    cpycrit(s, sl, buf); /* copy result to critical buffer */
 
 }
 
@@ -562,7 +588,8 @@ void ami_times(
 
 Get date string
 
-Converts the given date into a string.
+Converts the given date into a string. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -588,6 +615,7 @@ void ami_dates(
     short yd;   /* years in day holder */
     int done;   /* loop complete flag */
     int days[12];   /* days in months */
+    bufstr buf; /* buffer to build result in */
 
     days[0] = 31;   /* january */
     days[1] = 28;   /* february-leap day */
@@ -602,8 +630,6 @@ void ami_dates(
     days[10] = 30;   /* november */
     days[11] = 31;   /* december */
 
-    if (sl < 10) /* string to small to hold result */
-        error("*** String to small to hold date");
     if (t < 0) y = 1999; else y = 2000; /* set initial year */
     done = 0;   /* set no loop exit */
     t = labs(t);   /* find seconds magnitude */
@@ -637,29 +663,30 @@ void ami_dates(
 
     }
     /* place year/month/day */
+    buf[0] = 0; /* clear result */
     switch (ami_dateorder()) { /* place according to current location format */
 
         case 1:
-            s += sprintf(s, "%04d%c%02d%c%02d", y, ami_datesep(), m, ami_datesep(), d);
+            sprintf(buf, "%04d%c%02d%c%02d", y, ami_datesep(), m, ami_datesep(), d);
             break;
         case 2:
-            s += sprintf(s, "%04d%c%02d%c%02d", y, ami_datesep(), d, ami_datesep(), m);
+            sprintf(buf, "%04d%c%02d%c%02d", y, ami_datesep(), d, ami_datesep(), m);
             break;
         case 3:
-            s += sprintf(s, "%02d%c%02d%c%04d", m, ami_datesep(), d, ami_datesep(), y);
+            sprintf(buf, "%02d%c%02d%c%04d", m, ami_datesep(), d, ami_datesep(), y);
             break;
         case 4:
-            s += sprintf(s, "%02d%c%04d%c%02d", m, ami_datesep(), y, ami_datesep(), d);
+            sprintf(buf, "%02d%c%04d%c%02d", m, ami_datesep(), y, ami_datesep(), d);
             break;
         case 5:
-            s += sprintf(s, "%02d%c%02d%c%04d", d, ami_datesep(), m, ami_datesep(), y);
+            sprintf(buf, "%02d%c%02d%c%04d", d, ami_datesep(), m, ami_datesep(), y);
             break;
         case 6:
-            s += sprintf(s, "%02d%c%04d%c%02d", d, ami_datesep(), y, ami_datesep(), m);
+            sprintf(buf, "%02d%c%04d%c%02d", d, ami_datesep(), y, ami_datesep(), m);
             break;
 
     }
-    *s = 0; /* terminate string */
+    cpycrit(s, sl, buf); /* copy result to critical buffer */
 
 }
 
@@ -928,7 +955,9 @@ static void fndenv(
 
 Get environment string
 
-Returns an environment string by name.
+Returns an environment string by name. An unfound string returns empty. The
+result may occupy the entire buffer, in which case the terminating zero is left
+off (critical buffer convention).
 
 *******************************************************************************/
 
@@ -941,14 +970,8 @@ void ami_getenv(
 
     ami_envrec *p;
 
-    *esd = 0;
     fndenv(esn, &p);
-    if (p) {
-
-        if (strlen(p->data)+1 > esdl) error("String too large for destination");
-        if (p) strcpy(esd, p->data);
-
-    }
+    cpycrit(esd, esdl, p? p->data: ""); /* copy result to critical buffer */
 
 }
 
@@ -1361,7 +1384,9 @@ void ami_execew(
 
 Get current path
 
-Returns the current path in the given padded string.
+Returns the current path in the given padded string. The result may occupy the
+entire buffer, in which case the terminating zero is left off (critical buffer
+convention).
 
 ********************************************************************************/
 
@@ -1380,8 +1405,7 @@ void ami_getcur(
      we ignore that, since having a zero length current directory should be
      impossible. */
    if (!r) winerr(); /* process windows error */
-   if (r+1 > l) error("Current directory too long for string");
-   strcpy(pn, pb); /* copy into place */
+   cpycrit(pn, l, pb); /* copy result to critical buffer */
 
 }
 
@@ -1427,6 +1451,9 @@ consider "." to be a special character, but if the brknam and maknam procedures
 are properly paired, it will effectively be treated the same as if the "."
 were a normal character.
 
+Each result may occupy its entire buffer, in which case the terminating zero
+is left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_brknam(
@@ -1438,13 +1465,14 @@ void ami_brknam(
 
 {
 
-    int i, s, f, t; /* string indexes */
     char *s1, *s2, *t2;
+    bufstr lp, ln, le; /* local component holding buffers */
+    long l;
 
     /* clear all strings */
-    *p = 0;
-    *n = 0;
-    *e = 0;
+    lp[0] = 0;
+    ln[0] = 0;
+    le[0] = 0;
     if (!strlen(fn)) error("File specification is empty");
     s1 = fn; /* index file spec */
     /* skip spaces */
@@ -1459,16 +1487,11 @@ void ami_brknam(
     if (s2) {
 
         /* there was a path, store that */
-        while (s1 <= s2) {
-
-            if (!pl) error("String to large for destination\n");
-            *p++ = *s1++;
-            pl--;
-
-        }
-        if (!nl) error("String to large for destination\n");
-        *p = 0;
-        /* now s1 points after path */
+        l = s2-s1+1; /* find length of path section */
+        if (l >= MAXSTR) error("String too large for destination");
+        memcpy(lp, s1, l);
+        lp[l] = 0;
+        s1 = s2+1; /* now s1 points after path */
 
     }
     /* keep any leading '.' characters from fooling extension finder */
@@ -1479,33 +1502,32 @@ void ami_brknam(
     if (s2) {
 
         /* there was a name, store that */
-        while (s1 < s2) {
-
-            if (!nl) error("String to large for destination\n");
-            *n++ = *s1++;
-            nl--;
-
-        }
-        if (!nl) error("String to large for destination\n");
-        *n = 0;
-        /* now s1 points to extension or nothing */
+        l = s2-s1; /* find length of name section */
+        if (l >= MAXSTR) error("String too large for destination");
+        memcpy(ln, s1, l);
+        ln[l] = 0;
+        s1 = s2; /* now s1 points to extension or nothing */
 
     } else {
 
         /* no extension */
-        if (strlen(s1)+1 > nl) error("String to large for destination\n");
-        strcpy(n, s1);
+        if (strlen(s1) >= MAXSTR) error("String too large for destination");
+        strcpy(ln, s1);
         while (*s1) s1++;
 
     }
     if (*s1 == '.') {
 
         /* there is an extension */
-        if (strlen(s1)+1 > el) error("String to large for destination\n");
         s1++; /* skip '.' */
-        strcpy(e, s1);
+        if (strlen(s1) >= MAXSTR) error("String too large for destination");
+        strcpy(le, s1);
 
     }
+    /* copy results to critical buffers */
+    cpycrit(p, pl, lp);
+    cpycrit(n, nl, ln);
+    cpycrit(e, el, le);
 
 }
 
@@ -1515,7 +1537,8 @@ Make specification
 
 Creates a file specification from its components, the path, name and extention.
 We make sure that the path is properly terminated with ':' or '\' before
-concatenating.
+concatenating. The result may occupy the entire buffer, in which case the
+terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1528,35 +1551,36 @@ void ami_maknam(
 )
 {
 
-    int  i;    /* index for string */
-    int  fsi;  /* index for output filename */
-    char s[2]; /* path character buffer */
+    int    i;    /* index for string */
+    char   s[2]; /* path character buffer */
+    bufstr b;    /* buffer to build result in */
 
-    if (strlen(p) > fnl) error("String too large for destination");
-    strcpy(fn, p); /* place path */
+    if (strlen(p) >= MAXSTR) error("String too large for destination");
+    strcpy(b, p); /* place path */
     /* check path properly terminated; a '/' terminator counts, since the
        windows file APIs accept it as a separator (see brknam) */
     i = strlen(p);   /* find length */
     if (*p) /* not null */
         if (p[i-1] != ami_pthchr() && p[i-1] != '/') {
 
-        if (strlen(fn)+1 > fnl) error("String too large for destination");
+        if (strlen(b)+1 >= MAXSTR) error("String too large for destination");
         s[0] = ami_pthchr(); /* set up path character as string */
         s[1] = 0;
-        strcat(fn, s); /* add path separator */
+        strcat(b, s); /* add path separator */
 
     }
     /* terminate path */
-    if (strlen(fn)+strlen(n) > fnl) error("String too large for destination");
-    strcat(fn, n); /* place name */
+    if (strlen(b)+strlen(n) >= MAXSTR) error("String too large for destination");
+    strcat(b, n); /* place name */
     if (*e) {  /* there is an extension */
 
-        if (strlen(fn)+1+strlen(e) > fnl)
+        if (strlen(b)+1+strlen(e) >= MAXSTR)
             error("String too large for destination");
-        strcat(fn, "."); /* place '.' */
-        strcat(fn, e); /* place extension */
+        strcat(b, "."); /* place '.' */
+        strcat(b, e); /* place extension */
 
     }
+    cpycrit(fn, fnl, b); /* copy result to critical buffer */
 
 }
 
@@ -1566,7 +1590,10 @@ Make full file specification
 
 If the given file specification has a default path (the current path), then
 the current path is added to it. Essentially "normalizes" file specifications.
-No validity check is done. Garbage in, garbage out.
+No validity check is done. Garbage in, garbage out. The buffer is treated as
+critical in both directions: the input may fill the entire buffer without a
+terminating zero, and the result may occupy the entire buffer, in which case
+the terminating zero is left off.
 
 ********************************************************************************/
 
@@ -1578,8 +1605,21 @@ void ami_fulnam(
 
     /* file specification */
     bufstr p, n, e, ps;   /* filespec components */
+    bufstr fs;            /* copy of input file specification */
+    long l;               /* length of input */
 
-    ami_brknam(fn, p, MAXSTR, n, MAXSTR, e, MAXSTR);   /* break spec down */
+    /* copy input to local, since it may fill the entire buffer without a
+       terminating zero (critical buffer convention) */
+    l = 0;
+    while (l < fnl && fn[l]) {
+
+        if (l >= MAXSTR-1) error("String too large for destination");
+        fs[l] = fn[l];
+        l++;
+
+    }
+    fs[l] = 0; /* terminate */
+    ami_brknam(fs, p, MAXSTR, n, MAXSTR, e, MAXSTR);   /* break spec down */
     /* if the path is blank, then default to current */
     if (!*p) strcpy(p, ".");
     ami_getcur(ps, MAXSTR);   /* save current path */
@@ -1596,7 +1636,8 @@ void ami_fulnam(
 Get program path
 
 There is no direct call for program path. So we get the command line, and
-extract the program path from that.
+extract the program path from that. The result may occupy the entire buffer,
+in which case the terminating zero is left off (critical buffer convention).
 
 ********************************************************************************/
 
@@ -1608,6 +1649,7 @@ void ami_getpgm(
 
     char*  cp;           /* command line holder */
     bufstr cb;           /* command buffer */
+    bufstr pb;           /* path holding buffer */
     bufstr n, e;         /* path components */
     char   path[MAXPTH]; /* execution path */
     int    i;            /* index for path */
@@ -1621,38 +1663,48 @@ void ami_getpgm(
     r = GetModuleFileNameA(NULL, cb, MAXSTR);
     if (r > 0 && r < MAXSTR) {
 
-        ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */
-        if (*p) return; /* have the path */
+        ami_brknam(cb, pb, MAXSTR, n, MAXSTR, e, MAXSTR); /* break off the path */
+        if (*pb) {
+
+            cpycrit(p, pl, pb); /* copy result to critical buffer */
+            return; /* have the path */
+
+        }
 
     }
     cp = GetCommandLine(); /* get the command line */
     fstwrd(cp, cb, MAXSTR); /* get command */
-    ami_brknam(cb, p, pl, n, MAXSTR, e, MAXSTR); /* break off the path */
-    if (!*p) { /* no path provided, we must search for it */
+    ami_brknam(cb, pb, MAXSTR, n, MAXSTR, e, MAXSTR); /* break off the path */
+    if (!*pb) { /* no path provided, we must search for it */
 
         /* try current directory */
-        ami_getcur(p, pl); /* get current path */
-        ami_maknam(cb, MAXSTR, p, n, "exe"); /* construct name with that path */
+        ami_getcur(pb, MAXSTR); /* get current path */
+        ami_maknam(cb, MAXSTR, pb, n, "exe"); /* construct name with that path */
         if (!exists(cb)) { /* try search path */
 
-            ami_getenv("Path", path, MAXPTH);
+            /* getenv leaves an exactly fitting result unterminated, so hold
+               one byte back and keep the last byte zero */
+            path[MAXPTH-1] = 0;
+            ami_getenv("Path", path, MAXPTH-1);
             f = 0; /* set path not found */
             while (*path && !f) { /* search path */
 
                 i = strchr(path, ';')-path; /* find next path separator */
                 if (!i) { /* none, the rest is the path */
 
-                    strcpy(p, path); /* place all in path */
+                    if (strlen(path) >= MAXSTR)
+                        error("String too large for destination");
+                    strcpy(pb, path); /* place all in path */
                     *path = 0; /* clear the path */
 
                 } else { /* break off next segment */
 
-                    extract(p, pl, path, 0, i-1); /* place path */
+                    extract(pb, MAXSTR-1, path, 0, i-1); /* place path */
                     /* extract the rest as remainer */
-                    extract(path, MAXPTH, path, i+1, strlen(path));
+                    extract(path, MAXPTH-1, path, i+1, strlen(path));
 
                 }
-                ami_maknam(cb, MAXSTR, p, n, "exe"); /* construct name with that path */
+                ami_maknam(cb, MAXSTR, pb, n, "exe"); /* construct name with that path */
                 f = exists(cb); /* check that exists */
 
             }
@@ -1661,6 +1713,7 @@ void ami_getpgm(
         }
 
     }
+    cpycrit(p, pl, pb); /* copy result to critical buffer */
 
 }
 
@@ -1685,6 +1738,9 @@ should be used instead, or the current path as required. The filenames used
 with program and user paths should be unique in case they end up in the same
 directory.
 
+The result may occupy the entire buffer, in which case the terminating zero is
+left off (critical buffer convention).
+
 ********************************************************************************/
 
 void ami_getusr(
@@ -1696,26 +1752,37 @@ void ami_getusr(
 
     bufstr b, b1; /* buffer for result */
 
-    ami_getenv("USERPROFILE", b, MAXSTR);
+    /* getenv leaves an exactly fitting result unterminated, so hold one byte
+       back and keep the last byte zero */
+    b[MAXSTR-1] = 0;
+    ami_getenv("USERPROFILE", b, MAXSTR-1);
     /* HOME is the unix convention, but is commonly set on windows (msys,
        cygwin, git bash), and a program can set it to relocate the user
        path; honor it next */
-    if (!*b) ami_getenv("HOME", b, MAXSTR);
+    if (!*b) ami_getenv("HOME", b, MAXSTR-1);
     if (!*b) { /* not found */
 
-        ami_getenv("HOMEPATH", b, MAXSTR);
+        ami_getenv("HOMEPATH", b, MAXSTR-1);
         if (*b) {
 
             strcpy(b1, b); /* save that */
-            ami_getenv("HOMEDRIVE", b, MAXSTR);
-            if (*b) strcat(b, b1); /* combine */
+            ami_getenv("HOMEDRIVE", b, MAXSTR-1);
+            if (*b) { /* combine */
+
+                if (strlen(b)+strlen(b1) >= MAXSTR)
+                    error("String too large for destination");
+                strcat(b, b1);
+
+            }
 
         }
         if (!*b) { /* not found */
 
-            ami_getenv("USERNAME", b, MAXSTR);
+            ami_getenv("USERNAME", b, MAXSTR-1);
             if (*b) { /* path that */
 
+                if (strlen(b)+7 >= MAXSTR) /* prefix is 7 characters */
+                    error("String too large for destination");
                 strcpy(b1, b); /* copy */
                 strcpy(b, "\\users\\"); /* set prefix */
                 strcat(b, b1); /* combine */
@@ -1726,8 +1793,7 @@ void ami_getusr(
         }
 
     }
-    if (strlen(b) > fnl+1) error("String too large for destination");
-    strcpy(fn, b); /* copy into place */
+    cpycrit(fn, fnl, b); /* copy result to critical buffer */
 
 }
 
@@ -2149,7 +2215,9 @@ long ami_country(void)
 Find country identifier string
 
 Finds the identifier string for the given ISO 3166-1 country code. If the string
-does not fit into the string provided, an error results.
+does not fit into the string provided, an error results. The result may occupy
+the entire buffer, in which case the terminating zero is left off (critical
+buffer convention).
 
 3166-1 country codes are both numeric codes, 2 letter country codes, and 3
 letter country codes. We only use the 2 letter codes.
@@ -2435,8 +2503,7 @@ void ami_countrys(
     p = countrytab;
     while (p->countrynum && p->countrynum != c) p++;
     if (!p->countrynum) error("Country number invalid");
-    if (strlen(p->countrystr) > len) error("Country string too large for buffer");
-    strncpy(s, p->countrystr, len);
+    cpycrit(s, len, p->countrystr); /* copy result to critical buffer */
 
 }
 
@@ -2537,7 +2604,9 @@ long ami_language(void)
 Find language identifier string from language code
 
 Finds a language identifier string from a given language code. If the identifier
-string is too long for the string buffer, an error results.
+string is too long for the string buffer, an error results. The result may
+occupy the entire buffer, in which case the terminating zero is left off
+(critical buffer convention).
 
 The language codes are from the ISO 639-1 standard. It describes languages with
 2 and 3 letter codes. We use only the two letter codes here.
@@ -2757,8 +2826,7 @@ void ami_languages(char* s, long len, long l)
     p = langtab;
     while (p->langnum && p->langnum != l) p++;
     if (!p->langnum) error("Language number invalid");
-    if (strlen(p->langstr) > len) error("Language string too larg e for buffer");
-    strncpy(s, p->langstr, len);
+    cpycrit(s, len, p->langstr); /* copy result to critical buffer */
 
 }
 
@@ -3290,7 +3358,10 @@ static void ami_init_services()
 
     }
 
-    ami_getenv("Path", pthstr, MAXPTH); /* load up the current path */
+    /* load up the current path. getenv leaves an exactly fitting result
+       unterminated, so hold one byte back; the last byte stays zero from
+       static initialization */
+    ami_getenv("Path", pthstr, MAXPTH-1);
     trim(pthstr); /* make sure left aligned */
 
     /* set default language and country */

--- a/windows/sound.c
+++ b/windows/sound.c
@@ -300,6 +300,30 @@ static void error(const string s)
 
 /*******************************************************************************
 
+Copy string to critical output buffer
+
+Copies the given source string to a caller supplied output buffer. Output
+buffers follow the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
+
+*******************************************************************************/
+
+static void cpycrit(char* d, long dl, const char* s)
+
+{
+
+    long l;
+
+    l = strlen(s); /* find length of source */
+    if (l > dl) error("String too large for destination");
+    memcpy(d, s, l); /* copy string into place */
+    if (l < dl) d[l] = 0; /* terminate if shorter than buffer */
+
+}
+
+/*******************************************************************************
+
 Find path separator character
 
 Returns the character used to separate filename path sections.
@@ -3554,7 +3578,10 @@ dbg_printf(dlinfo, "wBitsPerSample: %d\n", wf.wBitsPerSample);
 
 Find device name of synthesizer output port
 
-Returns the ALSA device name of the given synthsizer output port.
+Returns the device name of the given synthsizer output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -3567,8 +3594,7 @@ void ami_synthoutname(long p, string name, long len)
 
     r = midiOutGetDevCaps(p-1, &pmoc, sizeof(MIDIOUTCAPS));
     if (r != MMSYSERR_NOERROR) error("Unable to get Midi device capabilities");
-    if (strlen(pmoc.szPname)+1 > len) error("String to large for destination");
-    strcpy(name, pmoc.szPname);
+    cpycrit(name, len, pmoc.szPname); /* return name */
 
 }
 
@@ -3576,7 +3602,10 @@ void ami_synthoutname(long p, string name, long len)
 
 Find device name of synthesizer input port
 
-Returns the ALSA device name of the given synthsizer input port.
+Returns the device name of the given synthsizer input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -3589,8 +3618,7 @@ void ami_synthinname(long p, string name, long len)
 
     r = midiInGetDevCaps(p-1, &pmic, sizeof(MIDIINCAPS));
     if (r != MMSYSERR_NOERROR) error("Unable to get Midi device capabilities");
-    if (strlen(pmic.szPname)+1 > len) error("String to large for destination");
-    strcpy(name, pmic.szPname);
+    cpycrit(name, len, pmic.szPname); /* return name */
 
 }
 
@@ -3598,7 +3626,10 @@ void ami_synthinname(long p, string name, long len)
 
 Find device name of wave output port
 
-Returns the ALSA device name of the given wave output port.
+Returns the device name of the given wave output port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -3611,8 +3642,7 @@ void ami_waveoutname(long p, string name, long len)
 
     r = waveOutGetDevCaps(p-1, &pwoc, sizeof(WAVEOUTCAPS));
     if (r != MMSYSERR_NOERROR) error("Unable to get wave device capabilities");
-    if (strlen(pwoc.szPname)+1 > len) error("String to large for destination");
-    strcpy(name, pwoc.szPname);
+    cpycrit(name, len, pwoc.szPname); /* return name */
 
 }
 
@@ -3620,7 +3650,10 @@ void ami_waveoutname(long p, string name, long len)
 
 Find device name of wave input port
 
-Returns the ALSA device name of the given wave input port.
+Returns the device name of the given wave input port. The name is
+returned by the critical buffer convention: a result that fills the entire
+buffer is not zero terminated, a shorter result is zero terminated, and it is
+an error if the result cannot fit.
 
 *******************************************************************************/
 
@@ -3633,8 +3666,7 @@ void ami_waveinname(long p, string name, long len)
 
     r = waveInGetDevCaps(p-1, &pwic, sizeof(WAVEINCAPS));
     if (r != MMSYSERR_NOERROR) error("Unable to get Midi device capabilities");
-    if (strlen(pwic.szPname)+1 > len) error("String to large for destination");
-    strcpy(name, pwic.szPname);
+    cpycrit(name, len, pwic.szPname); /* return name */
 
 }
 
@@ -4026,7 +4058,9 @@ Get device parameter synth out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -4047,7 +4081,9 @@ Get device parameter synth in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -4068,7 +4104,9 @@ Get device parameter wave out
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.
@@ -4089,7 +4127,9 @@ Get device parameter wave in
 
 Reads a device parameter by name. Device parameters are strings indexed by name.
 The device parameter is returned if it exists, otherwise an empty string is
-returned.
+returned. The value is returned by the critical buffer convention: a result
+that fills the entire buffer is not zero terminated, a shorter result is zero
+terminated, and it is an error if the result cannot fit.
 
 Device parameters are generally implemented for plug-ins only. The set of
 parameters implemented on a particular device are dependent on that device.


### PR DESCRIPTION
Closes #7.

## Summary

Every API routine that fills a caller-supplied string buffer `(char* buf, long len)` now follows the **critical buffer** convention:

- the result may occupy the **entire** buffer, in which case the terminating zero is left off;
- results shorter than the buffer are zero terminated;
- it is an error if the result cannot fit.

This lets non-C callers pass fixed-size buffers with no room reserved for a terminator, per the issue. C callers should use length-limited reads of these buffers (`strnlen` and friends), as the header banners now document.

## Implementation

- A small static `cpycrit(dest, destlen, src)` helper per implementation file, wired to that file's error mechanism.
- **Covered routines**: services — times, dates, getenv, getcur, brknam (3 outputs), maknam, fulnam (in/out), getpgm, getusr, countrys, languages; graphics — fontnam, getwidgettext, queryopen, querysave, queryfind, queryfindrep; sound — the four device-name getters, four parameter getters, and the plug-in getparam vectors; network — certnet/certmsg (explicit length return unchanged; they now terminate only when shorter than the buffer).
- **Platforms**: linux, windows, macosx, stubs, plus the GNOME widget layer and the Cocoa dialog plumbing (bridge contract unchanged; the critical copy happens at the graphics.c boundary).
- The convention is documented in the services/graphics/sound/network header banners and in each converted routine's comment block.
- Internal library code that reads these buffers back was made safe: gnome_widgets uses a terminating wrapper (`getwidgettextz`), services reserves one byte on internal getenv calls, and `ami_fulnam` explicitly accepts an unterminated exact-fit input.

## Real bugs fixed by the sweep

- `ami_getusr` ignored its length bound entirely on linux (unbounded strcpy) and allowed a 2-byte overflow on windows
- `fontnam` had an off-by-two overrun on both linux and windows
- The four windows query dialogs wrote the NUL one byte past the buffer on exact-fit results; `getwidgettext` silently truncated instead of erroring
- `brknam` checked the wrong length variable when terminating the path component on both platforms; `maknam` had off-by-one NUL writes
- macosx device-name getters truncated silently with no error; macosx widget text could copy uninitialized bytes when a widget was not an NSControl
- **Visible behavior change**: `ami_times`' " pm" suffix was being erased by a stray `*s = 0` on linux and windows — pm times now carry the suffix in 12-hour locales

## Pre-existing issues found during the sweep

Filed separately as #159–#172 (BIO leak, `ami_setenv` heap bugs, internal path handling, pitch-bend scaling, managerc/gnome_widgets defects, libc/stdio.h format attributes, and more).

## Verification

- Full linux `make all`: zero errors, zero warnings
- Runtime: stdio_test (800+ self checks), services_test, network_test loopback suite (TLS/DTLS/messages/certs) all pass
- A guard-byte runtime test confirmed exact-fit fills stay in bounds and omit the NUL, and shorter results are terminated
- All five windows sources cross-compile clean under mingw-w64; macosx verified structurally (no Apple toolchain here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to