### PR TITLE
widgets: selectwidget accepted on all widgets, rendered on buttons

### DIFF
--- a/macosx/graphics_cocoa.m
+++ b/macosx/graphics_cocoa.m
@@ -2402,8 +2402,16 @@ void pa_cocoa_widget_select(pa_winhan win, int id, int on)
 {
     run_on_main(^{
         NSView* v = find_widget(win, id);
-        if (v && [v isKindOfClass:[NSButton class]])
-            [(NSButton*)v setState:(on ? NSControlStateValueOn : NSControlStateValueOff)];
+        if (v && [v isKindOfClass:[NSButton class]]) {
+            NSButton* b = (NSButton*)v;
+            /* A momentary push button does not render its state; convert it
+               to push-on/push-off the first time a select is applied so the
+               pressed-in look persists. Checkboxes and radios already show
+               state (nonzero showsStateBy) and are left alone. */
+            if ([[b cell] showsStateBy] == 0)
+                [b setButtonType:NSButtonTypePushOnPushOff];
+            b.state = on ? NSControlStateValueOn : NSControlStateValueOff;
+        }
     });
 }
 

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -1388,8 +1388,9 @@ static void button_draw(
 
 {
 
-    /* color the background */
-    if (wg->pressed) fcolort(wg->wf, th_backpressed);
+    /* color the background; a selected button keeps the pressed in look,
+       giving a persistent active state for modal buttons */
+    if (wg->pressed || wg->select) fcolort(wg->wf, th_backpressed);
     else fcolort(wg->wf, th_back);
     ami_frect(wg->wf, 1, 1, ami_maxxg(wg->wf),
               ami_maxyg(wg->wf));
@@ -3891,7 +3892,10 @@ static void ikillwidget(
 
 Select/deselect widget
 
-Selects or deselects a widget.
+Selects or deselects a widget. Any widget accepts and records the select
+state. Buttons render it as a persistent pressed in look, checkboxes and
+radio buttons as their check figure; widget kinds with no select rendering
+simply record the state.
 
 *******************************************************************************/
 
@@ -3907,13 +3911,9 @@ static void iselectwidget(
     long      chg; /* widget state changes */
 
     wp = fndwig(f, id); /* index the widget */
-    /* check this widget is selectable */
-    if (wp->typ != wtcheckbox && wp->typ != wtradiobutton && 
-        wp->typ != wtcbutton)
-        error("Widget is not selectable");
     chg = wp->select != !!e; /* check select state changes */
     wp->select = !!e; /* set select state */
-    /* if the select changes, refresh the checkbox */
+    /* if the select changes, refresh the widget */
     if (chg) widget_redraw(wp); /* send redraw to widget */
 
 }

--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -12308,7 +12308,10 @@ void ami_killwidget(FILE* f, long id)
 
 Select/deselect widget
 
-Selects or deselects a widget.
+Selects or deselects a widget. Any widget accepts the select state. Buttons
+render it as a persistent pressed in look, checkboxes and radio buttons as
+their check figure; widget kinds with no select rendering accept the call
+without effect.
 
 *******************************************************************************/
 
@@ -12317,16 +12320,35 @@ static void iselectwidget(winptr win, long id, long e)
 {
 
     wigptr wp;  /* widget entry */
-    int    r; /* return value */
+    int    r;   /* return value */
+    LONG   fl;  /* window style */
 
     if (!win->visible) winvis(win); /* make sure we are displayed */
     wp = fndwig(win, id); /* find widget */
     if (!wp) error(ewignf); /* not found */
-    /* check this widget is selectable */
-    if (wp->typ != wtcheckbox && wp->typ != wtradiobutton) error(ewigsel);
-    unlockmain(); /* end exclusive access */
-    r = SendMessage(wp->han, BM_SETCHECK, e, 0);
-    lockmain();/* start exclusive access */
+    if (wp->typ == wtbutton) {
+
+        /* A plain push button has no persistent select rendering. Restyle
+           it as a pushlike checkbox, which looks the same but holds a
+           pressed in look while checked. The check state is program
+           controlled, so clicks still just send button events */
+        unlockmain(); /* end exclusive access */
+        fl = GetWindowLong(wp->han, GWL_STYLE);
+        if (!(fl & BS_PUSHLIKE))
+            SetWindowLong(wp->han, GWL_STYLE,
+                          (fl & ~(LONG)0xf) | BS_CHECKBOX | BS_PUSHLIKE);
+        r = SendMessage(wp->han, BM_SETCHECK, !!e, 0);
+        lockmain();/* start exclusive access */
+
+    } else if (wp->typ == wtcheckbox || wp->typ == wtradiobutton) {
+
+        unlockmain(); /* end exclusive access */
+        r = SendMessage(wp->han, BM_SETCHECK, !!e, 0);
+        lockmain();/* start exclusive access */
+
+    }
+    /* other widget kinds have no select rendering; the call is accepted
+       without effect */
 
 }
 


### PR DESCRIPTION
Closes #156.

`selectwidget()` moves from "only some widgets" to all of them, per the survey on the issue: every implementation now accepts the call on any widget kind, and buttons — the ICD modal-tool-button use case — get a real persistent rendering:

- **gnome_widgets (linux)**: type restriction removed; every widget records `select` and redraws on change. A selected button draws with the pressed-in background (`th_backpressed`) — the same visual vocabulary as a press, and distinct from the focus ring the issue calls out as misleading.
- **windows**: on first select, a plain push button is restyled `BS_CHECKBOX | BS_PUSHLIKE` — visually identical, but holds the pressed-in look while checked. Deliberately not `BS_AUTOCHECKBOX`: the state stays program-controlled, so clicking still just sends the button event and the app's `selectwidget` calls decide the state (exactly the modal pattern). Checkbox/radio unchanged; other kinds accept the call without effect instead of raising `ewigsel`.
- **macosx**: momentary push buttons convert to push-on/push-off on first select (`showsStateBy == 0` guard leaves checkboxes/radios untouched) so `NSButton.state` actually renders. One platform quirk: macOS toggles the visual itself on click; the caller's post-event `selectwidget` calls settle it — acceptable for the modal use case, noted here for the record.
- **stub**: unchanged (errors "not implemented" by design).

ICD can reinstate its original `selectwidget` calls as-is.

Verified: full linux `make all` clean, `bin/regress` 3/3, windows cross-compile clean under mingw-w64. macosx structurally checked (no Apple toolchain here); the button treatments need an eyeball on real windows/mac to confirm the native looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to