### PR TITLE
services: fix timezone day wrap; test paths use the system separator

### DIFF
--- a/bin/regress
+++ b/bin/regress
@@ -61,9 +61,9 @@ if [ -z "$tests" ]; then tests="stdio_test services_test network_test"; fi
 #   the line width varies run to run and the whole time is masked with '*'
 # - elapsed tick counts on the "test 11:" line of services_test
 # - process ids in temp file names from stdio_test
-# - timezone offset and daylight savings flag, which change with the season
-#   (and the timezone value currently also flips with the time of day, see
-#   the ami_timezone day wrap issue)
+# - the daylight savings flag, which changes with the season. The timezone
+#   offset is not masked: it is a fixed property of the machine's zone now
+#   that ami_timezone handles the day wrap
 #
 mask()
 {
@@ -74,7 +74,6 @@ mask()
         -e 's|[0-9]{2}:[0-9]{2}:[0-9]{2}( [ap]m)?|*|g' \
         -e 's|^(test 11: )[0-9]+|\1*|' \
         -e 's|/tmp/tmp\.[0-9]+\.|/tmp/tmp.*.|g' \
-        -e 's|^(test 58: Timezone: )-?[0-9]+|\1*|' \
         -e 's|^(test 59: Daysave: )[0-9]+|\1*|' \
         -e 's|^(    google.com A    -> ).*|\1*|' \
         -e 's|^(    google.com AAAA -> ).*|\1*|'

--- a/linux/services.c
+++ b/linux/services.c
@@ -2675,13 +2675,25 @@ long ami_timezone(void)
     time_t t, nt;  /* seconds time holder */
     struct tm gmt; /* time structure gmt */
     struct tm lcl; /* local time structure */
+    int dd;        /* day difference, local to gmt */
 
     t = time(NULL); /* get seconds time */
     gmtime_r(&t, &gmt); /* get gmt */
     localtime_r(&t, &lcl); /* get local */
-    nt = (lcl.tm_hour-gmt.tm_hour)*HOURSEC-(!!lcl.tm_isdst*HOURSEC);
+    /* Find the difference. Minutes are included because a number of zones
+       are offset by a half or quarter hour, not a whole one. */
+    nt = (lcl.tm_hour-gmt.tm_hour)*HOURSEC+(lcl.tm_min-gmt.tm_min)*60;
+    /* The two can fall on different days, in which case the hour difference
+       above is out by a day. The year end is the reason for the second test
+       in each case: there the day numbers run 364 against 0. */
+    dd = lcl.tm_yday-gmt.tm_yday;
+    if (dd == 1 || dd < -1) nt += DAYSEC;      /* local is the next day */
+    else if (dd == -1 || dd > 1) nt -= DAYSEC; /* local is the previous day */
+    /* the result includes daylight savings; remove it, since ami_local adds
+       it back from ami_daysave() */
+    if (lcl.tm_isdst > 0) nt -= HOURSEC;
 
-    /* return hour difference */
+    /* return the offset */
     return nt;
 
 }

--- a/tests/services_test.c
+++ b/tests/services_test.c
@@ -168,11 +168,19 @@ int main(void)
     ami_setcur(s);
     ami_getcur(s, MAXSTR);
     printf("test 31: %s s/b <the current path>\n", s);
-    ami_brknam("c:\\what\\ho\\junk.com", p, MAXSTR, n, MAXSTR, e, MAXSTR);
+    /* Build the path with the system's own separator. The test used a
+       Windows path with backslashes, which is not a separator on Unix, so
+       brknam correctly returned the whole string as the name and the test
+       appeared to fail everywhere but Windows. */
+    sprintf(s2, "%cwhat%cho%cjunk.com", ami_pthchr(), ami_pthchr(),
+            ami_pthchr());
+    ami_brknam(s2, p, MAXSTR, n, MAXSTR, e, MAXSTR);
     printf("test 32: Path: %s Name: %s Ext: %s ", p, n, e);
