### PR TITLE
services: ami_times emits am, and the noon hour is pm

### DIFF
--- a/linux/services.c
+++ b/linux/services.c
@@ -603,8 +603,14 @@ void ami_times(
     am = 0;
     if (!ami_time24hour()) { /* do am/pm adjustment */
 
-        if (h == 0) h = 12; /* hour zero */
-        else if (h > 12) { h -= 12; pm = 1; } /* 1 pm to 11 pm */
+        /* Noon and after is pm, the rest am. The hour then folds into 1
+           through 12: midnight and noon are both shown as 12, which is why
+           they are handled apart from the simple subtraction. */
+        pm = h >= 12;
+        am = !pm;
+        if (h == 0) h = 12;        /* midnight hour is 12 am */
+        else if (h > 12) h -= 12;  /* 1 pm to 11 pm */
+        /* the noon hour stays 12, and is pm */
 
     }
     /* place hour:miniute:second */

--- a/windows/services.c
+++ b/windows/services.c
@@ -553,8 +553,14 @@ void ami_times(
     am = 0;
     if (!ami_time24hour()) { /* do am/pm adjustment */
 
-        if (h == 0) h = 12; /* hour zero */
-        else if (h > 12) { h -= 12; pm = 1; } /* 1 pm to 11 pm */
+        /* Noon and after is pm, the rest am. The hour then folds into 1
+           through 12: midnight and noon are both shown as 12, which is why
+           they are handled apart from the simple subtraction. */
+        pm = h >= 12;
+        am = !pm;
+        if (h == 0) h = 12;        /* midnight hour is 12 am */
+        else if (h > 12) h -= 12;  /* 1 pm to 11 pm */
+        /* the noon hour stays 12, and is pm */
 
     }
     /* place hour:miniute:second */


### PR DESCRIPTION
Fixes #163 — and a second fault in the same three lines that the issue didn't cover.

## The reported bug

`am` was declared and tested but **never set**, so morning times printed with no suffix while afternoon times printed `" pm"`.

## The one alongside it

The noon hour wasn't handled at all:

```c
if (h == 0) h = 12;                     /* midnight */
else if (h > 12) { h -= 12; pm = 1; }   /* 1 pm to 11 pm */
```

12:00 through 12:59 matches **neither** arm — the hour stays 12 and `pm` stays clear, so noon printed bare, indistinguishable from morning.

Both stem from folding the hour and choosing the suffix in the same test. They're now separate concerns: noon and after is pm, the rest am; then the hour folds into 1–12, with midnight and noon both displayed as 12 — which is exactly why those two need handling apart from the plain subtraction.

## Verified across the boundaries

```
hour  0 -> 12:30:15 am     hour 12 -> 12:30:15 pm
hour  1 -> 01:30:15 am     hour 13 -> 01:30:15 pm
hour 11 -> 11:30:15 am     hour 23 -> 11:30:15 pm
```

Both faults were present on linux and windows; both fixed on both. Full build clean, `bin/regress` 3/3 (times are wildcard-masked in the baseline, so the added suffix doesn't disturb it), windows cross-compiles clean under mingw-w64.