### PR TITLE
widgets: full scale color unpack, no focus ring on disabled

### DIFF
--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -117,9 +117,12 @@ static enum { /* debug levels */
 #define BLUEP(v)  (v & 0xff)
 
 /* macros to unpack color table entries to LONG_MAX ratioed numbers */
-#define RED(v)   (LONG_MAX/256*REDP(v))   /* red */
-#define GREEN(v) (LONG_MAX/256*GREENP(v)) /* green */
-#define BLUE(v)  (LONG_MAX/256*BLUEP(v)) /* blue */
+/* Unpack a byte color component to the API full scale. Dividing by 255,
+   not 256, so a component of 0xff gives exactly LONG_MAX: the divide is
+   first, so the multiply cannot overflow */
+#define RED(v)   (LONG_MAX/255*REDP(v))   /* red */
+#define GREEN(v) (LONG_MAX/255*GREENP(v)) /* green */
+#define BLUE(v)  (LONG_MAX/255*BLUEP(v)) /* blue */
 
 /* default values for color table. Note these can be overridden.
  * To increase or decrease luminescence, add or subtract a BW() value from
@@ -1283,7 +1286,8 @@ static void cbutton_draw(
     ami_frrect(wg->wf, 1, 1, ami_maxxg(wg->wf), ami_maxyg(wg->wf), 20, 20);
     /* outline */
     ami_linewidth(wg->wf, 3);
-    if (wg->focus) fcolorp(wg->wf, wg->cbc->bof);
+    /* a disabled widget does not show the focus ring; see button_draw */
+    if (wg->focus && wg->enb) fcolorp(wg->wf, wg->cbc->bof);
     else fcolorp(wg->wf, wg->cbc->bon);
     ami_rrect(wg->wf, 2, 2, ami_maxxg(wg->wf)-1, ami_maxyg(wg->wf)-1, 20, 20);
     if (wg->enb) fcolorp(wg->wf, wg->cbc->btn);
@@ -1398,9 +1402,11 @@ static void button_draw(
     else fcolort(wg->wf, th_back);
     ami_frect(wg->wf, 1, 1, ami_maxxg(wg->wf),
               ami_maxyg(wg->wf));
-    /* outline */
+    /* Outline. A disabled widget does not show the focus ring: it cannot be
+       operated, so advertising focus on it misleads (windows denies focus to
+       disabled widgets outright) */
     ami_linewidth(wg->wf, 4);
-    if (wg->focus) fcolort(wg->wf, th_focus);
+    if (wg->focus && wg->enb) fcolort(wg->wf, th_focus);
     else fcolort(wg->wf, th_outline1);
     ami_rrect(wg->wf, 2, 2, ami_maxxg(wg->wf)-1,
              ami_maxyg(wg->wf)-1, 20, 20);

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -93,9 +93,10 @@
 #define BLUEP(v)  (v & 0xff)
 
 /* macros to unpack color table entries to LONG_MAX ratioed numbers */
-#define RED(v)   (LONG_MAX/256*REDP(v))   /* red */
-#define GREEN(v) (LONG_MAX/256*GREENP(v)) /* green */
-#define BLUE(v)  (LONG_MAX/256*BLUEP(v)) /* blue */
+/* unpack to full scale: divide by 255 so 0xff gives exactly LONG_MAX */
+#define RED(v)   (LONG_MAX/255*REDP(v))   /* red */
+#define GREEN(v) (LONG_MAX/255*GREENP(v)) /* green */
+#define BLUE(v)  (LONG_MAX/255*BLUEP(v)) /* blue */
 
 static const int colormap[] = {
 


### PR DESCRIPTION
Addresses items 3, 9 and 10 of #29 (widgets roundup). The remaining items are triaged in a comment on that issue.

- **Item 10** — `querycolor` of `$ffffff` did not give full-scale values. The `RED`/`GREEN`/`BLUE` unpack macros divided by 256, so a component of 255 produced 255/256 of `LONG_MAX` — 0.39% short of white, and never exactly full scale. Now divided by 255, mapping `0xff` to exactly `LONG_MAX`; the divide stays first so the multiply cannot overflow. The same macros in `tests/terminal_test.c` are corrected with them.
- **Item 3** — focus highlighting on disabled buttons: the focus ring now draws only when the widget is also enabled, for both public buttons and the internal dialog buttons. A disabled widget can't be operated, so showing focus on it misleads; Windows denies focus to disabled widgets outright.
- **Item 9** — already resolved in the current code: the widgets `error()` ends in `exit(1)`.

Verified: full build clean, regress 3/3. The visual items want an eyeball on a live display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to