### PR TITLE
services: bound the internal path copies, fix a strchr misuse

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -211,6 +211,9 @@ characters in the substring are too large for the destination.
 
 ********************************************************************************/
 
+/* Extract a substring, from index st through ed, into d. The length l is
+   the maximum CONTENT length: the terminator is written after it, so a
+   buffer of N characters admits l = N-1. */
 static void extract(char *d, int l, char *s, int st, int ed)
 {
 
@@ -1282,6 +1285,32 @@ Returns the properly pathed command if found.
 
 ********************************************************************************/
 
+/********************************************************************************
+
+Copy string to internal buffer
+
+Copies a string to an internal working buffer of the given length, which
+unlike an API output buffer must end up a usable C string: the result is
+always zero terminated, and a string that does not fit is an error. Used for
+the module's own path plumbing, where the source can be an environment value
+or a name handed in by the caller, and so is not bounded by anything this
+module controls.
+
+********************************************************************************/
+
+static void cpylim(
+    /** destination */        char* d,
+    /** destination length */ int dl,
+    /** source */             const char* s
+)
+
+{
+
+    if (strlen(s) >= dl) error("String too large for buffer");
+    strcpy(d, s);
+
+}
+
 void cmdpth(
     /* command to search for */           char *cn,
     /* result correctly pathed command */ char *pcn,
@@ -1294,9 +1323,15 @@ void cmdpth(
     bufstr ncn;
     char *cp;
 
-    strcpy(ncn, cn); /* copy command to temp */
-    /* perform pathing search */
-    ami_brknam(cn, p, MAXSTR, n, MAXSTR, e, MAXSTR); /* break down the name */
+    cpylim(ncn, MAXSTR, cn); /* copy command to temp */
+    /* Break down the name. The component buffers are given one short of
+       their size with the last byte cleared, so a component that exactly
+       fills one still comes back a usable C string: these are critical
+       output buffers and would otherwise be left unterminated. */
+    p[MAXSTR-1] = 0;
+    n[MAXSTR-1] = 0;
+    e[MAXSTR-1] = 0;
+    ami_brknam(cn, p, MAXSTR-1, n, MAXSTR-1, e, MAXSTR-1);
     if (*p == 0 && *pthstr != 0) { /* no path on name and environment path exists */
 
         strcpy(pc, pthstr);   /* make a copy of the path */
@@ -1306,17 +1341,22 @@ void cmdpth(
             cp = strchr(pc, ':' /*ami_pthchr()*/); /* find next path separator */
             if (!cp) {  /* none left, use entire remaining */
 
-                strcpy(p, pc); /* none left, use entire remaining */
+                cpylim(p, MAXSTR, pc); /* none left, use entire remaining */
                 pc[0] = 0; /* clear the rest */
 
             } else { /* copy partial */
 
-                extract(p, MAXSTR, pc, 0, cp-pc-1);   /* get left side to path */
-                extract(pc, MAXSTR, pc, cp-pc+1, strlen(pc)); /* remove from path */
+                /* extract() takes a maximum content length and writes the
+                   terminator after it, so a buffer of MAXSTR admits
+                   MAXSTR-1 characters */
+                extract(p, MAXSTR-1, pc, 0, cp-pc-1); /* get left side to path */
+                extract(pc, MAXSTR-1, pc, cp-pc+1, strlen(pc)); /* remove from path */
                 trim(pc); /* make sure left aligned */
 
             }
-            ami_maknam(ncn, MAXSTR, p, n, e);   /* create filename */
+            /* one short of the buffer, so the result is terminated */
+            ncn[MAXSTR-1] = 0;
+            ami_maknam(ncn, MAXSTR-1, p, n, e);   /* create filename */
             if (exists(ncn)) *pc = 0;  /* found, indicate stop */
 
         }
@@ -1818,7 +1858,7 @@ void ami_getpgm(
     bufstr   pcn;  /* pathed command name */
 
 #if defined(__linux) || defined(__MINGW32__) /* linux, Windows */
-    strcpy(pn, program_invocation_name); /* copy invoke name to path */
+    cpylim(pn, MAXSTR, program_invocation_name); /* copy invoke name to path */
 #elif defined(__FreeBSD__) /* BSD, FreeBSD */
     strcpy(pn, prgpth); /* copy from program path */
 #else /* Mac OS X */

--- a/windows/services.c
+++ b/windows/services.c
@@ -216,6 +216,9 @@ characters in the substring are too large for the destination.
 
 ********************************************************************************/
 
+/* Extract a substring, from index st through ed, into d. The length l is
+   the maximum CONTENT length: the terminator is written after it, so a
+   buffer of N characters admits l = N-1. */
 static void extract(char *d, int l, char *s, int st, int ed)
 {
 
@@ -1147,8 +1150,11 @@ static void cmdpth(
 
                 } else { /* copy partial */
 
-                    extract(p, MAXSTR, pc, 0, cp-pc-1);   /* get left side to path */
-                    extract(pc, MAXPTH, pc, cp-pc+1, strlen(pc)); /* remove from path */
+                    /* extract() takes a maximum content length and writes
+                       the terminator after it, so a buffer of N admits N-1
+                       characters */
+                    extract(p, MAXSTR-1, pc, 0, cp-pc-1); /* get left side to path */
+                    extract(pc, MAXPTH-1, pc, cp-pc+1, strlen(pc)); /* remove from path */
                     trim(pc); /* make sure left aligned */
 
                 }
@@ -1689,8 +1695,14 @@ void ami_getpgm(
             f = 0; /* set path not found */
             while (*path && !f) { /* search path */
 
-                i = strchr(path, ';')-path; /* find next path separator */
-                if (!i) { /* none, the rest is the path */
+                /* Find the next path separator. strchr gives NULL when
+                   there is none, so the pointer difference must not be
+                   taken until that is known: the old code subtracted
+                   first, leaving a meaningless index, and tested it
+                   against zero, which is also a legitimate result (a
+                   separator in the first position). */
+                cp = strchr(path, ';'); /* find next path separator */
+                if (!cp) { /* none, the rest is the path */
 
                     if (strlen(path) >= MAXSTR)
                         error("String too large for destination");
@@ -1699,6 +1711,7 @@ void ami_getpgm(
 
                 } else { /* break off next segment */
 
+                    i = cp-path; /* index of the separator */
                     extract(pb, MAXSTR-1, path, 0, i-1); /* place path */
                     /* extract the rest as remainer */
                     extract(path, MAXPTH-1, path, i+1, strlen(path));


### PR DESCRIPTION
Fixes #162.

## linux/services.c

- **Unbounded copies.** `cmdpth` copied the caller's command name with a plain `strcpy`, and `ami_getpgm` did the same with `program_invocation_name` — which comes from the system and can be any length. Both now go through a new `cpylim()`, which errors when the string doesn't fit and always terminates. These are internal working buffers that must end up usable C strings, so unlike the API output buffers they can't be left critical.

- **Critical-buffer interaction.** `cmdpth` called `ami_brknam` and `ami_maknam` with the *full* buffer size. Those are critical output buffers since #7: a component that exactly filled one came back unterminated, and the following `strlen`/`fopen` would read past it. They now get one less, with the last byte cleared — the same pattern used elsewhere in the file for internal `ami_getenv` calls.

## windows/services.c

- **`strchr` misuse.** `ami_getpgm` computed `i = strchr(path, ';')-path` *before* testing for NULL, so with no separator present the index was meaningless. It then tested that index against zero — which is also a legitimate result (a separator in the first position), so the "no separator" branch was doubly broken. The pointer is now tested first, and the difference taken only when there is one.

## Both

- **`extract` off-by-one — in the callers, not the function.** `extract(d, l, ...)` takes a maximum *content* length and writes the terminator after it, so a buffer of N admits `l = N-1`. Most call sites honor that (including the `malloc(l+1)` pair in `ami_allenv`, which depends on it), but the two in `cmdpth` passed the full buffer size, putting the terminator one byte past the end. Fixed at those sites, and `extract` now carries a comment stating the contract — which is what both sites had misread. (I misread it myself at first and nearly "fixed" `extract`, which would have broken the `malloc(l+1)` callers.)

## Verification

Full build clean, `bin/regress` 3/3, and the services **exec** tests — the ones that actually drive `cmdpth`'s PATH search — still pass. Windows cross-compiles clean under mingw-w64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to