### PR TITLE
services: decode child status in ami_execw/ami_execew

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -1384,7 +1384,10 @@ void ami_exec(
 
 Execute program with wait
 
-Executes a program by name. Waits for the program to complete.
+Executes a program by name. Waits for the program to complete. The returned
+error is 0 for success, the program exit code for a normal exit, or
+128+signal if the program was terminated by a signal (shell convention), so
+an abnormal termination is always nonzero.
 
 ********************************************************************************/
 
@@ -1430,7 +1433,11 @@ void ami_execw(
         int ws; /* wait status (system type) */
 
         waitpid(pid, &ws, 0);
-        *err = WEXITSTATUS(ws);
+        /* WEXITSTATUS is only valid after a normal exit; a signal death
+           leaves the exit code byte 0, which would read as success */
+        if (WIFEXITED(ws)) *err = WEXITSTATUS(ws);
+        else if (WIFSIGNALED(ws)) *err = 128+WTERMSIG(ws);
+        else *err = 128;
 
     }
 
@@ -1490,7 +1497,9 @@ void ami_exece(
 Execute program with environment and wait
 
 Executes a program by name. Waits for the program to complete. Supplies the
-program environment.
+program environment. The returned error is 0 for success, the program exit
+code for a normal exit, or 128+signal if the program was terminated by a
+signal (shell convention), so an abnormal termination is always nonzero.
 
 ********************************************************************************/
 
@@ -1535,7 +1544,11 @@ void ami_execew(
         int ws; /* wait status (system type) */
 
         waitpid(pid, &ws, 0);
-        *err = ws;
+        /* decode the status word the same way as ami_execw: the raw word
+           would report a normal exit(1) as 256 */
+        if (WIFEXITED(ws)) *err = WEXITSTATUS(ws);
+        else if (WIFSIGNALED(ws)) *err = 128+WTERMSIG(ws);
+        else *err = 128;
 
     }
 


### PR DESCRIPTION
Closes #124.

`ami_execw` applied `WEXITSTATUS` without checking `WIFEXITED`, so a child that died from a signal (segfault, abort, kill) reported 0 — success. This is the bug that let a crashed pcom slip through Pascal-P6's `pc` build driver. `ami_execew` had the inverse defect: it stored the raw `waitpid` status word, so a normal `exit(1)` reported as 256.

Both parent branches now decode identically per the shell convention: `WIFEXITED` → exit code, `WIFSIGNALED` → 128+signal, else 128 — abnormal termination is always nonzero. Doc banners state the contract. macOS builds from this file and inherits the fix; windows already returns nonzero on crash via `GetExitCodeProcess`, so the platforms now agree on "crash ⇒ nonzero".

Verified: direct harness (segfault child → 139, `exit(3)` → 3 through both variants), `make all` clean, `bin/regress` 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to