### PR TITLE
widgets: theme values settable from the config file

### DIFF
--- a/petit_ami.cfg
+++ b/petit_ami.cfg
@@ -168,6 +168,55 @@ begin graphics
 end
 
 #
+# Definitions for widgets
+#
+begin widgets
+
+    #
+    # Theme values.
+    #
+    # Each entry overrides one point of the widget theme table. A color is
+    # written as three decimal components "red green blue" (0 to 255), or as
+    # a hex triplet "rrggbb" with an optional leading '#'. Theme points that
+    # are not colors take a plain number.
+    #
+    # Entries not listed keep their built in values, and an entry whose name
+    # is not a known theme point is ignored, so a config file written for a
+    # later version still loads here.
+    #
+    # The full set of names is the th_* list in portable/gnome_widgets.c with
+    # the "th_" prefix dropped. The common ones are shown below.
+    #
+    begin theme
+
+        # button background: normal, hovered, pressed
+        #back             252 252 252
+        #backhover        230 230 230
+        #backpressed      211 211 211
+
+        # button outline, focused outline, face text enabled and disabled
+        #outline1         149 149 149
+        #focus            53 132 228
+        #text             0 0 0
+        #textdis          146 149 149
+
+        # checkbox/radio button select figure and outline
+        #chkrad           53 132 228
+        #chkradout        205 199 194
+
+        # scrollbar background, bar, pressed bar
+        #scrollback       250 249 248
+        #scrollbar        126 126 126
+        #scrollbarpressed 86 86 86
+
+        # querycolor dialog palette, querycolor1 through querycolor36
+        #querycolor1      0 0 0
+
+    end
+
+end
+
+#
 # definitions for sound module
 #
 begin sound

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -8007,6 +8007,150 @@ static int iclose_nocancel(int fd)
 
 /** ****************************************************************************
 
+Theme point names
+
+The config file names for each theme table entry, in themeindex order. The
+"th_" prefix is dropped: theme point th_backpressed is written "backpressed"
+in the config file.
+
+*******************************************************************************/
+
+static const char* themnam[th_endmarker] = {
+
+    "backpressed", "back", "backhover", "outline1",
+    "text", "textdis", "focus", "chkrad",
+    "chkradout", "scrollback", "scrollbar", "scrollbarpressed",
+    "numseldiv", "numselud", "texterr", "proginacen",
+    "proginaedg", "progactcen", "progactedg", "lsthov",
+    "outline2", "droparrow", "droptext", "sldint",
+    "tabdis", "tabback", "tabsel", "tabfocus",
+    "cancelbackfocus", "canceltextfocus", "canceloutline", "selectbackfocus",
+    "selectback", "selecttextfocus", "selecttext", "selectoutline",
+    "selectoutlinefocus", "plusbackfocus", "plusback", "plustextfocus",
+    "plustext", "plusoutline", "plusoutlinefocus", "title",
+    "querycolor1", "querycolor2", "querycolor3", "querycolor4",
+    "querycolor5", "querycolor6", "querycolor7", "querycolor8",
+    "querycolor9", "querycolor10", "querycolor11", "querycolor12",
+    "querycolor13", "querycolor14", "querycolor15", "querycolor16",
+    "querycolor17", "querycolor18", "querycolor19", "querycolor20",
+    "querycolor21", "querycolor22", "querycolor23", "querycolor24",
+    "querycolor25", "querycolor26", "querycolor27", "querycolor28",
+    "querycolor29", "querycolor30", "querycolor31", "querycolor32",
+    "querycolor33", "querycolor34", "querycolor35", "querycolor36"
+
+};
+
+/** ****************************************************************************
+
+Parse a theme value
+
+Accepts a color as three decimal components "red green blue" (0 to 255), or
+as a hex triplet "rrggbb" with an optional leading '#'. Returns TRUE and the
+packed value if the string parses, FALSE if it does not. Note the theme table
+is a general value table; a plain number is accepted as well, for theme
+points that are not colors.
+
+*******************************************************************************/
+
+static int themval(
+    /** string to parse */ const char* s,
+    /** value returned */  unsigned long* v
+)
+
+{
+
+    long r, g, b;
+    char* ep;
+
+    while (*s == ' ') s++; /* skip leading spaces */
+    if (*s == '#' || strlen(s) == 6) { /* hex triplet */
+
+        if (*s == '#') s++;
+        *v = strtoul(s, &ep, 16);
+        while (*ep == ' ') ep++; /* trailing spaces are not an error */
+
+        return (!*ep);
+
+    }
+    /* three decimal components */
+    r = strtol(s, &ep, 10);
+    if (ep == s) return (FALSE);
+    s = ep;
+    g = strtol(s, &ep, 10);
+    if (ep == s) { /* single number: a non color theme value */
+
+        *v = r;
+
+        return (TRUE);
+
+    }
+    s = ep;
+    b = strtol(s, &ep, 10);
+    if (ep == s) return (FALSE);
+    while (*ep == ' ') ep++;
+    if (*ep) return (FALSE); /* trailing junk */
+    if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) return (FALSE);
+    *v = r<<16 | g<<8 | b;
+
+    return (TRUE);
+
+}
+
+/** ****************************************************************************
+
+Load theme from config
+
+Overrides the compiled in theme defaults with any values found in the
+config file, in the block:
+
+begin widgets
+    begin theme
+        back 252 252 252
+        ...
+    end
+end
+
+An entry whose name is not a known theme point is ignored, so a config
+written for a later version still loads here. An entry that does not parse
+is an error, since that is a mistake in the file rather than a version
+difference.
+
+*******************************************************************************/
+
+static void loadtheme(void)
+
+{
+
+    ami_valptr root;  /* config root */
+    ami_valptr wp;    /* widgets block */
+    ami_valptr tp;    /* theme block */
+    ami_valptr vp;    /* value entry */
+    themeindex ti;    /* theme index */
+    unsigned long v;  /* parsed value */
+
+    root = NULL;
+    ami_config(&root); /* get the config tree */
+    wp = ami_schlst("widgets", root); /* find widgets block */
+    if (!wp || !wp->sublist) return; /* no widgets block, keep defaults */
+    tp = ami_schlst("theme", wp->sublist); /* find theme subblock */
+    if (!tp || !tp->sublist) return; /* no theme block, keep defaults */
+    for (vp = tp->sublist; vp; vp = vp->next) { /* traverse theme points */
+
+        if (vp->name && vp->value)
+            for (ti = 0; ti < th_endmarker; ti++)
+                if (!strcmp(vp->name, themnam[ti])) {
+
+            if (!themval(vp->value, &v)) error("Invalid theme value");
+            themetable[ti] = v;
+
+        }
+
+    }
+
+}
+
+/** ****************************************************************************
+
 Widgets startup
 
 *******************************************************************************/
