### PR TITLE
joystick: soft fallback when absent or disconnected (all platforms)

### DIFF
--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -12281,8 +12281,23 @@ static void joyevt(ami_evtrec* er, int* keep, joyptr jp)
 
 #if !defined(__MACH__) && !defined(__FreeBSD__) /* Mac OS X */
     struct js_event ev;
+    ssize_t rl;
 
-    read(jp->fid, &ev, sizeof(ev)); /* get next joystick event */
+    if (jp->fid < 0) return; /* joystick already disconnected */
+    rl = read(jp->fid, &ev, sizeof(ev)); /* get next joystick event */
+    if (rl != sizeof(ev)) {
+
+        /* The joystick was disconnected: an end of file input is permanently
+           ready, so stop monitoring it or the event loop would spin. The
+           joystick keeps its logical number, but delivers no further events
+           or positions */
+        system_event_deaseinp(jp->sid);
+        close(jp->fid);
+        jp->fid = -1;
+
+        return;
+
+    }
     if (!(ev.type & JS_EVENT_INIT)) {
 
         if (ev.type & JS_EVENT_BUTTON) {

--- a/linux/system_event.c
+++ b/linux/system_event.c
@@ -26,6 +26,13 @@
 * Registers an input file to be monitored for input ready, or one or more      *
 * bytes ready to read. The logical system event number is returned.            *
 *                                                                              *
+* void system_event_deaseinp(int sid);                                         *
+*                                                                              *
+* Deactivates the input monitor with the given system event number. Used when  *
+* the underlying device goes away, such as a joystick disconnect, since an     *
+* end of file input is otherwise permanently ready and would spin the event    *
+* loop.                                                                        *
+*                                                                              *
 * int system_event_addsesig(int sig);                                          *
 *                                                                              *
 * Registers a signal to be monitored. A handler is also registered, and sends  *
@@ -227,6 +234,41 @@ int system_event_addseinp(int fid)
     kill(pid, SIGUSR1);
 
     return (sid); /* exit with logical event id */
+
+}
+
+/** *****************************************************************************
+
+Deactivate input event
+
+Deactivates the input monitor with the given system event number. Used when
+the underlying device goes away, such as a joystick disconnect: an end of
+file input is permanently ready, so leaving it registered would spin the
+event loop. The entry keeps its logical number but never fires again.
+
+*******************************************************************************/
+
+void system_event_deaseinp(int sid)
+
+{
+
+    pthread_mutex_lock(&evtlock); /* take the event lock */
+    if (sid <= 0 || !systab[sid-1] || systab[sid-1]->typ != se_inp) {
+
+        pthread_mutex_unlock(&evtlock); /* release the event lock */
+        fprintf(stderr, "*** System event: Invalid system event id\n");
+        fflush(stderr);
+        exit(1);
+
+    }
+    if (systab[sid-1]->fid >= 0) {
+
+        FD_CLR(systab[sid-1]->fid, &ifdseta); /* remove from active set */
+        FD_CLR(systab[sid-1]->fid, &ifdsets); /* and any pending set */
+        systab[sid-1]->fid = -1; /* mark input dead */
+
+    }
+    pthread_mutex_unlock(&evtlock); /* release the event lock */
 
 }
 

--- a/linux/system_event.h
+++ b/linux/system_event.h
@@ -30,6 +30,7 @@ typedef struct sysevt {
 } sysevt;
 
 int system_event_addseinp(int fid);
+void system_event_deaseinp(int sid);
 int system_event_addsesig(int sig);
 int system_event_addsetim(int sid, long t, long r);
 void system_event_deasetim(int sid);

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -2083,8 +2083,23 @@ static void joyevt(ami_evtrec* er, joyptr jp)
 
 #if !defined(__MACH__) && !defined(__FreeBSD__) /* Mac OS X or BSD */
     struct js_event ev;
+    ssize_t rl;
 
-    read(jp->fid, &ev, sizeof(ev)); /* get next joystick event */
+    if (jp->fid < 0) return; /* joystick already disconnected */
+    rl = read(jp->fid, &ev, sizeof(ev)); /* get next joystick event */
+    if (rl != sizeof(ev)) {
+
+        /* The joystick was disconnected: an end of file input is permanently
+           ready, so stop monitoring it or the event loop would spin. The
+           joystick keeps its logical number, but delivers no further events
+           or positions */
+        system_event_deaseinp(jp->sid);
+        close(jp->fid);
+        jp->fid = -1;
+
+        return;
+
+    }
     if (!(ev.type & JS_EVENT_INIT)) {
 
         if (ev.type & JS_EVENT_BUTTON) {

--- a/macosx/system_event.c
+++ b/macosx/system_event.c
@@ -25,6 +25,11 @@
 *                                                                              *
 * int system_event_addseinp(int fid);                                          *
 *                                                                              *
+* void system_event_deaseinp(int sid);                                         *
+*                                                                              *
+* Deactivates the input monitor with the given system event number. Used when  *
+* the underlying device goes away, such as a joystick disconnect.              *
+*                                                                              *
 * Registers an input file to be monitored for input ready, or one or more      *
 * bytes ready to read. The logical system event number is returned.            *
 *                                                                              *
@@ -247,6 +252,57 @@ int system_event_addseinp(int fid)
     kill(pid, SIGUSR1);
 
     return (sid); /* exit with logical event id */
+
+}
+
+/** *****************************************************************************
+
+Deactivate input event
+
+Deactivates the input monitor with the given system event number. Used when
+the underlying device goes away, such as a joystick disconnect: an end of
+file input is permanently ready, so leaving it registered would spin the
+event loop. The entry keeps its logical number but never fires again. The
+change list entry is removed and the list compacted, since the wait loop
+re-applies the full change list on every call.
+
+*******************************************************************************/
+
+void system_event_deaseinp(int sid)
+
+{
+
+    struct kevent ke; /* single change entry */
+    int           ci; /* change list index */
+    int           si; /* system table index */
+
+    pthread_mutex_lock(&evtlock); /* take the event lock */
+    if (sid <= 0 || !systab[sid-1] || systab[sid-1]->typ != se_inp) {
+
+        pthread_mutex_unlock(&evtlock); /* release the event lock */
+        fprintf(stderr, "*** System event: Invalid system event id\n");
+        fflush(stderr);
+        exit(1);
+
+    }
+    if (systab[sid-1]->fid >= 0) {
+
+        /* remove the filter from the kqueue now */
+        EV_SET(&ke, systab[sid-1]->fid, EVFILT_READ, EV_DELETE, 0, 0, 0);
+        kevent(kerque, &ke, 1, NULL, 0, NULL);
+        /* remove the registration from the change list and compact,
+           relinking the entries that moved down */
+        ci = systab[sid-1]->ei;
+        while (ci < nchg-1) { chgevt[ci] = chgevt[ci+1]; ci++; }
+        nchg--;
+        for (si = 0; si < MAXSYS; si++)
+            if (systab[si] && systab[si]->ei > systab[sid-1]->ei)
+                systab[si]->ei--;
+        systab[sid-1]->ei = -1; /* unlink */
+        systab[sid-1]->fid = -1; /* mark input dead */
+
+    }
+    pthread_mutex_unlock(&evtlock); /* release the event lock */
 
 }
 

--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -9120,7 +9120,8 @@ long ami_joystick(FILE* f)
 
 Return number of buttons on a joystick
 
-Returns the number of buttons on a given joystick.
+Returns the number of buttons on a given joystick. Returns 0 if the joystick
+cannot be accessed, as when it has been disconnected.
 
 *******************************************************************************/
 
@@ -9137,7 +9138,15 @@ long ami_joybutton(FILE* f, long j)
     win = txt2win(f); /* get window pointer from text file */
     if (j < 1 || j > win->numjoy) error(einvjoy); /* bad joystick id */
     r = joyGetDevCaps(j-1, &jc, sizeof(JOYCAPS));
-    if (r != JOYERR_NOERROR) error(ejoyqry); /* could not access joystick */
+    if (r != JOYERR_NOERROR) {
+
+        /* a registered joystick that cannot be accessed was disconnected;
+           report no buttons rather than stopping the program */
+        unlockmain(); /* end exclusive access */
+
+        return (0);
+
+    }
     nb = jc.wNumButtons; /* set number of buttons */
     /* We don't support more than 4 buttons. */
     if (nb > 4) nb = 4;
@@ -9153,7 +9162,8 @@ Return number of axies on a joystick
 
 Returns the number of axies implemented on a joystick, which can be 1 to 3.
 The axies order of implementation is x, y,  z. Typically, a monodimensional
-joystick can be considered a slider without positional meaning.
+joystick can be considered a slider without positional meaning. Returns 0 if the
+joystick cannot be accessed, as when it has been disconnected.
 
 *******************************************************************************/
 
@@ -9167,7 +9177,9 @@ static long ijoyaxis(winptr win, long j)
 
     if (j < 1 || j > win->numjoy) error(einvjoy); /* bad joystick id */
     r = joyGetDevCaps(j-1, &jc, sizeof(JOYCAPS));
-    if (r != JOYERR_NOERROR) error(ejoyqry); /* could not access joystick */
+    /* a registered joystick that cannot be accessed was disconnected;
+       report no axes rather than stopping the program */
+    if (r != JOYERR_NOERROR) return (0);
     na = jc.wNumAxes; /* set number of axes */
     /* We don"t support more than 3 axes. */
     if (na > 3) na = 3;
@@ -10492,19 +10504,11 @@ static void clswin(int fn)
     win = lfn2win(fn); /* get a pointer to the window */
     b = ReleaseDC(win->winhan, win->devcon); /* release device context */
     if (!b) winerr(); /* process error */
-    /* release the joysticks */
-    if (win->joy1cap) {
-
-        r = joyReleaseCapture(JOYSTICKID1);
-        if (r) error(ejoyacc); /* error */
-
-    }
-    if (win->joy2cap) {
-
-        r = joyReleaseCapture(JOYSTICKID2);
-        if (r) error(ejoyacc); /* error */
-
-    }
+    /* release the joysticks; a release can fail if the joystick was
+       disconnected while captured, which is not an error worth stopping
+       the program at window close */
+    if (win->joy1cap) r = joyReleaseCapture(JOYSTICKID1);
+    if (win->joy2cap) r = joyReleaseCapture(JOYSTICKID2);
     kilwin(win->winhan); /* kill window */
 
 }

--- a/windows/terminal.c
+++ b/windows/terminal.c
@@ -2556,7 +2556,8 @@ long ami_joystick(FILE* f)
 
 Return number of buttons on a joystick
 
-Returns the number of buttons on a given joystick.
+Returns the number of buttons on a given joystick. Returns 0 if the joystick
+cannot be accessed, as when it has been disconnected.
 
 *******************************************************************************/
 
@@ -2570,7 +2571,9 @@ static long ijoybutton(long j)
 
     if (j < 1 || j > numjoy) error(einvjoy); /* bad joystick id */
     r = joyGetDevCaps(j-1, &jc, sizeof(JOYCAPS));
-    if (r) error(ejoyqry); /* could not access joystick */
+    /* a registered joystick that cannot be accessed was disconnected;
+       report no buttons rather than stopping the program */
+    if (r) return (0);
     nb = jc.wNumButtons; /* set number of buttons */
     /* We don't support more than 4 buttons. */
     if (nb > 4) nb = 4;
@@ -2593,7 +2596,8 @@ Return number of axies on a joystick
 
 Returns the number of axies implemented on a joystick, which can be 1 to 3.
 The axies order of implementation is x, y, then z. Typically, a monodementional
-joystick can be considered a slider without positional meaning.
+joystick can be considered a slider without positional meaning. Returns 0 if the
+joystick cannot be accessed, as when it has been disconnected.
 
 *******************************************************************************/
 
@@ -2607,7 +2611,9 @@ long ami_joyaxis(FILE* f, long j)
 
     if (j < 1 || j > numjoy) error(einvjoy); /* bad joystick id */
     r = joyGetDevCaps(j-1, &jc, sizeof(JOYCAPS));
-    if (r) error(ejoyqry); /* could not access joystick */
+    /* a registered joystick that cannot be accessed was disconnected;
+       report no axes rather than stopping the program */
+    if (r) return (0);
     axis = jc.wNumAxes; /* set number of axes */
     /* We don't support more than 4 buttons. */
     if (axis > 3) axis = 3;


### PR DESCRIPTION
Closes #139.

The requested general contract: if the joystick open fails during init, a flag stays clear and the joystick is simply not registered — `ami_joystick()` reports none, no positions are delivered, nothing stops. And a stick that vanishes *after* init must degrade the same way.

**Init path** — already conforming everywhere: linux (failed `/dev/input/jsN` open → not counted, `joyenb` config flag), macosx (GameController count, invalid ids return 0), windows (`joyenb` + per-stick capture flags on both terminal and graphics).

**Windows query/release path** (commit 1) — the hard-error sites, reachable when a stick disconnected after capture:
- `windows/terminal.c` `ijoybutton`/`ami_joyaxis` and `windows/graphics.c` `ami_joybutton`/`ijoyaxis`: `joyGetDevCaps` failure raised `ejoyqry` and aborted — now report 0 buttons/axes (banners updated).
- `windows/graphics.c` `clswin`: `joyReleaseCapture` failure raised `ejoyacc` at window close — now ignored.

**Linux mid-run disconnect** (commit 2) — no hard error, but a silent livelock: `joyevt()` never checked its `read()` result, and an EOF fd is permanently select-ready, so an unplugged stick spun the event loop with garbage `js_event` data.
- `system_event` gains `system_event_deaseinp(sid)`, the input counterpart of `deasetim`: removes the fd from the monitored sets (linux pselect; macosx kqueue filter delete + change-list compaction, since the wait re-applies the change list).
- `joyevt` in linux/terminal.c and linux/graphics.c checks the read length; on a short read the joystick is deregistered, its fd closed and marked dead. It keeps its logical number but delivers no further events or positions.

Out-of-range joystick ids still raise `einvjoy` (caller error, not a device condition). Positions need no other change on windows — capture messages simply stop.

Verified: full linux `make all` clean, `bin/regress` 3/3, windows sources cross-compile clean under mingw-w64. macosx portion is structurally checked only (mac's terminal joystick path is compiled out; `deaseinp` exists there for API symmetry). Physical unplug testing needs real hardware on each platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to