-    printf("s/b: Path: c:\\what\\ho\\ Name: junk Ext: com\n");
+    printf("s/b: Path: %cwhat%cho%c Name: junk Ext: com\n", ami_pthchr(),
+           ami_pthchr(), ami_pthchr());
     ami_maknam(s, MAXSTR, p, n, e);
-    printf("test 33: %s s/b c:\\what\\ho\\junk.com\n", s);
+    printf("test 33: %s s/b %cwhat%cho%cjunk.com\n", s, ami_pthchr(),
+           ami_pthchr(), ami_pthchr());
     strcpy(s, "junk");
     ami_fulnam(s, MAXSTR);
     printf("test 36: %s s/b <path>junk\n", s);

--- a/tests/services_test.cmp
+++ b/tests/services_test.cmp
@@ -51,8 +51,8 @@ This is services_test1 "hi there"
 test 29: /home/samiam/projects/amitk/tests/regress s/b <the current path>
 test 30: /home/samiam s/b <the user path>
 test 31: /home/samiam/projects/amitk/tests/regress s/b <the current path>
-test 32: Path:  Name: c:\what\ho\junk Ext: com s/b: Path: c:\what\ho\ Name: junk Ext: com
-test 33: c:\what\ho\junk.com s/b c:\what\ho\junk.com
+test 32: Path: /what/ho/ Name: junk Ext: com s/b: Path: /what/ho/ Name: junk Ext: com
+test 33: /what/ho/junk.com s/b /what/ho/junk.com
 test 36: /home/samiam/projects/amitk/tests/regress/junk s/b <path>junk
 test 38: /home/samiam/projects/amitk/bin/ s/b <the program path>
 test 40: /home/samiam s/b <the user path>
@@ -68,7 +68,7 @@ test 54: longitude: 0
 test 55: Altitude: 0
 test 56: Country code: 840
 test 57: Country name: United States of America
-test 58: Timezone: *
+test 58: Timezone: -28800
 test 59: Daysave: *
 test 60: 24 hour time: 0
 test 61: Language: 41


### PR DESCRIPTION
Fixes #174, and items 2 and 3 (plus the macOS test 32 note) of the services roundup #33.

## The timezone day wrap

`ami_timezone` on linux computed the offset from the local and GMT **hour fields alone**:

```c
nt = (lcl.tm_hour-gmt.tm_hour)*HOURSEC-(!!lcl.tm_isdst*HOURSEC);
```

When the two fall on different days — the normal case for zones west of the meridian in the evening — the result is out by a full day. Measured on this UTC-7 machine at 22:00 local:

```
ami local time : 10:01:32 pm     system local : 22:01:32    ✓
ami local date : 2026/07/28      system date  : 2026/07/27   ✗
timezone=57600 (+16 h)           should be -28800
```

The error is exactly 86400 seconds, which is why the *time* looked right (it wraps modulo a day) while the *date* read one day ahead — roundup item 2, "the date is still one day off".

The difference now accounts for the day the two structures fall on (including the year end, where day numbers run 364 against 0) and **includes minutes**, since a number of zones are offset by a half or quarter hour rather than a whole one — the old code discarded `tm_min` entirely.

After: `timezone=-28800`, and the date matches the system clock.

Windows needs no change — it reads the offset from `GetTimeZoneInformation`, which has no such problem.

## Test 32

The test fed `ami_brknam` a Windows path, `"c:\what\ho\junk.com"`. Backslash isn't a separator on Unix, so `brknam` correctly returned the whole string as the name and the test appeared to fail everywhere but Windows — roundup item 3, and the identical macOS note "test 32 fails, path and name are combined". (I confirmed earlier that this output is byte-identical to the pre-critical-buffer implementation, so nothing regressed it.)

It now builds its path with `ami_pthchr()`, so it means the same thing on any system. Test 33, which reassembles what 32 took apart, follows it:

```
test 32: Path: /what/ho/ Name: junk Ext: com   s/b: Path: /what/ho/ Name: junk Ext: com
test 33: /what/ho/junk.com                     s/b /what/ho/junk.com
```

## Regress

The timezone field is no longer masked in `bin/regress` — it's a fixed property of the machine now that it's computed correctly. Baseline regenerated; verified green across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to