@@ -8216,6 +8360,9 @@ static void init_widgets()
     themetable[th_querycolor34]       = TD_QUERYCOLOR34;
     themetable[th_querycolor35]       = TD_QUERYCOLOR35;
     themetable[th_querycolor36]       = TD_QUERYCOLOR36;
+
+    /* override the defaults with any theme values from the config file */
+    loadtheme();
 
 }
 


### PR DESCRIPTION
The library half of #187.

The widget theme table was compiled-in constants with no override path of any kind. It now loads from the config file, using the config system every module already reads (program directory, user home, current directory — each layer overriding the previous):

```
begin widgets
    begin theme
        back      252 252 252
        backhover #405060
        tabsel    708090
    end
end
```

- **`themnam[]`** — the config name of each of the 80 theme points, in `themeindex` order (the `th_*` name with the prefix dropped).
- **`themval()`** — parses a color as three decimal components (0–255) or a hex triplet with optional leading `#`. A plain number is also accepted, since the theme table is a general value table: theme points that aren't colors parse the same way.
- **`loadtheme()`** — runs after the compiled-in defaults, so a config need only carry the points it changes. An unknown name is ignored (a config written for a later version still loads here); a value that doesn't parse is an error, since that's a mistake in the file rather than a version difference.
- **`petit_ami.cfg`** documents the block with the common theme points listed and commented out.

Verified: the block parses as expected through the live config reader (nested `widgets/theme`, all three value forms, unknown name ignored); the value parser was unit-tested over nine cases including the three malformed forms; full build clean; regress 3/3.

The `css2theme` utility that generates this block from a GTK CSS theme is the remaining half of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to