### PR TITLE
sound: scale MIDI pitch bend on input; pitch range in semitones

### DIFF
--- a/linux/fluidsynthplug.c
+++ b/linux/fluidsynthplug.c
@@ -216,8 +216,13 @@ static void writefluid(long p, ami_seqptr sp)
             fluid_synth_pitch_bend(fp->synth, sp->vsc-1, sp->vsv/(LONG_MAX/8192+1)+0x2000);
             break;
         case st_pitchrange:
-            /* this one is open for interpretation: what is a "semitone"? */
-            fluid_synth_pitch_wheel_sens(fp->synth, sp->vsc-1, sp->vsv/(LONG_MAX/16384+1));
+            /* Fluidsynth takes the sensitivity in semitones, so this uses
+               the same scale as the MIDI path, whose RPN data entry coarse
+               byte is semitones: full scale is 127 of them. It divided by
+               the 14 bit constant before, handing over a number up to
+               16383 where semitones were expected. */
+            fluid_synth_pitch_wheel_sens(fp->synth, sp->vsc-1,
+                                         sp->vsv/(LONG_MAX/128+1));
             break;
         case st_mono:         break; /* no equivalent function */
         case st_poly:         break; /* no equivalent function */

--- a/linux/sound.c
+++ b/linux/sound.c
@@ -1381,6 +1381,8 @@ static void inpseq(long p, ami_seqptr sp)
 
 {
 
+    long pv; /* pitch value expanded to full scale */
+
     devptr mp; /* midi input port */
     byte b;
     long t;
@@ -1513,7 +1515,19 @@ static void inpseq(long p, ami_seqptr sp)
                   sp->time = t; /* set time */
                   sp->st = st_pitch; /* set type */
                   sp->vsc = (b&15)+1; /* set channel */
-                  sp->vsv = p2<<7|p1; /* set pitch */
+                  /* Expand the 14 bit MIDI value to API full scale, the
+                     inverse of the reduction _pa_excseq performs on output.
+                     Without this a pitch read from a device or file plays
+                     back at (near) centre, since the raw value is tiny
+                     against full scale. Centring puts the range at
+                     -8192..8191, so the bottom end alone lands one past
+                     -LONG_MAX, and is clamped: a raw 0 therefore returns as
+                     1, one part in 16384 at the extreme of the bend, which
+                     is preferable to handing out a value the API does not
+                     admit and whose negation would overflow. */
+                  pv = ((long)(p2<<7|p1)-0x2000)*(LONG_MAX/8192+1);
+                  if (pv < -LONG_MAX) pv = -LONG_MAX;
+                  sp->vsv = pv; /* set pitch */
                   break;
         case 0xf: /* sysex/meta */
                   switch (b) {
@@ -4215,6 +4229,8 @@ static int dcdmidi(FILE* fh, byte b, int* endtrk, long p, long t, int* qnote,
 
 {
 
+    long pv; /* pitch value expanded to full scale */
+
     byte p1;
     byte p2;
     byte p3;
@@ -4339,7 +4355,19 @@ static int dcdmidi(FILE* fh, byte b, int* endtrk, long p, long t, int* qnote,
                   sp->time = t; /* set time */
                   sp->st = st_pitch; /* set type */
                   sp->vsc = (b&15)+1; /* set channel */
-                  sp->vsv = p2<<7|p1; /* set pitch */
+                  /* Expand the 14 bit MIDI value to API full scale, the
+                     inverse of the reduction _pa_excseq performs on output.
+                     Without this a pitch read from a device or file plays
+                     back at (near) centre, since the raw value is tiny
+                     against full scale. Centring puts the range at
+                     -8192..8191, so the bottom end alone lands one past
+                     -LONG_MAX, and is clamped: a raw 0 therefore returns as
+                     1, one part in 16384 at the extreme of the bend, which
+                     is preferable to handing out a value the API does not
+                     admit and whose negation would overflow. */
+                  pv = ((long)(p2<<7|p1)-0x2000)*(LONG_MAX/8192+1);
+                  if (pv < -LONG_MAX) pv = -LONG_MAX;
+                  sp->vsv = pv; /* set pitch */
                   break;
         case 0xf: /* sysex/meta */
                   switch (b) {

--- a/windows/sound.c
+++ b/windows/sound.c
@@ -3870,6 +3870,8 @@ static void parseq(long p, ami_seqptr sp, byte b1, byte b2, byte b3)
 
 {
 
+    long pv; /* pitch value expanded to full scale */
+
     long t;
     byte p1;
     byte p2;
@@ -3985,7 +3987,19 @@ static void parseq(long p, ami_seqptr sp, byte b1, byte b2, byte b3)
                   sp->time = t; /* set time */
                   sp->st = st_pitch; /* set type */
                   sp->vsc = (b1&15)+1; /* set channel */
-                  sp->vsv = p2<<7|p1; /* set pitch */
+                  /* Expand the 14 bit MIDI value to API full scale, the
+                     inverse of the reduction performed on output. Without
+                     this a pitch read from a device or file plays back at
+                     (near) centre, since the raw value is tiny against full
+                     scale. Centring puts the range at -8192..8191, so the
+                     bottom end alone lands one past -LONG_MAX, and is
+                     clamped: a raw 0 therefore returns as 1, one part in
+                     16384 at the extreme of the bend, which is preferable
+                     to handing out a value the API does not admit and whose
+                     negation would overflow. */
+                  pv = ((long)(p2<<7|p1)-0x2000)*(LONG_MAX/8192+1);
+                  if (pv < -LONG_MAX) pv = -LONG_MAX;
+                  sp->vsv = pv; /* set pitch */
                   break;
         case 0xf: /* sysex/meta */
                   /* windows sends system exclusive messages via the buffer


### PR DESCRIPTION
Fixes #164, both the main asymmetry and the related oddity noted at the end.

## Pitch bend input

Output reduced the API's full-scale pitch to the 14-bit MIDI range; input stored the **raw 14-bit value** straight into the sequencer message. Against full scale that value is negligible, so anything read from a device or MIDI file played back at centre:

```
old behaviour, raw value stored unscaled:
  raw 0      stored 0        plays back as 8192   (centre)
  raw 8192   stored 8192     plays back as 8192
  raw 16383  stored 16383    plays back as 8192
```

Every input value, hard-down to hard-up, collapsed to centre.

The three input sites — `inpseq` and `dcdmidi` on linux, `parseq` on windows — now apply the exact inverse of the output reduction. Verified the two compose to the identity:

```
raw in   full scale             raw out
0        -9223372036854775807   1        (see below)
1        -9222246136947933184   1
4096     -4611686018427387904   4096
8192     0                      8192     (centre)
12288     4611686018427387904   12288
16383     9222246136947933184   16383
```

The single exception is the bottom of the range. Centring puts it at −8192..8191, so the lowest value alone lands exactly one past −`LONG_MAX` and is clamped — a raw 0 returns as 1. That's one part in 16384 at the extreme of the bend, and preferable to handing out a value the API doesn't admit and **whose negation would overflow**.

## Pitch range in semitones

The MIDI path was already right: RPN 0 with the data-entry coarse byte in semitones (`vsv/(LONG_MAX/128+1)` → 0–127) and the fine byte as cents. But the fluidsynth plug-in divided by the *14-bit* constant and passed up to 16383 to `fluid_synth_pitch_wheel_sens`, which takes semitones. It now uses the same scale as the MIDI path — which also answers the comment sitting there asking "what is a semitone?".

Full build clean, `bin/regress` 3/3, windows cross-compiles clean under mingw-w64. Audible verification wants a synth and a MIDI file with pitch bend in it.