### PR TITLE
managerc: repair the window manager, add character mode widgets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,7 +591,7 @@ ifeq ($(OSTYPE),Windows_NT)
 # network implementation (TCP, TLS, messages, DTLS and certificates).
 all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig playwave \
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
-     connectwaveg random randomg genwave genwaveg terminal_test terminal_testg \
+     connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -608,7 +608,7 @@ else ifeq ($(OSTYPE),Darwin)
 all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig playwave \
      playwaveg playtextmidi playtextmidig printdev printdevg connectmidi \
      connectmidig connectwave \
-     connectwaveg random randomg genwave genwaveg terminal_test terminal_testg \
+     connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -624,7 +624,7 @@ else ifeq ($(OSTYPE),FreeBSD)
 #
 all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig playwave \
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
-     connectwaveg random randomg genwave genwaveg terminal_test terminal_testg \
+     connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -640,7 +640,7 @@ else
 #
 all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig playwave \
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
-     connectwaveg random randomg genwave genwaveg terminal_test terminal_testg \
+     connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -951,6 +951,20 @@ lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o \
 		utils/option.o  cpp/terminal.o -lstdc++ -o lib/petit_ami_term.so
 	
+#
+# Terminal library with the character mode window manager always included.
+# This is a separate file from lib/petit_ami_term.so so that both the plain
+# and the managed configurations can exist at once: they were previously the
+# same file, and building one silently replaced the other.
+#
+lib/petit_ami_termc.so: $(LINUXSTDIO) linux/services.o linux/network.o \
+	linux/terminal.o portable/managerc.o linux/system_event.o utils/config.o \
+	utils/option.o cpp/terminal.o
+	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
+		linux/terminal.o portable/managerc.o linux/system_event.o \
+		utils/config.o utils/option.o cpp/terminal.o -lstdc++ \
+		-o lib/petit_ami_termc.so
+
 lib/petit_ami_term.a: $(LINUXSTDIO) linux/services.o linux/sound.o \
 	linux/fluidsynthplug.o linux/dumpsynthplug.o linux/network.o \
 	linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o utils/option.o \
@@ -1009,6 +1023,28 @@ dif: utils/dif.c Makefile
 #
 css2theme: utils/css2theme.c Makefile
 	$(CC) utils/css2theme.c -o bin/css2theme
+
+#
+# GTK version of the widget sampler in test.c, as the reference to compare
+# the widget theme against. Not built by "make all": it links GTK, which
+# Petit-Ami deliberately does not.
+#
+test_gtk: test_gtk.c Makefile
+	$(CC) test_gtk.c `pkg-config --cflags --libs gtk+-3.0` -o test_gtk
+
+#
+# Managerc subwindow test. The terminal library must be built with managerc
+# in it: make lib/petit_ami_term.so USEMANAGERC=1
+#
+#
+# Managerc tests. These link the manager carrying library, so they need no
+# build flag: the plain and managed libraries coexist.
+#
+test_manager: test_manager.c lib/petit_ami_termc.so Makefile
+	$(CC) $(CFLAGS) test_manager.c $(CLIBSC) -o test_manager
+
+test_manager2: test_manager2.c lib/petit_ami_termc.so Makefile
+	$(CC) $(CFLAGS) test_manager2.c $(CLIBSC) -o test_manager2
 
 #
 # General test program
@@ -1160,6 +1196,12 @@ SCREEN_CAPTURE_OBJ = linux/screen_capture.o
 endif
 
 #
+# Link set for programs stacked on managerc over terminal. Same as CLIBS but
+# with the manager carrying library in place of the plain one.
+#
+CLIBSC = $(subst lib/petit_ami_term.so,lib/petit_ami_termc.so,$(CLIBS))
+
+#
 # Test console model compliant output
 #
 ifeq ($(OSTYPE),Darwin)
@@ -1212,6 +1254,24 @@ testviewer: linux/testviewer.c Makefile
 else
 testviewer: linux/testviewer.c Makefile
 	$(CC) -g3 linux/testviewer.c -lX11 -lpng -o bin/testviewer
+endif
+
+#
+# Test console model compliant output, stacked on the character mode window
+# manager: the same test as terminal_test, but running through
+# managerc over terminal rather than terminal alone. The test should behave
+# identically, since managerc presents the terminal API transparently when
+# the program does not open windows of its own.
+#
+ifeq ($(OSTYPE),Darwin)
+terminal_testc: lib/petit_ami_termc.so tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(CLIBSC) -o bin/terminal_testc
+else ifeq ($(OSTYPE),Windows_NT)
+terminal_testc: lib/petit_ami_termc.so tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(CLIBSC) -lpng -lz -o bin/terminal_testc
+else
+terminal_testc: lib/petit_ami_termc.so tests/terminal_test.c $(SCREEN_CAPTURE_OBJ)
+	$(CC) $(CFLAGS) tests/terminal_test.c $(SCREEN_CAPTURE_OBJ) $(CLIBSC) -lX11 -lpng -lz -o bin/terminal_testc
 endif
 
 #

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -89,6 +89,21 @@ typedef enum {
     /** window maximized */             ami_etmax,      
     /** window normalized */            ami_etnorm,     
     /** menu item selected */           ami_etmenus,    
+    /** button assert */                ami_etbutton,
+    /** checkbox click */               ami_etchkbox,
+    /** radio button click */           ami_etradbut,
+    /** scroll up/left line */          ami_etsclull,
+    /** scroll down/right line */       ami_etscldrl,
+    /** scroll up/left page */          ami_etsclulp,
+    /** scroll down/right page */       ami_etscldrp,
+    /** scroll bar position */          ami_etsclpos,
+    /** edit box signals done */        ami_etedtbox,
+    /** number select box done */       ami_etnumbox,
+    /** list box selection */           ami_etlstbox,
+    /** drop box selection */           ami_etdrpbox,
+    /** drop edit box done */           ami_etdrebox,
+    /** slider position */              ami_etsldpos,
+    /** tab bar select */               ami_ettabbar,
 
     /* Reserved extra code areas, these are module defined. */
     ami_etsys    = 0x1000, /* start of base system reserved codes */
@@ -163,6 +178,66 @@ typedef struct {
         };
         /* ami_etmenus */
         long menuid; /* menu item selected */
+        /* ami_etbutton */
+        long butid; /* button id */
+        /* ami_etchkbox */
+        long ckbxid; /* checkbox id */
+        /* ami_etradbut */
+        long radbid; /* radio button id */
+        /* ami_etsclull */
+        long sclulid; /* scroll up/left line id */
+        /* ami_etscldrl */
+        long scldrid; /* scroll down/right line id */
+        /* ami_etsclulp */
+        long sclupid; /* scroll up/left page id */
+        /* ami_etscldrp */
+        long scldpid; /* scroll down/right page id */
+        /* ami_etsclpos */
+        struct {
+
+            long sclpid; /* scroll bar id */
+            long sclpos; /* scroll bar position */
+
+        };
+        /* ami_etedtbox */
+        long edtbid; /* edit box complete id */
+        /* ami_etnumbox */
+        struct {
+
+            long numbid; /* num sel box id */
+            long numbsl; /* num select value */
+
+        };
+        /* ami_etlstbox */
+        struct {
+
+            long lstbid; /* list box id */
+            long lstbsl; /* list box select number */
+
+        };
+        /* ami_etdrpbox */
+        struct {
+
+            long drpbid; /* drop box id */
+            long drpbsl; /* drop box select */
+
+        };
+        /* ami_etdrebox */
+        long drebid; /* drop edit box id */
+        /* ami_etsldpos */
+        struct {
+
+            long sldpid; /* slider id */
+            long sldpos; /* slider position */
+
+        };
+        /* ami_ettabbar */
+        struct {
+
+            long tabid;  /* tab bar id */
+            long tabsel; /* tab select */
+
+        };
 
      };
 
@@ -219,6 +294,53 @@ typedef void (*ami_pevthan)(ami_evtrec*);
 typedef void (*ami_errhan)(ami_errcod e);
 
 /* menu */
+/* standardized menu entries */
+
+#define AMI_SMNEW        1 /* new file */
+#define AMI_SMOPEN       2 /* open file */
+#define AMI_SMCLOSE      3 /* close file */
+#define AMI_SMSAVE       4 /* save file */
+#define AMI_SMSAVEAS     5 /* save file as name */
+#define AMI_SMPAGESET    6 /* page setup */
+#define AMI_SMPRINT      7 /* print */
+#define AMI_SMEXIT       8 /* exit program */
+#define AMI_SMUNDO       9 /* undo edit */
+#define AMI_SMCUT       10 /* cut selection */
+#define AMI_SMPASTE     11 /* paste selection */
+#define AMI_SMDELETE    12 /* delete selection */
+#define AMI_SMFIND      13 /* find text */
+#define AMI_SMFINDNEXT  14 /* find next */
+#define AMI_SMREPLACE   15 /* replace text */
+#define AMI_SMGOTO      16 /* goto line */
+#define AMI_SMSELECTALL 17 /* select all text */
+#define AMI_SMNEWWINDOW 18 /* new window */
+#define AMI_SMTILEHORIZ 19 /* tile child windows horizontally */
+#define AMI_SMTILEVERT  20 /* tile child windows vertically */
+#define AMI_SMCASCADE   21 /* cascade windows */
+#define AMI_SMCLOSEALL  22 /* close all windows */
+#define AMI_SMHELPTOPIC 23 /* help topics */
+#define AMI_SMABOUT     24 /* about this program */
+#define AMI_SMMAX       24 /* maximum defined standard menu entries */
+
+/* orientation for tab bars */
+typedef enum { ami_totop, ami_toright, ami_tobottom, ami_toleft } ami_tabori;
+
+/* settable items in find query */
+typedef enum { ami_qfncase, ami_qfnup, ami_qfnre } ami_qfnopt;
+typedef long ami_qfnopts;
+/* settable items in replace query */
+typedef enum { ami_qfrcase, ami_qfrup, ami_qfrre, ami_qfrfind, ami_qfrallfil,
+               ami_qfralllin } ami_qfropt;
+typedef long ami_qfropts;
+/* effects in font query */
+typedef enum { ami_qfteblink, ami_qftereverse, ami_qfteunderline,
+               ami_qftesuperscript, ami_qftesubscript, ami_qfteitalic,
+               ami_qftebold, ami_qftestrikeout, ami_qftestandout,
+               ami_qftecondensed, ami_qfteextended, ami_qftexlight,
+               ami_qftelight, ami_qftexbold, ami_qftehollow,
+               ami_qfteraised } ami_qfteffect;
+typedef long ami_qfteffects;
+
 typedef struct ami_menurec* ami_menuptr;
 typedef struct ami_menurec {
 
@@ -311,6 +433,91 @@ void ami_frame(FILE* f, long e);
 void ami_sizable(FILE* f, long e);
 void ami_sysbar(FILE* f, long e);
 void ami_menu(FILE* f, ami_menuptr m);
+
+/* string list, for list box style widgets */
+typedef struct ami_strrec* ami_strptr;
+typedef struct ami_strrec {
+
+    ami_strptr next; /* next entry in list */
+    char*    str;  /* string */
+
+} ami_strrec;
+
+/* Character mode widgets. These are implemented by the character mode
+   window manager (managerc), drawn entirely in character cells, and take
+   character coordinates. They are not vectored: they exist only when the
+   window manager is present in the link. */
+
+long ami_getwigid(FILE* f);
+void ami_killwidget(FILE* f, long id);
+void ami_selectwidget(FILE* f, long id, long e);
+void ami_enablewidget(FILE* f, long id, long e);
+void ami_getwidgettext(FILE* f, long id, char* s, long sl);
+void ami_putwidgettext(FILE* f, long id, char* s);
+void ami_sizwidget(FILE* f, long id, long x, long y);
+void ami_poswidget(FILE* f, long id, long x, long y);
+void ami_backwidget(FILE* f, long id);
+void ami_frontwidget(FILE* f, long id);
+void ami_focuswidget(FILE* f, long id);
+void ami_buttonsiz(FILE* f, char* s, long* w, long* h);
+void ami_button(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_checkboxsiz(FILE* f, char* s, long* w, long* h);
+void ami_checkbox(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_radiobuttonsiz(FILE* f, char* s, long* w, long* h);
+void ami_radiobutton(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_groupsiz(FILE* f, char* s, long cw, long ch, long* w, long* h, long* ox,
+                  long* oy);
+void ami_group(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_background(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollvertsiz(FILE* f, long* w, long* h);
+void ami_scrollvert(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollhorizsiz(FILE* f, long* w, long* h);
+void ami_scrollhoriz(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollpos(FILE* f, long id, long r);
+void ami_scrollsiz(FILE* f, long id, long r);
+void ami_numselboxsiz(FILE* f, long l, long u, long* w, long* h);
+void ami_numselbox(FILE* f, long x1, long y1, long x2, long y2, long l, long u,
+                   long id);
+void ami_editboxsiz(FILE* f, char* s, long* w, long* h);
+void ami_editbox(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_progbarsiz(FILE* f, long* w, long* h);
+void ami_progbar(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_progbarpos(FILE* f, long id, long pos);
+void ami_listboxsiz(FILE* f, ami_strptr sp, long* w, long* h);
+void ami_listbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id);
+void ami_slidehorizsiz(FILE* f, long* w, long* h);
+void ami_slidehoriz(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                    long id);
+void ami_slidevertsiz(FILE* f, long* w, long* h);
+void ami_slidevert(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                   long id);
+void ami_dropboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                    long* oh);
+void ami_dropbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id);
+void ami_dropeditboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                        long* oh);
+void ami_dropeditbox(FILE* f, long x1, long y1, long x2, long y2,
+                     ami_strptr sp, long id);
+void ami_tabbarsiz(FILE* f, ami_tabori tor, long cw, long ch, long* w, long* h,
+                   long* ox, long* oy);
+void ami_tabbarclient(FILE* f, ami_tabori tor, long w, long h, long* cw,
+                      long* ch, long* ox, long* oy);
+void ami_tabbar(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                ami_tabori tor, long id);
+void ami_tabsel(FILE* f, long id, long tn);
+
+/* standard dialogs. These are presented inside the terminal surface as
+   managed windows, rather than as host system dialogs. */
+void ami_alert(char* title, char* message);
+void ami_querycolor(long* r, long* g, long* b);
+void ami_queryopen(char* s, long sl);
+void ami_querysave(char* s, long sl);
+void ami_queryfind(char* s, long sl, ami_qfnopts* opt);
+void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt);
+void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
+                   long* br, long* bg, long* bb, ami_qfteffects* effect);
 void ami_menuena(FILE* f, long id, long onoff);
 void ami_menusel(FILE* f, long id, long select);
 void ami_stdmenu(ami_stdmenusel sms, ami_menuptr* sm, ami_menuptr pm);

--- a/include/terminalw.h
+++ b/include/terminalw.h
@@ -1,19 +1,25 @@
 /** ****************************************************************************
  *
- * Terminal library interface header
+ * Terminal with windows library interface header
  *
- * Declares a routines and data for the Petit Ami terminal level
- * interface. The terminal interface describes a 2 demensional, fixed window on
- * which characters are drawn. Each character can have colors or attributes.
- * The size of the window can be determined, and timer, mouse, and joystick
- * services are supported.
+ * Declares the routines and data for the Petit Ami terminal level interface
+ * together with the window and widget layers. The terminal interface describes
+ * a 2 demensional, fixed window on which characters are drawn. Each character
+ * can have colors or attributes. The size of the window can be determined, and
+ * timer, mouse, and joystick services are supported.
+ *
+ * This header is the terminal interface with the windowing and widget calls
+ * added, for programs that run under the character mode window manager. A
+ * program that only needs the terminal surface uses terminal.h instead and
+ * does not carry the manager. Widgets are not broken out separately, since
+ * they only appear with windowed programs.
  *
  * Please see the Petit Ami documentation for more information.
  *
  ******************************************************************************/
 
-#ifndef __TERMINAL_H__
-#define __TERMINAL_H__
+#ifndef __TERMINALW_H__
+#define __TERMINALW_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,6 +95,21 @@ typedef enum {
     /** window maximized */             ami_etmax,      
     /** window normalized */            ami_etnorm,     
     /** menu item selected */           ami_etmenus,    
+    /** button assert */                ami_etbutton,
+    /** checkbox click */               ami_etchkbox,
+    /** radio button click */           ami_etradbut,
+    /** scroll up/left line */          ami_etsclull,
+    /** scroll down/right line */       ami_etscldrl,
+    /** scroll up/left page */          ami_etsclulp,
+    /** scroll down/right page */       ami_etscldrp,
+    /** scroll bar position */          ami_etsclpos,
+    /** edit box signals done */        ami_etedtbox,
+    /** number select box done */       ami_etnumbox,
+    /** list box selection */           ami_etlstbox,
+    /** drop box selection */           ami_etdrpbox,
+    /** drop edit box done */           ami_etdrebox,
+    /** slider position */              ami_etsldpos,
+    /** tab bar select */               ami_ettabbar,
 
     /* Reserved extra code areas, these are module defined. */
     ami_etsys    = 0x1000, /* start of base system reserved codes */
@@ -163,6 +184,66 @@ typedef struct {
         };
         /* ami_etmenus */
         long menuid; /* menu item selected */
+        /* ami_etbutton */
+        long butid; /* button id */
+        /* ami_etchkbox */
+        long ckbxid; /* checkbox id */
+        /* ami_etradbut */
+        long radbid; /* radio button id */
+        /* ami_etsclull */
+        long sclulid; /* scroll up/left line id */
+        /* ami_etscldrl */
+        long scldrid; /* scroll down/right line id */
+        /* ami_etsclulp */
+        long sclupid; /* scroll up/left page id */
+        /* ami_etscldrp */
+        long scldpid; /* scroll down/right page id */
+        /* ami_etsclpos */
+        struct {
+
+            long sclpid; /* scroll bar id */
+            long sclpos; /* scroll bar position */
+
+        };
+        /* ami_etedtbox */
+        long edtbid; /* edit box complete id */
+        /* ami_etnumbox */
+        struct {
+
+            long numbid; /* num sel box id */
+            long numbsl; /* num select value */
+
+        };
+        /* ami_etlstbox */
+        struct {
+
+            long lstbid; /* list box id */
+            long lstbsl; /* list box select number */
+
+        };
+        /* ami_etdrpbox */
+        struct {
+
+            long drpbid; /* drop box id */
+            long drpbsl; /* drop box select */
+
+        };
+        /* ami_etdrebox */
+        long drebid; /* drop edit box id */
+        /* ami_etsldpos */
+        struct {
+
+            long sldpid; /* slider id */
+            long sldpos; /* slider position */
+
+        };
+        /* ami_ettabbar */
+        struct {
+
+            long tabid;  /* tab bar id */
+            long tabsel; /* tab select */
+
+        };
 
      };
 
@@ -219,6 +300,53 @@ typedef void (*ami_pevthan)(ami_evtrec*);
 typedef void (*ami_errhan)(ami_errcod e);
 
 /* menu */
+/* standardized menu entries */
+
+#define AMI_SMNEW        1 /* new file */
+#define AMI_SMOPEN       2 /* open file */
+#define AMI_SMCLOSE      3 /* close file */
+#define AMI_SMSAVE       4 /* save file */
+#define AMI_SMSAVEAS     5 /* save file as name */
+#define AMI_SMPAGESET    6 /* page setup */
+#define AMI_SMPRINT      7 /* print */
+#define AMI_SMEXIT       8 /* exit program */
+#define AMI_SMUNDO       9 /* undo edit */
+#define AMI_SMCUT       10 /* cut selection */
+#define AMI_SMPASTE     11 /* paste selection */
+#define AMI_SMDELETE    12 /* delete selection */
+#define AMI_SMFIND      13 /* find text */
+#define AMI_SMFINDNEXT  14 /* find next */
+#define AMI_SMREPLACE   15 /* replace text */
+#define AMI_SMGOTO      16 /* goto line */
+#define AMI_SMSELECTALL 17 /* select all text */
+#define AMI_SMNEWWINDOW 18 /* new window */
+#define AMI_SMTILEHORIZ 19 /* tile child windows horizontally */
+#define AMI_SMTILEVERT  20 /* tile child windows vertically */
+#define AMI_SMCASCADE   21 /* cascade windows */
+#define AMI_SMCLOSEALL  22 /* close all windows */
+#define AMI_SMHELPTOPIC 23 /* help topics */
+#define AMI_SMABOUT     24 /* about this program */
+#define AMI_SMMAX       24 /* maximum defined standard menu entries */
+
+/* orientation for tab bars */
+typedef enum { ami_totop, ami_toright, ami_tobottom, ami_toleft } ami_tabori;
+
+/* settable items in find query */
+typedef enum { ami_qfncase, ami_qfnup, ami_qfnre } ami_qfnopt;
+typedef long ami_qfnopts;
+/* settable items in replace query */
+typedef enum { ami_qfrcase, ami_qfrup, ami_qfrre, ami_qfrfind, ami_qfrallfil,
+               ami_qfralllin } ami_qfropt;
+typedef long ami_qfropts;
+/* effects in font query */
+typedef enum { ami_qfteblink, ami_qftereverse, ami_qfteunderline,
+               ami_qftesuperscript, ami_qftesubscript, ami_qfteitalic,
+               ami_qftebold, ami_qftestrikeout, ami_qftestandout,
+               ami_qftecondensed, ami_qfteextended, ami_qftexlight,
+               ami_qftelight, ami_qftexbold, ami_qftehollow,
+               ami_qfteraised } ami_qfteffect;
+typedef long ami_qfteffects;
+
 typedef struct ami_menurec* ami_menuptr;
 typedef struct ami_menurec {
 
@@ -311,6 +439,92 @@ void ami_frame(FILE* f, long e);
 void ami_sizable(FILE* f, long e);
 void ami_sysbar(FILE* f, long e);
 void ami_menu(FILE* f, ami_menuptr m);
+
+/* string list, for list box style widgets */
+typedef struct ami_strrec* ami_strptr;
+typedef struct ami_strrec {
+
+    ami_strptr next; /* next entry in list */
+    char*    str;  /* string */
+
+} ami_strrec;
+
+/* Character mode widgets. These are implemented by the character mode window
+   manager, drawn entirely in character cells, and take character coordinates.
+   There are no graphical variants here: this is the character surface. */
+
+long ami_getwigid(FILE* f);
+void ami_killwidget(FILE* f, long id);
+void ami_selectwidget(FILE* f, long id, long e);
+void ami_enablewidget(FILE* f, long id, long e);
+void ami_getwidgettext(FILE* f, long id, char* s, long sl);
+void ami_putwidgettext(FILE* f, long id, char* s);
+void ami_sizwidget(FILE* f, long id, long x, long y);
+void ami_poswidget(FILE* f, long id, long x, long y);
+void ami_backwidget(FILE* f, long id);
+void ami_frontwidget(FILE* f, long id);
+void ami_focuswidget(FILE* f, long id);
+void ami_buttonsiz(FILE* f, char* s, long* w, long* h);
+void ami_button(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_checkboxsiz(FILE* f, char* s, long* w, long* h);
+void ami_checkbox(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_radiobuttonsiz(FILE* f, char* s, long* w, long* h);
+void ami_radiobutton(FILE* f, long x1, long y1, long x2, long y2, char* s,
+                     long id);
+void ami_groupsiz(FILE* f, char* s, long cw, long ch, long* w, long* h, long* ox,
+                  long* oy);
+void ami_group(FILE* f, long x1, long y1, long x2, long y2, char* s, long id);
+void ami_background(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollvertsiz(FILE* f, long* w, long* h);
+void ami_scrollvert(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollhorizsiz(FILE* f, long* w, long* h);
+void ami_scrollhoriz(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_scrollpos(FILE* f, long id, long r);
+void ami_scrollsiz(FILE* f, long id, long r);
+void ami_numselboxsiz(FILE* f, long l, long u, long* w, long* h);
+void ami_numselbox(FILE* f, long x1, long y1, long x2, long y2, long l, long u,
+                   long id);
+void ami_editboxsiz(FILE* f, char* s, long* w, long* h);
+void ami_editbox(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_progbarsiz(FILE* f, long* w, long* h);
+void ami_progbar(FILE* f, long x1, long y1, long x2, long y2, long id);
+void ami_progbarpos(FILE* f, long id, long pos);
+void ami_listboxsiz(FILE* f, ami_strptr sp, long* w, long* h);
+void ami_listbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id);
+void ami_slidehorizsiz(FILE* f, long* w, long* h);
+void ami_slidehoriz(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                    long id);
+void ami_slidevertsiz(FILE* f, long* w, long* h);
+void ami_slidevert(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                   long id);
+void ami_dropboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                    long* oh);
+void ami_dropbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id);
+void ami_dropeditboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                        long* oh);
+void ami_dropeditbox(FILE* f, long x1, long y1, long x2, long y2,
+                     ami_strptr sp, long id);
+void ami_tabbarsiz(FILE* f, ami_tabori tor, long cw, long ch, long* w, long* h,
+                   long* ox, long* oy);
+void ami_tabbarclient(FILE* f, ami_tabori tor, long w, long h, long* cw,
+                      long* ch, long* ox, long* oy);
+void ami_tabbar(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                ami_tabori tor, long id);
+void ami_tabsel(FILE* f, long id, long tn);
+
+/* Standard dialogs. These are presented inside the terminal surface as
+   managed windows, rather than as host system dialogs. */
+
+void ami_alert(char* title, char* message);
+void ami_querycolor(long* r, long* g, long* b);
+void ami_queryopen(char* s, long sl);
+void ami_querysave(char* s, long sl);
+void ami_queryfind(char* s, long sl, ami_qfnopts* opt);
+void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt);
+void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
+                   long* br, long* bg, long* bb, ami_qfteffects* effect);
 void ami_menuena(FILE* f, long id, long onoff);
 void ami_menusel(FILE* f, long id, long select);
 void ami_stdmenu(ami_stdmenusel sms, ami_menuptr* sm, ami_menuptr pm);
@@ -701,4 +915,4 @@ void _pa_frameover_ovr(_pa_frameover_t eh, _pa_frameover_t* oeh);
 }
 #endif
 
-#endif /* __TERMINAL_H__ */
+#endif /* __TERMINALW_H__ */

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -2666,67 +2666,6 @@ static void clrbuf(scnptr sc)
 
 /** ****************************************************************************
 
-Grow screen buffers
-
-Grows the screen buffers to at least the given dimensions, keeping their
-contents. Used when the onscreen surface expands: the buffers start at the
-surface size, and without this everything written beyond the old bounds was
-silently clipped. The buffers never shrink, since the display simply clips
-to a smaller surface and the content is kept.
-
-*******************************************************************************/
-
-static void growbuf(long nx, long ny)
-
-{
-
-    scnrec* ns; /* new screen */
-    scnrec* os; /* old screen */
-    scnrec* sp;
-    long    x, y;
-    int     si;
-
-    if (nx <= bufx && ny <= bufy) return; /* nothing to grow */
-    if (nx < bufx) nx = bufx; /* never shrink */
-    if (ny < bufy) ny = bufy;
-    for (si = 0; si < MAXCON; si++) if (screens[si]) {
-
-        os = screens[si]; /* index old screen */
-        ns = malloc(sizeof(scnrec)*ny*nx);
-        if (!ns) error(ami_dispenomem); /* no memory for screen */
-        for (y = 1; y <= ny; y++)
-            for (x = 1; x <= nx; x++) {
-
-            sp = &ns[(y-1)*nx+(x-1)]; /* index new cell */
-            if (x <= bufx && y <= bufy)
-                /* keep old contents */
-                *sp = os[(y-1)*bufx+(x-1)];
-            else { /* new cell, blank with current colors */
-
-                plcchrext(sp, ' ');
-#ifdef NATIVE24
-                sp->forergb = forergb;
-                sp->backrgb = backrgb;
-#else
-                sp->forec = forec;
-                sp->backc = backc;
-#endif
-                sp->attr = attr;
-
-            }
-
-        }
-        free(os); /* release the old screen */
-        screens[si] = ns;
-
-    }
-    bufx = nx; /* set new buffer size */
-    bufy = ny;
-
-}
-
-/** ****************************************************************************
-
 Initialize screen
 
 Clears all the parameters in the present screen context, and updates the
@@ -4763,9 +4702,6 @@ static void event_ivf(FILE* f, ami_evtrec *er)
             /* set new size */
             dimx = er->rszx;
             dimy = er->rszy;
-            /* an expanded surface needs expanded buffers, or output past
-               the old bounds is clipped */
-            growbuf(dimx, dimy);
             /* linux/xterm has an oddity here, if the winch contracts in y, it
                occasionally relocates the buffer contents up. This means we
                always need to refresh, and means it can flash. */

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -1020,44 +1020,16 @@ Uses the write() override.
 
 *******************************************************************************/
 
-/* Output batching. Every emitted byte lands here, and used to be a write()
-   system call of its own, which made large updates (and especially the
-   character window manager) unacceptably slow. Bytes now collect in this
-   buffer and go out in one write when it fills, and at the points where
-   output must be visible: before waiting for input or events, and at
-   shutdown. The terminal receives an identical byte stream, only in fewer
-   pieces. */
-
-#define OUTBUFSIZ 16384 /* size of the output batching buffer */
-
-static unsigned char outbuf[OUTBUFSIZ]; /* output batching buffer */
-static int           outbuflen = 0;     /* bytes in the buffer */
-
-static void flushout(void)
-
-{
-
-    ssize_t rc;      /* return code */
-    int     off = 0; /* offset into buffer */
-
-    while (off < outbuflen) { /* until the buffer is drained */
-
-        /* send to the next handler in the override chain */
-        rc = (*ofpwrite)(OUTFIL, outbuf+off, outbuflen-off);
-        if (rc <= 0) error(ami_dispeoutdev); /* output device error */
-        off += rc;
-
-    }
-    outbuflen = 0; /* buffer now empty */
-
-}
-
 static void putchr(unsigned char c)
 
 {
 
-    outbuf[outbuflen++] = c; /* place character in the batch */
-    if (outbuflen >= OUTBUFSIZ) flushout(); /* full, send it out */
+    ssize_t rc; /* return code */
+
+    /* send character to the next hander in the override chain */
+    rc = (*ofpwrite)(OUTFIL, &c, 1);
+
+    if (rc != 1) error(ami_dispeoutdev); /* output device error */
 
 }
 
@@ -2226,10 +2198,6 @@ static void ievent(void)
     do { /* match input events */
 
         evtfnd = 0; /* set no event found */
-        /* everything drawn must be onscreen before we wait */
-        pthread_mutex_lock(&termlock);
-        flushout();
-        pthread_mutex_unlock(&termlock);
         system_event_getsevt(&sev); /* get the next system event */
         /* check the read file has signaled */
         if (sev.typ == se_inp && sev.lse == inpsev) {
@@ -3624,9 +3592,6 @@ static ssize_t iread(int fd, void* buff, size_t count)
         while (cnt) {
 
             pthread_mutex_lock(&termlock); /* lock terminal broadlock */
-            /* a prompt may have been written; it must be visible before we
-               block for input */
-            flushout();
             /* if there is no line in the input buffer, get one */
             if (inpptr == -1) readline();
             *p = inpbuf[inpptr]; /* get and place next character */
@@ -4685,14 +4650,6 @@ static void event_ivf(FILE* f, ami_evtrec *er)
 
         }
 
-        /* Everything drawn must be onscreen before we block for an event.
-           This flush must be here, in the caller's thread: the event
-           thread's own flush only runs when a system event wakes it, so
-           output batched by this thread after that would otherwise sit in
-           the buffer for as long as the input stays quiet. */
-        pthread_mutex_lock(&termlock);
-        flushout();
-        pthread_mutex_unlock(&termlock);
         /* get next input event */
         dequepaevt(er); /* get next queued event */
         pthread_mutex_lock(&termlock); /* lock terminal broadlock */
@@ -5105,14 +5062,15 @@ Writes a string direct to the terminal, bypassing character handling.
 
 APIOVER(wrtstr)
 void ami_wrtstr(FILE* f, char* s) { (*wrtstr_vect)(f, s); }
+static void wrtstrn_ivf(FILE* f, char *s, long n); /* forward */
+
 static void wrtstr_ivf(FILE* f, char *s)
 
 {
 
     dbg_printf(dlapi, "API\n");
-    pthread_mutex_lock(&termlock); /* lock terminal broadlock */
-    putstrc(s);
-    pthread_mutex_unlock(&termlock); /* release terminal broadlock */
+    /* the counted form does the work, in one piece */
+    wrtstrn_ivf(f, s, strlen(s));
 
 }
 
@@ -5131,9 +5089,24 @@ static void wrtstrn_ivf(FILE* f, char *s, long n)
 
 {
 
+    ssize_t rc;      /* return code */
+    long    off = 0; /* offset into the string */
+
     dbg_printf(dlapi, "API\n");
     pthread_mutex_lock(&termlock); /* lock terminal broadlock */
-    while (n--) putchr(*s++);
+    /* Send the run in one piece. This call exists to bypass the per
+       character protocol, and emitting it a character at a time, which is
+       a write() each, gave up the very saving it is for. The caller's side
+       of that bargain is that the string holds no control characters. */
+    while (off < n) {
+
+        rc = (*ofpwrite)(OUTFIL, s+off, n-off);
+        if (rc <= 0) error(ami_dispeoutdev); /* output device error */
+        off += rc;
+
+    }
+    /* the cursor moved by the length written, and we did not track it */
+    curval = 0;
     pthread_mutex_unlock(&termlock); /* release terminal broadlock */
 
 }
@@ -5978,6 +5951,5 @@ static void ami_deinit_terminal()
 
     /* back to normal buffer on xterm */
     putstrc("\033[?1049l"); fflush(stdout);
-    flushout(); /* drain the output batch on the way out */
 
 }

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -1975,7 +1975,8 @@ static void synccur(scnptr sc)
         if (icurbnd(sc)) {
 
             /* set cursor position */
-            if ((ncurx != curx || ncury != cury) && curval) {
+            if (curval && ncurx == curx && ncury == cury) ; /* already there */
+            else if (curval) {
 
                 /* Cursor position and actual don't match. Try some optimized
                    cursor positions to reduce bandwidth. Note we don't count on
@@ -1993,11 +1994,8 @@ static void synccur(scnptr sc)
 
             } else {
 
-                /* don't count on physical cursor location, just reset */
+                /* the physical position is not known, state it outright */
                 trm_cursorset(ncurx, ncury);
-                curx = ncurx;
-                cury = ncury;
-                curval = 1;
 
             }
 

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -1768,6 +1768,25 @@ static void trm_cursor(long x, long y)
 
 }
 
+static int curdef = 0; /* a cursor state is recorded but not yet emitted */
+
+/* Position the cursor and record that the physical cursor is now there.
+   Routines that move the cursor about the screen for their own purposes,
+   such as scrolling and restoring, must use this rather than trm_cursor:
+   leaving the tracker stale lets a later positioning take a relative move
+   from a position the cursor is no longer at. */
+static void trm_cursorset(long x, long y)
+
+{
+
+    trm_cursor(x, y);
+    curx = x; /* the physical cursor is here now */
+    cury = y;
+    curval = 1; /* and the record of it is good */
+    curdef = 0; /* any deferred position has just been satisfied */
+
+}
+
 /** set title */
 static void trm_title(char* title)
 
@@ -1931,8 +1950,6 @@ to bring the old state of the display to the same state as the new display.
    from the two places where it becomes observable: just before characters
    are put out, and before waiting on the user. */
 
-static int curdef = 0; /* a cursor state is recorded but not yet emitted */
-
 static void setcur(scnptr sc)
 
 {
@@ -1973,7 +1990,7 @@ static void synccur(scnptr sc)
             } else {
 
                 /* don't count on physical cursor location, just reset */
-                trm_cursor(ncurx, ncury);
+                trm_cursorset(ncurx, ncury);
                 curx = ncurx;
                 cury = ncury;
                 curval = 1;
@@ -2105,7 +2122,7 @@ static void restore(scnptr sc)
 #endif
         for (yi = 1; yi <= bufy; yi++) {
 
-            trm_cursor(bufx+1, yi); /* locate to line start */
+            trm_cursorset(bufx+1, yi); /* locate to line start */
             for (xi = bufx+1; xi <= dimx; xi++) putchr(' '); /* fill */
 
         }
@@ -2121,7 +2138,7 @@ static void restore(scnptr sc)
 #endif
         for (yi = bufy+1; yi <= dimy; yi++) {
 
-            trm_cursor(1, yi); /* locate to line start */
+            trm_cursorset(1, yi); /* locate to line start */
             for (xi = 1; xi <= dimx; xi++) putchr(' '); /* fill */
 
         }
@@ -2817,7 +2834,7 @@ static void iscroll(scnptr sc, long x, long y)
             trm_curoff(); /* turn cursor off for display */
             curon = FALSE;
             /* downward straight scroll, we can do this with native scrolling */
-            trm_cursor(1, dimy); /* position to bottom of screen */
+            trm_cursorset(1, dimy); /* position to bottom of screen */
             /* use linefeed to scroll. linefeeds work no matter the state of
                wrap, and use whatever the current background color is */
             yi = y;   /* set line count */
@@ -2828,7 +2845,7 @@ static void iscroll(scnptr sc, long x, long y)
 
             }
             /* restore cursor position */
-            trm_cursor(ncurx, ncury);
+            trm_cursorset(ncurx, ncury);
             cursts(sc); /* re-enable cursor */
 
         }
@@ -2864,7 +2881,7 @@ static void iscroll(scnptr sc, long x, long y)
             trm_clear();   /* scroll would result in complete clear, do it */
             clrbuf(sc);   /* clear the screen buffer */
             /* restore cursor position */
-            trm_cursor(ncurx, ncury);
+            trm_cursorset(ncurx, ncury);
 
         } else { /* scroll */
 
@@ -3609,7 +3626,7 @@ static void finish(char* title)
             i = 0; /* set string start */
             xs = dimx/2-ml/2; /* set centered line start */
             if (xs < 1) xs = 1; /* if string too long, clip right */
-            trm_cursor(xs, 1); /* move cursor to start */
+            trm_cursorset(xs, 1); /* move cursor to start */
             for (xi = xs; xi <= dimx && i < ml; xi++) {
 
                 p = &SCNBUF(sc, xi, 1); /* index this screen element */

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -1041,14 +1041,73 @@ Writes a string directly to the output file.
 
 *******************************************************************************/
 
+/* Control sequence assembly. A sequence is built here and sent in one
+   write, rather than a system call per byte. Nothing about the byte stream
+   changes, only the number of pieces it arrives in. */
+
+#define SEQMAX 64 /* longest control sequence assembled */
+
+static char seqbuf[SEQMAX]; /* sequence under construction */
+static int  seqlen = 0;     /* length so far */
+
+/* place a character in the sequence under construction */
+static void seqchr(char c)
+
+{
+
+    if (seqlen < SEQMAX-1) seqbuf[seqlen++] = c;
+
+}
+
+/* place a string in the sequence under construction */
+static void seqstr(const char* s)
+
+{
+
+    while (*s) seqchr(*s++);
+
+}
+
+/* place an integer, in decimal, in the sequence under construction */
+static void seqint(long i)
+
+{
+
+    char b[24];
+    int  n = 0;
+
+    if (i < 0) { seqchr('-'); i = -i; }
+    do { b[n++] = i%10+'0'; i = i/10; } while (i && n < 24);
+    while (n) seqchr(b[--n]);
+
+}
+
+/* send the assembled sequence in one piece */
+static void seqout(void)
+
+{
+
+    ssize_t rc;      /* return code */
+    int     off = 0; /* offset into the sequence */
+
+    while (off < seqlen) {
+
+        rc = (*ofpwrite)(OUTFIL, seqbuf+off, seqlen-off);
+        if (rc <= 0) error(ami_dispeoutdev); /* output device error */
+        off += rc;
+
+    }
+    seqlen = 0;
+
+}
+
 static void putstr(unsigned char *s)
 
 
 {
 
-    /** index for string */ int i;
-
-    while (*s) putchr(*s++); /* output characters */
+    seqstr((const char*)s); /* assemble */
+    seqout(); /* and send in one piece */
 
 }
 
@@ -1065,9 +1124,8 @@ static void putstrc(char *s)
 
 {
 
-    /** index for string */ int i;
-
-    while (*s) putchr(*s++); /* output characters */
+    seqstr(s); /* assemble */
+    seqout(); /* and send in one piece */
 
 }
 
@@ -1618,19 +1676,21 @@ static void trm_colorrgbc(int fore, int r, int g, int b)
 
     if (havetruecolor()) {
 
-        putstrc(fore? "\33[38;2;": "\33[48;2;");
-        wrtint(r);
-        putstrc(";");
-        wrtint(g);
-        putstrc(";");
-        wrtint(b);
-        putstrc("m");
+        seqstr(fore? "\33[38;2;": "\33[48;2;");
+        seqint(r);
+        seqchr(';');
+        seqint(g);
+        seqchr(';');
+        seqint(b);
+        seqchr('m');
+        seqout();
 
     } else { /* fall back to the 256 color palette */
 
-        putstrc(fore? "\33[38;5;": "\33[48;5;");
-        wrtint(rgb256(r, g, b));
-        putstrc("m");
+        seqstr(fore? "\33[38;5;": "\33[48;5;");
+        seqint(rgb256(r, g, b));
+        seqchr('m');
+        seqout();
 
     }
 
@@ -1699,11 +1759,12 @@ static void trm_cursor(long x, long y)
 
 {
 
-    putstrc("\33[");
-    wrtint(y);
-    putstrc(";");
-    wrtint(x);
-    putstrc("H");
+    seqstr("\33["); /* assemble the whole position, then send it once */
+    seqint(y);
+    seqchr(';');
+    seqint(x);
+    seqchr('H');
+    seqout();
 
 }
 
@@ -1862,10 +1923,31 @@ to bring the old state of the display to the same state as the new display.
 
 *******************************************************************************/
 
+/* Cursor emission is deferred. Positioning the cursor costs a control
+   sequence, and a program that walks the cursor about while drawing pays
+   for every step of the walk even though only the last position before an
+   output, or before the user is given the chance to look, can be observed.
+   setcur() therefore records the wanted position, and synccur() emits it,
+   from the two places where it becomes observable: just before characters
+   are put out, and before waiting on the user. */
+
+static int curdef = 0; /* a cursor state is recorded but not yet emitted */
+
 static void setcur(scnptr sc)
 
 {
 
+    if (indisp(sc)) curdef = 1; /* wanted state noted, emit it when needed */
+
+}
+
+/* emit the recorded cursor state, if there is one outstanding */
+static void synccur(scnptr sc)
+
+{
+
+    if (!curdef) return; /* nothing outstanding */
+    curdef = 0;
     if (indisp(sc)) { /* in display */
 
         /* check cursor in bounds */
@@ -3144,8 +3226,12 @@ static void plcchr(scnptr sc, unsigned char c)
             /* This handling is from iright. We do this here because
                placement implicitly moves the cursor */
             if (ncurx >= 1 && ncurx <= bufx &&
-                ncury >= 1 && ncury <= bufy)
+                ncury >= 1 && ncury <= bufy) {
+
+                synccur(sc); /* the character lands at the cursor: place it */
                 putchr(c); /* output character to terminal */
+
+            }
 #ifdef ALLOWUTF8
             if (!utf8cnt)
 #endif
@@ -3592,6 +3678,7 @@ static ssize_t iread(int fd, void* buff, size_t count)
         while (cnt) {
 
             pthread_mutex_lock(&termlock); /* lock terminal broadlock */
+            synccur(screens[curdsp-1]); /* about to wait on the user */
             /* if there is no line in the input buffer, get one */
             if (inpptr == -1) readline();
             *p = inpbuf[inpptr]; /* get and place next character */
@@ -4650,6 +4737,11 @@ static void event_ivf(FILE* f, ami_evtrec *er)
 
         }
 
+        /* The user is about to be given the chance to look, so the
+           cursor must be where it belongs before we wait. */
+        pthread_mutex_lock(&termlock);
+        synccur(screens[curdsp-1]);
+        pthread_mutex_unlock(&termlock);
         /* get next input event */
         dequepaevt(er); /* get next queued event */
         pthread_mutex_lock(&termlock); /* lock terminal broadlock */
@@ -5094,6 +5186,7 @@ static void wrtstrn_ivf(FILE* f, char *s, long n)
 
     dbg_printf(dlapi, "API\n");
     pthread_mutex_lock(&termlock); /* lock terminal broadlock */
+    synccur(screens[curupd-1]); /* the run lands at the cursor: place it */
     /* Send the run in one piece. This call exists to bypass the per
        character protocol, and emitting it a character at a time, which is
        a write() each, gave up the very saving it is for. The caller's side

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -761,6 +761,9 @@ static void error_ivf(ami_errcod e)
 
 {
 
+    /* leave the alternate screen first, or the message is written to it
+       and discarded when the exit sequence switches back */
+    fprintf(stderr, "\033[0m\033[?1049l\r\n");
     fprintf(stderr, "*** Error: xterm: ");
     switch (e) { /* error */
 
@@ -1017,16 +1020,44 @@ Uses the write() override.
 
 *******************************************************************************/
 
+/* Output batching. Every emitted byte lands here, and used to be a write()
+   system call of its own, which made large updates (and especially the
+   character window manager) unacceptably slow. Bytes now collect in this
+   buffer and go out in one write when it fills, and at the points where
+   output must be visible: before waiting for input or events, and at
+   shutdown. The terminal receives an identical byte stream, only in fewer
+   pieces. */
+
+#define OUTBUFSIZ 16384 /* size of the output batching buffer */
+
+static unsigned char outbuf[OUTBUFSIZ]; /* output batching buffer */
+static int           outbuflen = 0;     /* bytes in the buffer */
+
+static void flushout(void)
+
+{
+
+    ssize_t rc;      /* return code */
+    int     off = 0; /* offset into buffer */
+
+    while (off < outbuflen) { /* until the buffer is drained */
+
+        /* send to the next handler in the override chain */
+        rc = (*ofpwrite)(OUTFIL, outbuf+off, outbuflen-off);
+        if (rc <= 0) error(ami_dispeoutdev); /* output device error */
+        off += rc;
+
+    }
+    outbuflen = 0; /* buffer now empty */
+
+}
+
 static void putchr(unsigned char c)
 
 {
 
-    ssize_t rc; /* return code */
-
-    /* send character to the next hander in the override chain */
-    rc = (*ofpwrite)(OUTFIL, &c, 1);
-
-    if (rc != 1) error(ami_dispeoutdev); /* output device error */
+    outbuf[outbuflen++] = c; /* place character in the batch */
+    if (outbuflen >= OUTBUFSIZ) flushout(); /* full, send it out */
 
 }
 
@@ -2195,6 +2226,10 @@ static void ievent(void)
     do { /* match input events */
 
         evtfnd = 0; /* set no event found */
+        /* everything drawn must be onscreen before we wait */
+        pthread_mutex_lock(&termlock);
+        flushout();
+        pthread_mutex_unlock(&termlock);
         system_event_getsevt(&sev); /* get the next system event */
         /* check the read file has signaled */
         if (sev.typ == se_inp && sev.lse == inpsev) {
@@ -2626,6 +2661,67 @@ static void clrbuf(scnptr sc)
         sp->attr = attr;
 
     }
+
+}
+
+/** ****************************************************************************
+
+Grow screen buffers
+
+Grows the screen buffers to at least the given dimensions, keeping their
+contents. Used when the onscreen surface expands: the buffers start at the
+surface size, and without this everything written beyond the old bounds was
+silently clipped. The buffers never shrink, since the display simply clips
+to a smaller surface and the content is kept.
+
+*******************************************************************************/
+
+static void growbuf(long nx, long ny)
+
+{
+
+    scnrec* ns; /* new screen */
+    scnrec* os; /* old screen */
+    scnrec* sp;
+    long    x, y;
+    int     si;
+
+    if (nx <= bufx && ny <= bufy) return; /* nothing to grow */
+    if (nx < bufx) nx = bufx; /* never shrink */
+    if (ny < bufy) ny = bufy;
+    for (si = 0; si < MAXCON; si++) if (screens[si]) {
+
+        os = screens[si]; /* index old screen */
+        ns = malloc(sizeof(scnrec)*ny*nx);
+        if (!ns) error(ami_dispenomem); /* no memory for screen */
+        for (y = 1; y <= ny; y++)
+            for (x = 1; x <= nx; x++) {
+
+            sp = &ns[(y-1)*nx+(x-1)]; /* index new cell */
+            if (x <= bufx && y <= bufy)
+                /* keep old contents */
+                *sp = os[(y-1)*bufx+(x-1)];
+            else { /* new cell, blank with current colors */
+
+                plcchrext(sp, ' ');
+#ifdef NATIVE24
+                sp->forergb = forergb;
+                sp->backrgb = backrgb;
+#else
+                sp->forec = forec;
+                sp->backc = backc;
+#endif
+                sp->attr = attr;
+
+            }
+
+        }
+        free(os); /* release the old screen */
+        screens[si] = ns;
+
+    }
+    bufx = nx; /* set new buffer size */
+    bufy = ny;
 
 }
 
@@ -3166,9 +3262,13 @@ static void plcchr(scnptr sc, unsigned char c)
 
                     /* prevent overflow, but otherwise its unlimited */
                     if (ncurx < LONG_MAX) ncurx++;
-                    /* don't count on physical cursor behavior if scrolling is
-                       off and we are at extreme right */
-                    curval = 0;
+                    /* Don't count on physical cursor behavior if scrolling is
+                       off and we are at the extreme right. Note the
+                       condition: invalidating unconditionally here caused a
+                       full cursor position sequence to be emitted after
+                       every character output with auto off, about a twelve
+                       times expansion of the output. */
+                    if (curx >= dimx) curval = 0;
 
                 }
                 setcur(sc); /* update physical cursor */
@@ -3585,6 +3685,9 @@ static ssize_t iread(int fd, void* buff, size_t count)
         while (cnt) {
 
             pthread_mutex_lock(&termlock); /* lock terminal broadlock */
+            /* a prompt may have been written; it must be visible before we
+               block for input */
+            flushout();
             /* if there is no line in the input buffer, get one */
             if (inpptr == -1) readline();
             *p = inpbuf[inpptr]; /* get and place next character */
@@ -4643,6 +4746,14 @@ static void event_ivf(FILE* f, ami_evtrec *er)
 
         }
 
+        /* Everything drawn must be onscreen before we block for an event.
+           This flush must be here, in the caller's thread: the event
+           thread's own flush only runs when a system event wakes it, so
+           output batched by this thread after that would otherwise sit in
+           the buffer for as long as the input stays quiet. */
+        pthread_mutex_lock(&termlock);
+        flushout();
+        pthread_mutex_unlock(&termlock);
         /* get next input event */
         dequepaevt(er); /* get next queued event */
         pthread_mutex_lock(&termlock); /* lock terminal broadlock */
@@ -4652,6 +4763,9 @@ static void event_ivf(FILE* f, ami_evtrec *er)
             /* set new size */
             dimx = er->rszx;
             dimy = er->rszy;
+            /* an expanded surface needs expanded buffers, or output past
+               the old bounds is clipped */
+            growbuf(dimx, dimy);
             /* linux/xterm has an oddity here, if the winch contracts in y, it
                occasionally relocates the buffer contents up. This means we
                always need to refresh, and means it can flash. */
@@ -5928,5 +6042,6 @@ static void ami_deinit_terminal()
 
     /* back to normal buffer on xterm */
     putstrc("\033[?1049l"); fflush(stdout);
+    flushout(); /* drain the output batch on the way out */
 
 }

--- a/linux/terminal.c
+++ b/linux/terminal.c
@@ -259,7 +259,8 @@ typedef enum {
     /* superscript */                sasuper,
     /* subscripting */               sasubs,
     /* italic text */                saital,
-    /* bold text */                  sabold
+    /* bold text */                  sabold,
+    /* struck out text */            sastkout
 
 } scnatt;
 
@@ -1617,6 +1618,8 @@ static void trm_clear(void) { putstrc("\33[2J\33[H"); }
 /** turn on underline */ static void trm_undl(void) { putstrc("\33[4m"); }
 /** turn on bold attribute */ static void trm_bold(void) { putstrc("\33[1m"); }
 /** turn on italic attribute */ static void trm_ital(void) { putstrc("\33[3m"); }
+/** turn on strikeout attribute */
+static void trm_stkout(void) { putstrc("\33[9m"); }
 /** turn off all attributes */
 static void trm_attroff(void) { putstrc("\33[0m"); }
 /** turn on cursor wrap */ static void trm_wrapon(void) { putstrc("\33[7h"); }
@@ -1851,6 +1854,7 @@ static void setattr(scnptr sc, scnatt a)
             case sasubs:  break;                /* subscripting */
             case saital:  trm_ital();    break; /* italic text */
             case sabold:  trm_bold();    break; /* bold text */
+            case sastkout: trm_stkout(); break; /* struck out text */
 
         }
         /* attribute off may change the colors back to "normal" (normal for that
@@ -4237,9 +4241,9 @@ static void bold_ivf(FILE *f, long e)
 
 Turn on strikeout attribute
 
-Turns on/off the strikeout attribute.
-
-Not implemented.
+Turns on/off the strikeout attribute. This is SGR 9, which the terminals
+that came after the fixed function ones generally present; one that does
+not simply leaves the text unmarked, as with any other attribute it lacks.
 
 *******************************************************************************/
 
@@ -4250,7 +4254,7 @@ static void strikeout_ivf(FILE *f, long e)
 {
 
     dbg_printf(dlapi, "API\n");
-    /* no capability */
+    attronoff(f, e, sastkout); /* enable/disable attribute */
 
 }
 

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -4259,6 +4259,14 @@ static void intevent(FILE* f)
                    in content, or the root background beyond the old bounds
                    can never be restored. */
                 growwinbuf(win, dimx, dimy);
+                /* The layer below keeps its own screen buffers, sized when
+                   it started, and clips writes to them. Grow those through
+                   the standard call rather than by reaching into that
+                   module: the manager runs over any terminal implementation
+                   and must not require changes in it. The contents are
+                   discarded by that call, which costs nothing here since
+                   the whole surface is repainted below. */
+                (*sizbuf_vect)(stdout, dimx, dimy);
 
             }
             recalcfmask(); /* occlusion clips to the new bounds */

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -2039,6 +2039,10 @@ static void restoreclp(winptr win,   /* window to restore */
     long bx, by;   /* buffer location */
     long l;        /* mask index */
     rectangle r1, r2;
+    char runbuf[MAXLIN]; /* run of characters to emit as a string */
+    long runx;           /* screen x the run starts at */
+    ami_color runfc, runbc; /* the run's colors */
+    int  runat;          /* the run's attributes */
 
     if (win->bufmod && win->visible)  { /* buffered mode is on, and visible */
 
@@ -2065,21 +2069,68 @@ static void restoreclp(winptr win,   /* window to restore */
                overlaps it. The cursor is positioned per cell, which costs
                nothing for consecutive visible cells, since the position
                cache knows the cursor advances with each character. */
+            /* Draw in runs. A run is a stretch of cells on one line that
+               are visible, share colors and attributes, and hold no
+               control character. Those go out with one string call, which
+               exists to bypass the per character protocol below; the
+               leftovers go a character at a time. Drawing every cell
+               singly was the bulk of the manager's output cost. */
             for (y = r2.y1; y <= r2.y2; y++) {
 
-                for (x = r2.x1; x <= r2.x2; x++) {
+                long rl = 0; /* length of the run being gathered */
 
-                    bx = x-(win->orgx+win->coffx)+1; /* buffer location */
-                    by = y-(win->orgy+win->coffy)+1;
-                    l = (by-1)*win->bufx+(bx-1); /* mask index */
-                    if (win->fmask[l/8] & 1<<(l%8)) { /* not occluded */
+                for (x = r2.x1; x <= r2.x2+1; x++) {
 
-                        scp = &SCNBUF(sc, bx, by); /* index character */
-                        setcursor(x, y); /* at that location */
-                        setfcolor(scp->forec); /* set colors */
-                        setbcolor(scp->backc);
-                        setattrs(scp->attr); /* set attributes */
-                        wrtchr(scp->ch); /* output character */
+                    int vis = FALSE;
+
+                    scp = NULL;
+                    if (x <= r2.x2) { /* a real cell, not the end sentinel */
+
+                        bx = x-(win->orgx+win->coffx)+1; /* buffer location */
+                        by = y-(win->orgy+win->coffy)+1;
+                        l = (by-1)*win->bufx+(bx-1); /* mask index */
+                        vis = !!(win->fmask[l/8] & 1<<(l%8));
+                        if (vis) scp = &SCNBUF(sc, bx, by);
+
+                    }
+                    /* a cell continues the run if it is visible, matches
+                       the run's colors and attributes, and is printable */
+                    if (scp && scp->ch >= ' ' && scp->ch != 0x7f &&
+                        (!rl || (scp->forec == runfc && scp->backc == runbc &&
+                                 scp->attr == runat)) && rl < MAXLIN-1) {
+
+                        if (!rl) { /* starting a run, note its state */
+
+                            runfc = scp->forec;
+                            runbc = scp->backc;
+                            runat = scp->attr;
+                            runx = x;
+
+                        }
+                        runbuf[rl++] = scp->ch;
+
+                    } else { /* the run ends here */
+
+                        if (rl) { /* flush what was gathered */
+
+                            setcursor(runx, y);
+                            setfcolor(runfc);
+                            setbcolor(runbc);
+                            setattrs(runat);
+                            (*wrtstrn_vect)(stdout, runbuf, rl);
+                            curx += rl; /* the string moved the cursor */
+                            rl = 0;
+
+                        }
+                        if (scp) { /* an odd cell, place it singly */
+
+                            setcursor(x, y);
+                            setfcolor(scp->forec);
+                            setbcolor(scp->backc);
+                            setattrs(scp->attr);
+                            wrtchr(scp->ch);
+
+                        }
 
                     }
 

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -104,7 +104,7 @@ extern char *program_invocation_short_name;
 #define USEUNICODE   /* use unicode frame characters */
 //#define PRTROOTEVT /* print root window events */
 //#define PRTEVT     /* print outbound events */
-//#define PRTFMASK   /* print the forward masks calculated */
+//#define PRTFMASK /* print the forward masks calculated */
 
 /* file handle numbers at the system interface level */
 #define INPFIL 0 /* handle to standard input */
@@ -312,6 +312,17 @@ typedef struct {
 
 /* window description */
 typedef struct winrec* winptr;
+typedef struct wigrec* wigptr;
+
+/* menu enable state, kept per window aside the caller's menu records */
+typedef struct menena* menenaptr;
+typedef struct menena {
+
+    struct menena* next;
+    long id;   /* menu item id */
+    int  ena;  /* enabled */
+
+} menena;
 typedef struct winrec {
 
     winptr   next;              /* next entry (for free list) */
@@ -366,11 +377,53 @@ typedef struct winrec {
     int      zorder;            /* Z ordering of window, 0 = bottom, N = top */
     unsigned char* fmask;       /* forward mask in bits per character */
     long     fmasklen;          /* length of the bitmask */
+    int      widget;            /* window is a widget face */
+    wigptr   wig;               /* widget data if so */
+    wigptr   wiglst;            /* list of widgets owned by this window */
+    ami_menuptr amenu;          /* API menu attached to this window */
+    wigptr   mbar;              /* the menu bar widget if a menu is on */
+    menenaptr menena;           /* menu item enable states */
     int      timers[AMI_MAXTIM]; /* timer id array */
     int      frmtim;            /* frame timer */
     ami_color frmcolor;          /* frame color */
 
 } winrec;
+
+/* widget types */
+typedef enum {
+
+    wtbutton, wtcheckbox, wtradio, wtgroup, wtbackground,
+    wtscrollvert, wtscrollhoriz, wtnumselbox, wteditbox, wtprogbar,
+    wtlistbox, wtslidehoriz, wtslidevert, wtdropbox, wtdropeditbox,
+    wttabbar, wtmenubar, wtpopup
+
+} wigtyp;
+
+/* widget tracking record. A widget is a small frameless subwindow of its
+   owning window, drawn in character cells, whose events are intercepted
+   and translated to widget events for the owner. */
+typedef struct wigrec {
+
+    wigptr next;    /* next widget in the owner's list */
+    long   id;      /* widget logical id, unique per owner */
+    wigtyp typ;     /* type of widget */
+    winptr parent;  /* owning window */
+    FILE*  wf;      /* widget subwindow file */
+    winptr win;     /* widget subwindow record */
+    char*  face;    /* label, or edit box content */
+    char** list;    /* list box strings */
+    long   listn;   /* number of list strings */
+    int    enb;     /* enabled */
+    int    sel;     /* selected state */
+    long   val;     /* value: numsel, progress, scroll and slider position */
+    long   low, high; /* numsel range */
+    long   sclsiz;  /* scroll bar thumb size, full scale */
+    long   curs;    /* edit box cursor index, 0 based */
+    ami_tabori tor; /* tab bar orientation */
+    wigptr owner;   /* for popups, the widget or bar that opened it */
+    ami_menuptr mitems; /* for menu popups, the item list shown */
+
+} wigrec;
 
 /* File tracking.
   Files can be passthrough to the OS, or can be associated with a window. If
@@ -474,6 +527,10 @@ static int      fautohold;    /* automatic hold on exit flag */
 static int      fend;         /* end of program ordered flag */
 static drgtyp   drag;         /* drag type in progress */
 static winptr   drgwin;       /* drag window */
+static wigptr   drgwig;       /* drag widget (slider or scroll thumb) */
+#define MAXPOP 8              /* maximum popup nesting (menu cascade) */
+static wigptr   popstk[MAXPOP]; /* open popup stack, bottom first */
+static int      popcnt;       /* number of open popups */
 static long     drgx;         /* drag pin x */
 static long     drgy;         /* drag pin y */
 static ami_pevthan evthan[ami_etmenus+1]; /* array of event handler routines */
@@ -498,6 +555,13 @@ static void error(
 
 {
 
+    /* Leave the alternate screen before reporting. The message would
+       otherwise be written onto the alternate screen, which the exit
+       sequence then switches away from and discards, leaving the user
+       looking at a blank screen or a single stray character of the
+       message. stderr shares the terminal with stdout, so the sequence
+       takes effect from here. */
+    fprintf(stderr, "\033[0m\033[?1049l\r\n");
     fprintf(stderr, "Error: Managerc: %s\n", es);
     fflush(stderr);
 
@@ -705,6 +769,19 @@ static winptr getwin(void)
         winfre = p->next; /* gap from list */
 
     } else p = malloc(sizeof(winrec));
+    if (!p) error("Out of memory");
+    /* The forward mask is examined before opnwin allocates it, when the Z
+       order lists are remade with this window first entered into them, so
+       it cannot be left as garbage from malloc or from the record's
+       previous life. */
+    p->fmask = NULL;
+    p->fmasklen = 0;
+    p->widget = FALSE; /* not a widget, and owns no widgets */
+    p->wig = NULL;
+    p->wiglst = NULL;
+    p->amenu = NULL; /* no API menu */
+    p->mbar = NULL;
+    p->menena = NULL;
 
     return (p);
 
@@ -1535,6 +1612,7 @@ static void calcfmask(winptr win)
     long      cx, cy;
     long      l;
 
+    if (!win->fmask) return; /* window not fully constructed yet */
     memset(win->fmask, 0xff, win->fmasklen); /* set the bitmap */
     /* find the onscreen client rectangle in root terms */
     setrect(&r1, win->orgx+win->coffx, win->orgy+win->coffy,
@@ -1622,6 +1700,73 @@ void recalcfmask(void)
         win = win->winlst; /* next window */
 
     }
+
+}
+
+/*******************************************************************************
+
+Grow window buffer
+
+Grows the given window's screen buffers to at least the given dimensions,
+keeping their contents; new cells are blanked in the window's current
+colors. The forward mask is reallocated to match, since it is sized and
+indexed by the buffer.
+
+The rule this maintains is that a window's buffer always covers at least
+its client area. Without it, a window sized larger than its buffer had
+client cells that could never be restored, and worse, the forward mask
+calculation indexed those cells into a buffer sized mask, writing outside
+the allocation.
+
+Buffers never shrink: a smaller client simply views less of the buffer.
+
+*******************************************************************************/
+
+static void growwinbuf(winptr win, long nx, long ny)
+
+{
+
+    scnrec* ns; /* new screen */
+    scnrec* os; /* old screen */
+    scnrec* scp;
+    long    x, y;
+    int     si;
+
+    if (nx <= win->maxx && ny <= win->maxy) return; /* nothing to grow */
+    if (nx < win->maxx) nx = win->maxx; /* never shrink */
+    if (ny < win->maxy) ny = win->maxy;
+    for (si = 0; si < MAXCON; si++) if (win->screens[si]) {
+
+        os = win->screens[si]; /* index old screen */
+        ns = malloc(sizeof(scnrec)*ny*nx);
+        if (!ns) error("Out of memory");
+        for (y = 1; y <= ny; y++)
+            for (x = 1; x <= nx; x++) {
+
+            scp = &ns[(y-1)*nx+(x-1)]; /* index new cell */
+            if (x <= win->maxx && y <= win->maxy)
+                /* keep old contents */
+                *scp = os[(y-1)*win->maxx+(x-1)];
+            else { /* new cell, blank in window colors */
+
+                scp->ch = ' ';
+                scp->forec = win->fcolor;
+                scp->backc = win->bcolor;
+                scp->attr = win->attr;
+
+            }
+
+        }
+        free(os); /* release the old screen */
+        win->screens[si] = ns;
+
+    }
+    win->maxx = nx; /* set new buffer size */
+    win->maxy = ny;
+    win->bufx = nx;
+    win->bufy = ny;
+    if (win->fmask) free(win->fmask); /* mask must match the buffer */
+    alcfmask(win);
 
 }
 
@@ -1828,6 +1973,14 @@ static void setcur(winptr win)
 
 {
 
+    /* The physical cursor belongs to the focus window: cursor activity in
+       any other window changes only that window's recorded position, and
+       the visible cursor stays where the user is typing. Without this the
+       cursor was left wherever the last drawing operation finished, and
+       came back to the focus window only when something happened to
+       restore that window last. When no window has focus yet, the given
+       window stands. */
+    if (curfocus && win != curfocus) return;
     if (indisp(win)) { /* in display */
 
         /* check cursor in bounds */
@@ -1883,6 +2036,8 @@ static void restoreclp(winptr win,   /* window to restore */
     scnrec* scp;   /* pointer to screen location */
     scnrec* sc;
     long x, y;
+    long bx, by;   /* buffer location */
+    long l;        /* mask index */
     rectangle r1, r2;
 
     if (win->bufmod && win->visible)  { /* buffered mode is on, and visible */
@@ -1891,36 +2046,49 @@ static void restoreclp(winptr win,   /* window to restore */
         setcurvis(FALSE); /* turn off cursor for drawing */
         if (win->frame) drwfrm(win, cr); /* draw window frame */
 
-        /* find intersection with client area */
+        /* Find intersection with client area. The area is bounded by both
+           the client dimensions and the buffer dimensions: the client can
+           be larger than the buffer, and the buffer must not be read
+           outside itself. */
         setrect(&r1, win->orgx+win->coffx, win->orgy+win->coffy,
-                   win->orgx+win->coffx+win->cmaxx-1,
-                   win->orgy+win->coffy+win->cmaxy-1);
+                   win->orgx+win->coffx+
+                       (win->cmaxx < win->maxx? win->cmaxx: win->maxx)-1,
+                   win->orgy+win->coffy+
+                       (win->cmaxy < win->maxy? win->cmaxy: win->maxy)-1);
         if (intersect(cr, &r1)) { /* there is an intersection with client area */
 
             intersection(&r2, cr, &r1); /* find client-clip intersection */
             sc = win->screens[win->curdsp-1]; /* index screen */
-            /* restore window from buffer */
+            /* Restore window from buffer. Cells the forward mask holds off
+               belong to windows above this one and are skipped: without
+               that check a restore of a lower window paints over whatever
+               overlaps it. The cursor is positioned per cell, which costs
+               nothing for consecutive visible cells, since the position
+               cache knows the cursor advances with each character. */
             for (y = r2.y1; y <= r2.y2; y++) {
 
-                /* Reset cursor at the start of each line. Note frame offsets. */
-                setcursor(r2.x1, y);
-                /* draw each line */
                 for (x = r2.x1; x <= r2.x2; x++) {
 
-                    /* index screen character location */
-                    scp = &SCNBUF(sc, x-(win->orgx+win->coffx)+1,
-                                      y-(win->orgy+win->coffy)+1);
-                    setfcolor(scp->forec); /* set colors */
-                    setbcolor(scp->backc);
-                    setattrs(scp->attr); /* set attributes */
-                    wrtchr(scp->ch); /* output character */
+                    bx = x-(win->orgx+win->coffx)+1; /* buffer location */
+                    by = y-(win->orgy+win->coffy)+1;
+                    l = (by-1)*win->bufx+(bx-1); /* mask index */
+                    if (win->fmask[l/8] & 1<<(l%8)) { /* not occluded */
+
+                        scp = &SCNBUF(sc, bx, by); /* index character */
+                        setcursor(x, y); /* at that location */
+                        setfcolor(scp->forec); /* set colors */
+                        setbcolor(scp->backc);
+                        setattrs(scp->attr); /* set attributes */
+                        wrtchr(scp->ch); /* output character */
+
+                    }
 
                 }
 
             }
 
         }
-        setcur(win); /* reenable cursor */
+        setcur(curfocus? curfocus: win); /* reenable cursor */
 
     }
 
@@ -2087,12 +2255,20 @@ window. Thus it is a more complete send of the event.
 
 *******************************************************************************/
 
+static void wigevt(wigptr wg, ami_evtrec* er); /* forward */
+static void wigdrag(void); /* forward */
+static void clspops(int downto); /* forward */
+static void wigdrw(wigptr wg); /* forward */
+
 static void intsendevent(winptr win, ami_evtrec* er)
 
 {
 
     ami_evtrec ec; /* copy of event record */
 
+    /* events for a widget window go to the widget logic, never to the
+       client program */
+    if (win && win->widget) { wigevt(win->wig, er); return; }
     memcpy(&ec, er, sizeof(ami_evtrec));
     ec.winid = 0; /* set anonymous window id */
     if (win) ec.winid = win->wid; /* overwrite window id */
@@ -2122,6 +2298,11 @@ void remfocus(void)
 
         if (win->focus) { /* if this window has focus */
 
+            /* Clear the flag before announcing the loss. A widget redraws
+               its face when it hears this, and reads the flag to decide
+               whether to show itself focused: announcing first left every
+               widget drawn as though it still held the focus. */
+            win->focus = FALSE;
             /* send defocus message */
             ev.etype = ami_etnofocus; /* set no focus event */
             intsendevent(win, &ev); /* send to queue */
@@ -2325,6 +2506,12 @@ static void makzmax2min(void)
         }
 
     }
+    /* The occlusion masks depend on the Z order, and the restore paths
+       honor them, so every change of the order must recalculate them.
+       Previously only open, close, move and resize did: a window brought to
+       the front by a focus click kept the mask from its old depth, and was
+       restored with holes where windows used to be above it. */
+    recalcfmask();
 
 }
 
@@ -2481,6 +2668,12 @@ static void intfront(winptr win)
     else zmin2max = win; /* list is empty, set first */
     win->zorder = ztop; /* set our entry as top Z order */
     makzmax2min(); /* remake the max 2 min list */
+    /* Repaint the window in its new place. This was left to the mouse
+       click handler, so a front change made through the API reordered the
+       lists but left the screen stale. */
+    if (win->visible)
+        redraw(win, win->orgx, win->orgy,
+                    win->orgx+win->pmaxx-1, win->orgy+win->pmaxy-1);
 
 }
 
@@ -2515,6 +2708,11 @@ static void intback(winptr win)
     zmin2max->zmin2max = win;
     win->zorder = ztop; /* set our entry as bottom Z order */
     makzmax2min(); /* remake the max 2 min list */
+    /* repaint the region from the new order: whatever was under this
+       window is now on top of it */
+    if (win->visible)
+        redraw(zmax2min, win->orgx, win->orgy,
+                         win->orgx+win->pmaxx-1, win->orgy+win->pmaxy-1);
 
 }
 
@@ -2915,22 +3113,27 @@ static void intscroll(winptr win, long x, long y)
 
 {
 
-    long     xi, yi;       /* screen counters */
-    scnptr   scnsav;       /* full screen buffer save */
-    long     lx;           /* last unmatching character index */
-    int      m;            /* match flag */
-    scnptr   sc;           /* pointer to current screen */
-    scnptr   sp;           /* pointer to screen record */
-    long     curxs, curys; /* cursor position save */
+    long      xi, yi; /* screen counters */
+    scnptr    sc;     /* pointer to current screen */
+    scnptr    sp;     /* pointer to screen record */
+    rectangle cr;     /* client rectangle */
 
     /* when the scroll is arbitrary, we do it by completely refreshing the
        contents of the screen from the buffer */
     if (x <= -win->maxx || x >= win->maxx || y <= -win->maxy || y >= win->maxy) {
 
-        wrtchr('\f'); /* scroll would result in complete clear, do it */
+        /* scroll would result in complete clear, do it. Note this clears
+           and repaints only this window: the previous code cleared the
+           whole root surface, taking every other window with it. */
         iniscn(win, win->screens[win->curupd-1]);   /* clear the screen buffer */
-        /* restore cursor position */
-        setcursor(win->orgx+win->coffx, win->orgy+win->coffy);
+        if (indisp(win)) { /* in display, repaint the client area */
+
+            setrect(&cr, win->orgx+win->coffx, win->orgy+win->coffy,
+                       win->orgx+win->coffx+win->cmaxx-1,
+                       win->orgy+win->coffy+win->cmaxy-1);
+            restoreclp(win, &cr);
+
+        }
 
     } else { /* scroll */
 
@@ -2942,13 +3145,6 @@ static void intscroll(winptr win, long x, long y)
            compared to that while being output. this saves work when most of
            the screen is spaces anyways */
         sc = win->screens[win->curupd-1]; /* index current screen */
-        if (indisp(win)) { /* in display */
-
-            /* save the entire buffer */
-            scnsav = malloc(sizeof(scnrec)*win->maxy*win->maxx);
-            memcpy(scnsav, sc, sizeof(scnrec)*win->maxy*win->maxx);
-
-        }
         if (y > 0) {  /* move text up */
 
             for (yi = 1; yi < win->maxy; yi++) /* move any lines up */
@@ -3035,55 +3231,19 @@ static void intscroll(winptr win, long x, long y)
         }
         if (indisp(win)) { /* in display */
 
-            curxs = curx; /* save cursor position */
-            curys = cury;
-            /* the buffer is adjusted. now just copy the complete buffer to the
-               screen */
-            for (yi = 1; yi <= win->maxy; yi++) { /* lines */
-
-                win->curx = 1; /* set cursor */
-                win->cury = yi;
-                setcur(win);
-                /* find the last unmatching character between real and new buffers.
-                   Then, we only need output the leftmost non-matching characters
-                   on the line. note that it does not really help us that characters
-                   WITHIN the line match, because a character output is as or more
-                   efficient as a cursor movement. if, however, you want to get
-                   SERIOUSLY complex, we could check runs of matching characters,
-                   then check if performing a direct cursor position is less output
-                   characters than just outputting data :) */
-                lx = win->maxx; /* set to end */
-                do { /* check matches */
-
-                    m = 1; /* set match */
-                    /* check all elements match */
-                    if (SCNBUF(sc, lx, yi).ch != SCNBUF(scnsav, lx, yi).ch)
-                        m = 0;
-                    if (SCNBUF(sc, lx, yi).forec !=
-                        SCNBUF(scnsav, lx, yi).forec) m = 0;
-                    if (SCNBUF(sc, lx, yi).backc !=
-                        SCNBUF(scnsav, lx, yi).backc) m = 0;
-                    if (SCNBUF(sc, lx, yi).attr != SCNBUF(scnsav, lx, yi).attr)
-                        m = 0;
-                    if (m) lx--; /* next character */
-
-                } while (m && lx); /* until match or no more */
-                for (xi = 1; xi <= lx; xi++) { /* characters */
-
-                    /* for each new character, we compare the attributes and colors
-                       with what is set. if a new color or attribute is called for,
-                       we set that, and update the saves. this technique cuts down on
-                       the amount of output characters */
-                    sp = &SCNBUF(sc, xi, yi);
-                    setfcolor(sp->forec); /* set the foreground color */
-                    setbcolor(sp->backc); /* set the background color */
-                    setattrs(sp->attr); /* set the attribute */
-                    wrtchr(sp->ch);
-
-                }
-
-            }
-            (*cursor_vect)(stdout, curxs, curys); /* restore cursor position */
+            /* The buffer is adjusted; repaint the client area from it by
+               the same clipped path every other repaint uses. The previous
+               code here kept a private unclipped paint loop over the whole
+               buffer, which sprayed outside the window whenever the buffer
+               was larger than the client area, ignored occlusion, and
+               diffed against a saved copy of the buffer on the assumption
+               that the screen still matched it, which the clipping of other
+               windows had long since made false: the visible result was
+               window contents that flashed in and then blanked out. */
+            setrect(&cr, win->orgx+win->coffx, win->orgy+win->coffy,
+                       win->orgx+win->coffx+win->cmaxx-1,
+                       win->orgy+win->coffy+win->cmaxy-1);
+            restoreclp(win, &cr);
 
         }
 
@@ -3131,6 +3291,11 @@ static void intsetsiz(winptr win, long x, long y)
         win->maxy -= win->frame*2+win->size*2;
 
     }
+    /* the buffer must always cover the client area */
+    if (win->bufmod) growwinbuf(win, win->cmaxx, win->cmaxy);
+    /* as in intsetpos, the repaints below consult the masks, so they must
+       reflect the new size first */
+    recalcfmask();
     if (win->visible) { /* window is onscreen */
 
         /* check old and new overlap */
@@ -3190,10 +3355,20 @@ static void intsetpos(winptr win, long x, long y)
     long ox, oy; /* previous position of window */
     rectangle r1, r2, r3, rt, rl, rr, rb;
 
+    wigptr wg; /* widget list pointer */
+
     ox = win->orgx; /* save previous position of window */
     oy = win->orgy;
     win->orgx = x; /* set position in parent */
     win->orgy = y;
+    /* the window's widgets ride along with it */
+    for (wg = win->wiglst; wg; wg = wg->next)
+        intsetpos(wg->win, wg->win->orgx+(x-ox), wg->win->orgy+(y-oy));
+    /* The masks must reflect the new position before anything repaints:
+       the repaint of the vacated area consults them, and with the old
+       masks it skips exactly the cells this window used to cover, leaving
+       its old frame behind on the screen. */
+    recalcfmask();
     if (win->visible) { /* window is onscreen */
 
         /* check old and new overlap */
@@ -4003,21 +4178,148 @@ static void intevent(FILE* f)
 
             }
             break;
+        /* The terminal surface gained or lost the host focus, or the mouse
+           entered or left it. These describe the surface as a whole, so
+           they go to the window that owns the manager's focus, and to the
+           root when nothing else holds it. They were dropped entirely,
+           which left a program running under the manager seeing neither
+           focus nor hover. */
+        case ami_etfocus:
+        case ami_etnofocus:
+
+            win = curfocus;
+            if (!win) { /* nothing focused, find the root */
+
+                win = winlst;
+                while (win && !win->root) win = win->winlst;
+
+            }
+            if (win) {
+
+                er.etype = ev.etype;
+                er.winid = win->wid;
+                intsendevent(win, &er);
+
+            }
+            break;
+
+        case ami_ethover:
+        case ami_etnohover:
+
+            /* Hover follows the mouse rather than the focus: it belongs to
+               the window under the pointer. The manager tracks hover for
+               its own windows on mouse movement, so the surface level
+               event is only passed on when the pointer is over the root
+               itself, which is the case a lone program sees. */
+            win = fndtop(mousex, mousey);
+            if (!win) { /* off any window, use the root */
+
+                win = winlst;
+                while (win && !win->root) win = win->winlst;
+
+            }
+            /* Only pass it on when the state actually changes. The
+               manager raises hover itself when the pointer moves into a
+               window, so forwarding unconditionally reported it twice. */
+            if (win && !!win->hover != (ev.etype == ami_ethover)) {
+
+                er.etype = ev.etype;
+                er.winid = win->wid;
+                intsendevent(win, &er);
+                win->hover = ev.etype == ami_ethover;
+
+            }
+            break;
+
+        case ami_etresize: /* the terminal surface changed size */
+
+            /* Follow the new terminal dimensions. Without this the manager
+               kept the size found at startup: after a terminal resize the
+               clip to the old root bounds was wrong, and the underlying
+               terminal package had already repainted its raw screen over
+               the composition, so nothing came back until some other
+               action forced a redraw. */
+            dimx = ev.rszx; /* set new root dimensions */
+            dimy = ev.rszy;
+            win = winlst; /* find the root window record */
+            while (win && !win->root) win = win->winlst;
+            if (win) { /* track the surface in the root window */
+
+                win->pmaxx = dimx; /* the root window is the surface */
+                win->pmaxy = dimy;
+                win->cmaxx = dimx; /* frameless, client is the whole */
+                win->cmaxy = dimy;
+                if (!win->bufmod) { /* in follow mode track the buffer too */
+
+                    win->maxx = dimx;
+                    win->maxy = dimy;
+
+                }
+                /* An expanded surface needs an expanded root buffer, kept
+                   in content, or the root background beyond the old bounds
+                   can never be restored. */
+                growwinbuf(win, dimx, dimy);
+
+            }
+            recalcfmask(); /* occlusion clips to the new bounds */
+            /* repaint the whole composition over the terminal's own
+               recovery paint */
+            redraw(zmax2min, 1, 1, dimx, dimy);
+            if (win) { /* tell the client its surface changed */
+
+                er.etype = ami_etresize;
+                er.rszx = dimx;
+                er.rszy = dimy;
+                er.winid = win->wid;
+                intsendevent(win, &er);
+
+            }
+            break;
         case ami_etmouba:  /* mouse button assertion */
             win = fndtop(mousex, mousey); /* find the enclosing window */
+            /* a click outside the open popups dismisses them */
+            if (popcnt) {
+
+                int inpop = FALSE;
+                int pi;
+
+                for (pi = 0; pi < popcnt; pi++)
+                    if (win == popstk[pi]->win) inpop = TRUE;
+                if (win && win->widget && win->wig->typ == wtmenubar)
+                    inpop = TRUE; /* the bar manages its own popups */
+                if (!inpop) clspops(0); /* close them all */
+
+            }
             /* first click with no focus gives focus, next click gives message */
             if (win) {
 
+                /* A widget acts on the same click that focuses it: the
+                   click-consuming focus rule below is window etiquette,
+                   and making a scroll bar or button need two clicks is
+                   not. The focus change still happens in the unfocused
+                   branch; the action is delivered here either way. */
+                if (win->widget && inclient(win, mousex, mousey)) {
+
+                    er.etype = ami_etmouba;
+                    er.amoun = ev.amoun;
+                    er.amoubn = ev.amoubn;
+                    intsendevent(win, &er); /* to the widget logic */
+
+                }
                 if (win->focus) { /* window has focus */
 
                     if (inclient(win, mousex, mousey)) {
 
-                        /* in client area */
-                        er.etype = ami_etmouba; /* set mouse button asserts */
-                        er.amoun = ev.amoun; /* set mouse number */
-                        er.amoubn = ev.amoubn; /* set button number */
-                        er.winid = win->wid; /* set window logical id */
-                        intsendevent(win, &er); /* issue event */
+                        if (!win->widget) { /* widgets were served above */
+
+                            /* in client area */
+                            er.etype = ami_etmouba; /* set mouse button asserts */
+                            er.amoun = ev.amoun; /* set mouse number */
+                            er.amoubn = ev.amoubn; /* set button number */
+                            er.winid = win->wid; /* set window logical id */
+                            intsendevent(win, &er); /* issue event */
+
+                        }
 
                     } else if (ev.mmoun == 1) {
 
@@ -4153,13 +4455,24 @@ static void intevent(FILE* f)
                         }
 
                     }
-                    if (win->zorder != ztop && !win->root) { /* if not already top window */
+                    if (!win->root) { /* the root stays put */
 
-                        intfront(win); /* bring to front */
-                        /* redraw for order */
-                        redraw(win, win->orgx, win->orgy,
-                                    win->orgx+win->pmaxx-1,
-                                    win->orgy+win->pmaxy-1);
+                        winptr fw = win->widget? win->wig->parent: win;
+                        wigptr wg;
+
+                        /* widgets on the root need no fronting: the root
+                           is always at the bottom and its widgets above */
+                        if (fw->zorder != ztop && !fw->root) {
+
+                            /* Bring the family to the front: the owning
+                               window, then its widgets above it. Fronting
+                               only the clicked widget would float it over
+                               every other window. */
+                            intfront(fw);
+                            for (wg = fw->wiglst; wg; wg = wg->next)
+                                intfront(wg->win);
+
+                        }
 
                     }
 
@@ -4180,6 +4493,7 @@ static void intevent(FILE* f)
             }
             /* cancel any drag */
             drag = dt_none;
+            drgwig = NULL;
             break;
         case ami_etmoumov: /* mouse move */
             mousex = ev.moupx; /* set current mouse position */
@@ -4211,6 +4525,8 @@ static void intevent(FILE* f)
                 }
 
             }
+            /* a value widget being dragged follows the mouse */
+            if (drgwig) wigdrag();
             /* check drag is active and mouse has moved */
             if (drag != dt_none && (drgx != mousex || drgy != mousey)) {
 
@@ -5041,50 +5357,56 @@ static void iwrtstrn(FILE* f, char* s, long n)
 
     winptr win; /* window record pointer */
     scnptr scp; /* screen buffer */
-    char*  ss;
-    long   ns;
+    long   l;   /* character location */
 
     win = txt2win(f); /* get window from file */
     if (win->autof) error("Cannot direct write string with auto on");
     if (!win->visible) winvis(win); /* make sure we are displayed */
-    if (win->bufmod) { /* buffer is active */
+    /* Write each character with the same bounds as plcchr: the store is
+       bounded by the buffer, the display by the client area and the forward
+       mask. The previous code kept separate store and display loops, both
+       bounded by the client area, which discarded buffer content below the
+       viewport, drew over occluding windows, and advanced the cursor once
+       in each loop, twice per character in all. */
+    while (n) {
 
-        ss = s; /* save string */
-        ns = n;
-        while (ns && icurbnd(f)) { /* print string */
+        if (win->curx >= 1 && win->curx <= win->bufx &&
+            win->cury >= 1 && win->cury <= win->bufy) { /* in buffer */
 
-            /* index screen character location */
-            scp = &SCNBUF(win->screens[win->curdsp-1],
-                            win->curx, win->cury);
-            /* place character to buffer */
-            scp->ch = *ss++;
-            scp->forec = win->fcolor;
-            scp->backc = win->bcolor;
-            scp->attr = win->attr;
-            win->curx++; /* next location */
-            ns--; /* count */
+            if (win->bufmod) { /* buffer is active */
+
+                /* the store goes to the UPDATE screen: writing to the
+                   display screen sent everything to whatever was being
+                   shown, so buffers prepared while another was displayed
+                   stayed empty */
+                scp = &SCNBUF(win->screens[win->curupd-1],
+                              win->curx, win->cury);
+                scp->ch = *s; /* place character to buffer */
+                scp->forec = win->fcolor;
+                scp->backc = win->bcolor;
+                scp->attr = win->attr;
+
+            }
+            l = (win->cury-1)*win->bufx+(win->curx-1);
+            if (indisp(win) && intcurbnd(win) &&
+                win->fmask[l/8] & 1<<(l%8)) { /* visible on screen */
+
+                setattrs(win->attr); /* set attributes */
+                setfcolor(win->fcolor); /* set colors */
+                setbcolor(win->bcolor);
+                setcursor(win->curx+win->orgx-1+win->coffx,
+                          win->cury+win->orgy-1+win->coffy);
+                wrtchr(*s); /* output */
+
+            }
 
         }
+        if (win->curx < LONG_MAX) win->curx++; /* next location */
+        s++; /* next character */
+        n--; /* count */
 
     }
-    if (indisp(win)) { /* do it again for the current screen */
-
-        /* set root cursor to correct position */
-        setcursor(win->curx+win->orgx-1+win->coffx,
-                  win->cury+win->orgy-1+win->coffy);
-        setattrs(win->attr); /* set attributes */
-        setfcolor(win->fcolor); /* set colors */
-        setbcolor(win->bcolor);
-        while (*s && icurbnd(f)) { /* print string */
-
-            /* draw character to active screen */
-            wrtchr(*s++); /* output */
-            win->curx++; /* next location */
-            n--; /* count */
-
-        }
-
-    }
+    setcur(curfocus? curfocus: win); /* place the cursor */
 
 }
 
@@ -5252,16 +5574,38 @@ static void isizbuf(FILE* f, long x, long y)
 
     win = txt2win(f); /* get window from file */
     if (!win->bufmod) error("Buffer mode is not enabled");
+    if (x < 1 || y < 1) error("Invalid buffer size");
     if (win->bufx != x || win->bufy != y) {
 
         /* buffer size has changed */
         clrbufs(win); /* all the screen buffers are wrong, so tear them out */
-        /* allocate prime buffer */
-        win->screens[0] = malloc(sizeof(scnrec)*win->maxy*win->maxx);
-        /* clear */
-        iniscn(win, win->screens[0]);
+        /* Take the new size before allocating: the buffer dimensions are
+           what the screens are sized and indexed by, and they were left at
+           the old values here, so the new screens came out the previous
+           size. */
+        win->bufx = x;
+        win->bufy = y;
+        win->maxx = x;
+        win->maxy = y;
+        /* Allocate the screens that are selected, not just the first one.
+           A program that has selected any other screen, which the select
+           call makes routine, was left with a null screen pointer and
+           faulted on its next write. */
+        win->screens[win->curupd-1] = malloc(sizeof(scnrec)*y*x);
+        if (!win->screens[win->curupd-1]) error("Out of memory");
+        iniscn(win, win->screens[win->curupd-1]);
+        if (win->curdsp != win->curupd) { /* display screen is a different one */
+
+            win->screens[win->curdsp-1] = malloc(sizeof(scnrec)*y*x);
+            if (!win->screens[win->curdsp-1]) error("Out of memory");
+            iniscn(win, win->screens[win->curdsp-1]);
+
+        }
         free(win->fmask); /* release previous mask */
         alcfmask(win); /* allocate and clear forward mask */
+        /* the buffer must still cover the client area */
+        growwinbuf(win, win->cmaxx, win->cmaxy);
+        if (indisp(win)) restore(win); /* repaint from the new buffer */
 
     }
     recalcfmask(); /* recalculate the forward masks */
@@ -5449,6 +5793,31 @@ Turns the window frame on and off.
 
 *******************************************************************************/
 
+/* Recompute the client geometry after a decoration change. The client
+   offsets and dimensions are derived from the frame, size and system bar
+   flags; they were set at open and must follow any change of those flags,
+   with the buffer grown to keep covering the client, and the masks redone
+   for the new client rectangle. */
+static void recompcli(winptr win)
+
+{
+
+    win->coffx = 0+(win->frame && win->size);
+    win->coffy = 0+(win->frame && win->size)+win->sysbar*2;
+    win->cmaxx = win->pmaxx; /* client dimensions from decorations */
+    win->cmaxy = win->pmaxy;
+    win->cmaxx -= (win->frame && win->size)*2;
+    win->cmaxy -= win->frame*2+win->size*2;
+    if (!win->bufmod) { /* in follow mode track the buffer */
+
+        win->maxx = win->cmaxx;
+        win->maxy = win->cmaxy;
+
+    } else growwinbuf(win, win->cmaxx, win->cmaxy);
+    recalcfmask();
+
+}
+
 static void iframe(FILE* f, long e)
 
 {
@@ -5460,6 +5829,7 @@ static void iframe(FILE* f, long e)
     if (win->frame != e) {
 
         win->frame = e; /* set frame state */
+        recompcli(win); /* the client geometry follows the decorations */
         restore(win); /* redraw */
 
     }
@@ -5489,6 +5859,7 @@ static void isizable(FILE* f, long e)
     if (win->size != e) {
 
         win->size = e; /* set frame state */
+        recompcli(win); /* the client geometry follows the decorations */
         restore(win); /* redraw */
 
     }
@@ -5517,6 +5888,7 @@ static void isysbar(FILE* f, long e)
     if (win->sysbar != e) {
 
         win->sysbar = e; /* set frame state */
+        recompcli(win); /* the client geometry follows the decorations */
         restore(win); /* redraw */
 
     }
@@ -5533,11 +5905,6 @@ deleted.
 
 *******************************************************************************/
 
-static void imenu(FILE* f, ami_menuptr m)
-
-{
-
-}
 
 /** ****************************************************************************
 
@@ -5548,11 +5915,6 @@ and will no longer send messages.
 
 *******************************************************************************/
 
-static void imenuena(FILE* f, long id, long onoff)
-
-{
-
-}
 
 /** ****************************************************************************
 
@@ -5563,11 +5925,6 @@ selected, with no check if not.
 
 *******************************************************************************/
 
-static void imenusel(FILE* f, long id, long select)
-
-{
-
-}
 
 /** ****************************************************************************
 
@@ -5585,11 +5942,6 @@ end of the menu, then the program selections placed in the menu.
 
 *******************************************************************************/
 
-static void istdmenu(ami_stdmenusel sms, ami_menuptr* sm, ami_menuptr pm)
-
-{
-
-}
 
 /** ****************************************************************************
 
@@ -5694,12 +6046,29 @@ static void plcchr(FILE* f, char c)
 
         /* find character location */
         l = (win->cury-1)*win->bufx+(win->curx-1); 
-        if (icurbnd(f) && win->fmask[l/8] & 1<<(l%8)) { /* cursor is in bounds */
+        /* The store and the display have different bounds. The store is
+           bounded by the buffer, which can be larger than the window: the
+           client area is a viewport onto it. The display is bounded by the
+           client area, and also by the forward mask, since an occluded
+           character must not be drawn but must still reach the buffer, or
+           it would be missing when the occluding window moves away. The
+           previous code gated both on the client area and the mask
+           together, so anything written below the viewport, or under
+           another window, was silently discarded from the buffer as well:
+           a window with a buffer taller than itself lost everything past
+           the visible rows. */
+        if (win->curx >= 1 && win->curx <= win->bufx &&
+            win->cury >= 1 && win->cury <= win->bufy) { /* in buffer */
 
             if (win->bufmod) { /* buffer is active */
 
-                /* index screen character location */
-                scp = &SCNBUF(win->screens[win->curdsp-1],
+                /* Index screen character location. This is the UPDATE
+                   screen, which is the one being written; it is the
+                   display screen only when the two are selected the same.
+                   Indexing the display screen here sent writes to whatever
+                   happened to be shown, so a program preparing buffers
+                   while displaying another left them all empty. */
+                scp = &SCNBUF(win->screens[win->curupd-1],
                               win->curx, win->cury);
                 /* place character to buffer */
                 scp->ch = c;
@@ -5708,7 +6077,8 @@ static void plcchr(FILE* f, char c)
                 scp->attr = win->attr;
 
             }
-            if (indisp(win)) { /* do it again for the current screen */
+            if (indisp(win) && intcurbnd(win) &&
+                win->fmask[l/8] & 1<<(l%8)) { /* visible on screen */
 
                 setattrs(win->attr); /* set attributes */
                 setfcolor(win->fcolor); /* set colors */
@@ -5860,8 +6230,13 @@ static ssize_t ivwrite(pwrite_t writedc, int fd, const void* buff, size_t count)
     if (opnfil[fd] && opnfil[fd]->win) { /* process window output file */
 
         win = opnfil[fd]->win; /* index window */
+        /* The cursor is off while drawing, then restored to the focus
+           window: client output must not leave the visible cursor sitting
+           wherever the last character landed. */
+        setcurvis(FALSE);
         /* send data to terminal */
         while (cnt--) plcchr(opnfil[fd]->sfp, *p++);
+        setcur(curfocus? curfocus: win); /* restore the cursor */
         rc = count; /* set return same as count */
 
     } else rc = (*writedc)(fd, buff, count);
@@ -5988,11 +6363,2458 @@ static off_t ilseek(int fd, off_t offset, int whence)
 
 /** ****************************************************************************
 
+                          CHARACTER MODE WIDGETS
+
+Implements the standard Petit-Ami widget set in character cells. Each widget
+is a small frameless subwindow of its owning window, kept on the owner's
+widget list. The subwindow machinery provides drawing, buffering, occlusion
+and repaint for free; this section provides the faces, drawn in characters,
+and the behavior: events arriving for a widget window are intercepted in
+intsendevent() and translated here into widget events for the owner.
+
+Only the character coordinate calls exist; the widgets have no graphical
+counterparts in this module. Drop boxes and tab bars are not (yet)
+implemented.
+
+*******************************************************************************/
+
+static long wigmul(long range, long val); /* forward */
+static long wigscl(long num, long den); /* forward */
+
+/* find widget by id in a window */
+static wigptr fndwig(winptr win, long id)
+
+{
+
+    wigptr wg;
+
+    wg = win->wiglst; /* index the widget list */
+    while (wg && wg->id != id) wg = wg->next;
+
+    return (wg);
+
+}
+
+/* write a string into a widget face, with reverse video select */
+static void wigtxt(wigptr wg, long x, long y, const char* s, int rev)
+
+{
+
+    winptr win = wg->win;
+
+    icursor(wg->wf, x, y); /* place cursor */
+    if (rev) win->attr |= BIT(sarev);
+    while (*s) plcchr(wg->wf, *s++);
+    win->attr &= ~BIT(sarev);
+
+}
+
+/* clear a widget face to spaces */
+static void wigclr(wigptr wg)
+
+{
+
+    long x, y;
+
+    for (y = 1; y <= wg->win->cmaxy; y++) {
+
+        icursor(wg->wf, 1, y);
+        for (x = 1; x <= wg->win->cmaxx; x++) plcchr(wg->wf, ' ');
+
+    }
+
+}
+
+/* draw a centered label into a row, clipped to width */
+static void wiglab(wigptr wg, long y, const char* s, int rev)
+
+{
+
+    long w = wg->win->cmaxx;
+    long l = strlen(s);
+    long x;
+
+    if (l > w) l = w; /* clip */
+    x = (w-l)/2+1; /* center */
+    icursor(wg->wf, x, y);
+    if (rev) wg->win->attr |= BIT(sarev);
+    while (l--) plcchr(wg->wf, *s++);
+    wg->win->attr &= ~BIT(sarev);
+
+}
+
+/** ****************************************************************************
+
+                        POPUPS, TAB BARS AND MENUS
+
+A popup is a widget whose face is a list of lines, floated above everything
+and dismissed by a selection or by a click elsewhere. Drop boxes use one to
+show their list; menus use a cascade of them. Popups are kept on a stack so
+a click outside closes the whole cascade.
+
+*******************************************************************************/
+
+/* close popups from the top down to the given depth */
+static void clspops(int downto)
+
+{
+
+    wigptr wg;
+
+    while (popcnt > downto) {
+
+        wg = popstk[--popcnt];
+        popstk[popcnt] = NULL;
+        /* unlink from its owner's widget list and drop it */
+        if (wg->parent) {
+
+            wigptr* lp = &wg->parent->wiglst;
+            while (*lp && *lp != wg) lp = &(*lp)->next;
+            if (*lp) *lp = wg->next;
+
+        }
+        fclose(wg->wf); /* close the popup window */
+        if (wg->face) free(wg->face);
+        if (wg->list) {
+
+            long i;
+            for (i = 0; i < wg->listn; i++) free(wg->list[i]);
+            free(wg->list);
+
+        }
+        free(wg);
+
+    }
+
+}
+
+/* Open a popup list at a root position. The strings are copied. Returns the
+   popup widget, which is pushed on the popup stack. */
+static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
+                     wigptr owner, ami_menuptr mitems)
+
+{
+
+    wigptr wg;
+    FILE*  wf;
+    long   i, w = 1;
+
+    if (popcnt >= MAXPOP) clspops(MAXPOP-1); /* bound the cascade */
+    for (i = 0; i < n; i++) /* widest entry sets the width */
+        if ((long)strlen(strs[i]) > w) w = strlen(strs[i]);
+    w += 2; /* frame columns */
+    wg = malloc(sizeof(wigrec));
+    if (!wg) error("Out of memory");
+    iopenwin(&stdin, &wf, NULL, igetwinid()); /* parentless: floats over all */
+    wg->id = 0; /* popups have no client id */
+    wg->typ = wtpopup;
+    wg->parent = par;
+    wg->wf = wf;
+    wg->win = txt2win(wf);
+    wg->face = NULL;
+    wg->list = malloc(sizeof(char*)*(n? n: 1));
+    if (!wg->list) error("Out of memory");
+    for (i = 0; i < n; i++) {
+
+        wg->list[i] = malloc(strlen(strs[i])+1);
+        if (!wg->list[i]) error("Out of memory");
+        strcpy(wg->list[i], strs[i]);
+
+    }
+    wg->listn = n;
+    wg->enb = TRUE;
+    wg->sel = 0;
+    wg->val = 0;
+    wg->low = 0;
+    wg->high = 0;
+    wg->sclsiz = 0;
+    wg->curs = 0;
+    wg->tor = ami_totop;
+    wg->owner = owner;
+    wg->mitems = mitems;
+    wg->win->widget = TRUE;
+    wg->win->wig = wg;
+    wg->next = par->wiglst; /* on the owner's list for cleanup */
+    par->wiglst = wg;
+    /* frame it, no system bar: a plain bordered list */
+    wg->win->frame = TRUE;
+    wg->win->size = FALSE;
+    wg->win->sysbar = FALSE;
+    recompcli(wg->win);
+    intsetsiz(wg->win, w, n+2);
+    /* keep it on the surface */
+    if (rx+w-1 > dimx) rx = dimx-w+1;
+    if (ry+n+1 > dimy) ry = dimy-n-1;
+    if (rx < 1) rx = 1;
+    if (ry < 1) ry = 1;
+    intsetpos(wg->win, rx, ry);
+    intfront(wg->win); /* above everything */
+    popstk[popcnt++] = wg; /* push */
+    wigdrw(wg);
+
+    return (wg);
+
+}
+
+/* count and collect a menu level into a string array. Returns the count.
+   Submenus are marked with a trailing arrow, checked items with a mark. */
+static long mencol(winptr win, ami_menuptr m, char*** strs)
+
+{
+
+    ami_menuptr p;
+    long n = 0, i = 0;
+    char buf[MAXLIN];
+    menenaptr me;
+
+    for (p = m; p; p = p->next) n++;
+    *strs = malloc(sizeof(char*)*(n? n: 1));
+    if (!*strs) error("Out of memory");
+    for (p = m; p; p = p->next) {
+
+        int ena = TRUE;
+        for (me = win->menena; me; me = me->next)
+            if (me->id == p->id) ena = me->ena;
+        snprintf(buf, sizeof(buf), "%c%c%s%s",
+                 ena? ' ': '(', /* disabled shown in parens */
+                 p->onoff || p->oneof? '*': ' ', /* check mark */
+                 p->face,
+                 p->branch? " >": (ena? "": ")"));
+        (*strs)[i] = malloc(strlen(buf)+1);
+        if (!(*strs)[i]) error("Out of memory");
+        strcpy((*strs)[i], buf);
+        i++;
+
+    }
+
+    return (n);
+
+}
+
+/* find the nth entry of a menu level */
+static ami_menuptr mennth(ami_menuptr m, long n)
+
+{
+
+    while (m && n > 1) { m = m->next; n--; }
+
+    return (m);
+
+}
+
+/* is a menu item enabled */
+static int menenb(winptr win, long id)
+
+{
+
+    menenaptr me;
+
+    for (me = win->menena; me; me = me->next) if (me->id == id) return (me->ena);
+
+    return (TRUE); /* enabled unless said otherwise */
+
+}
+
+/* draw the menu bar face: top level titles in a row */
+static void drwmbar(wigptr wg)
+
+{
+
+    ami_menuptr p;
+    long x = 1;
+
+    wigclr(wg);
+    for (p = wg->mitems; p; p = p->next) {
+
+        wigtxt(wg, x, 1, " ", FALSE);
+        wigtxt(wg, x+1, 1, p->face, wg->sel == x); /* selected shows reversed */
+        x += strlen(p->face)+2;
+
+    }
+
+}
+
+/* find which top level menu title a bar column lies in; returns the item or
+   NULL, and sets the column the title starts at */
+static ami_menuptr mbarhit(wigptr wg, long lx, long* startx)
+
+{
+
+    ami_menuptr p;
+    long x = 1;
+
+    for (p = wg->mitems; p; p = p->next) {
+
+        long w = strlen(p->face)+2;
+        if (lx >= x && lx < x+w) { *startx = x; return (p); }
+        x += w;
+
+    }
+
+    return (NULL);
+
+}
+
+/* draw the face of a widget from its state */
+static void wigdrw(wigptr wg)
+
+{
+
+    winptr win = wg->win;
+    long   w = win->cmaxx;
+    long   h = win->cmaxy;
+    long   x, y, i, n, ts, tp;
+    char   buf[MAXLIN];
+    int    rev;
+
+    switch (wg->typ) {
+
+        case wtbutton:
+            wigclr(wg);
+            rev = wg->sel || (win->focus && wg->enb);
+            if (h >= 3) { /* boxed face */
+
+                icursor(wg->wf, 1, 1);
+                plcchr(wg->wf, '+');
+                for (x = 2; x < w; x++) plcchr(wg->wf, '-');
+                plcchr(wg->wf, '+');
+                for (y = 2; y < h; y++) {
+
+                    icursor(wg->wf, 1, y); plcchr(wg->wf, '|');
+                    icursor(wg->wf, w, y); plcchr(wg->wf, '|');
+
+                }
+                icursor(wg->wf, 1, h);
+                plcchr(wg->wf, '+');
+                for (x = 2; x < w; x++) plcchr(wg->wf, '-');
+                plcchr(wg->wf, '+');
+                wiglab(wg, (h+1)/2, wg->face, rev);
+
+            } else { /* single row face */
+
+                icursor(wg->wf, 1, 1); plcchr(wg->wf, '[');
+                icursor(wg->wf, w, 1); plcchr(wg->wf, ']');
+                wiglab(wg, 1, wg->face, rev);
+
+            }
+            break;
+
+        case wtcheckbox:
+            wigclr(wg);
+            snprintf(buf, sizeof(buf), "[%c] %s", wg->sel? 'X': ' ', wg->face);
+            wigtxt(wg, 1, 1, buf, win->focus && wg->enb);
+            break;
+
+        case wtradio:
+            wigclr(wg);
+            snprintf(buf, sizeof(buf), "(%c) %s", wg->sel? '*': ' ', wg->face);
+            wigtxt(wg, 1, 1, buf, win->focus && wg->enb);
+            break;
+
+        case wtgroup:
+            wigclr(wg);
+            icursor(wg->wf, 1, 1);
+            plcchr(wg->wf, '+');
+            for (x = 2; x < w; x++) plcchr(wg->wf, '-');
+            plcchr(wg->wf, '+');
+            for (y = 2; y < h; y++) {
+
+                icursor(wg->wf, 1, y); plcchr(wg->wf, '|');
+                icursor(wg->wf, w, y); plcchr(wg->wf, '|');
+
+            }
+            icursor(wg->wf, 1, h);
+            plcchr(wg->wf, '+');
+            for (x = 2; x < w; x++) plcchr(wg->wf, '-');
+            plcchr(wg->wf, '+');
+            /* title in the top run */
+            if (wg->face && *wg->face) {
+
+                n = strlen(wg->face); if (n > w-4) n = w-4;
+                icursor(wg->wf, 3, 1);
+                plcchr(wg->wf, ' ');
+                for (i = 0; i < n; i++) plcchr(wg->wf, wg->face[i]);
+                plcchr(wg->wf, ' ');
+
+            }
+            break;
+
+        case wtbackground:
+            wigclr(wg);
+            break;
+
+        case wtscrollvert:
+            /* arrows at the ends, track between, thumb from size/position */
+            wigtxt(wg, 1, 1, "^", FALSE);
+            for (y = 2; y < h; y++) wigtxt(wg, 1, y, ".", FALSE);
+            wigtxt(wg, 1, h, "v", FALSE);
+            n = h-2; /* track length */
+            if (n > 0) {
+
+                ts = wigmul(n, wg->sclsiz); /* thumb size */
+                if (ts < 1) ts = 1;
+                if (ts > n) ts = n;
+                tp = wigmul(n-ts, wg->val); /* offset */
+                for (y = 0; y < ts; y++) wigtxt(wg, 1, 2+tp+y, "#", FALSE);
+
+            }
+            break;
+
+        case wtscrollhoriz:
+            wigtxt(wg, 1, 1, "<", FALSE);
+            for (x = 2; x < w; x++) wigtxt(wg, x, 1, ".", FALSE);
+            wigtxt(wg, w, 1, ">", FALSE);
+            n = w-2;
+            if (n > 0) {
+
+                ts = wigmul(n, wg->sclsiz);
+                if (ts < 1) ts = 1;
+                if (ts > n) ts = n;
+                tp = wigmul(n-ts, wg->val);
+                for (x = 0; x < ts; x++) wigtxt(wg, 2+tp+x, 1, "#", FALSE);
+
+            }
+            break;
+
+        case wtnumselbox:
+            wigclr(wg);
+            wigtxt(wg, 1, 1, "-", FALSE);
+            wigtxt(wg, w, 1, "+", FALSE);
+            snprintf(buf, sizeof(buf), "%*ld", (int)(w-2), wg->val);
+            wigtxt(wg, 2, 1, buf, win->focus);
+            break;
+
+        case wteditbox:
+            wigclr(wg);
+            n = strlen(wg->face);
+            /* keep the cursor visible: scroll the text if needed */
+            i = 0; /* display start */
+            if (wg->curs >= w) i = wg->curs-w+1;
+            for (x = 1; x <= w && i+x-1 < n+1; x++) {
+
+                char c = i+x-1 < n? wg->face[i+x-1]: ' ';
+                rev = win->focus && (i+x-1 == wg->curs);
+                buf[0] = c; buf[1] = 0;
+                wigtxt(wg, x, 1, buf, rev);
+
+            }
+            break;
+
+        case wtprogbar:
+            for (x = 1; x <= w; x++) {
+
+                n = wigmul(w, wg->val);
+                wigtxt(wg, x, 1, x <= n? "=": ".", FALSE);
+
+            }
+            break;
+
+        case wtlistbox:
+            wigclr(wg);
+            for (y = 1; y <= h && y <= wg->listn; y++)
+                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel);
+            break;
+
+        case wtslidehoriz:
+            for (x = 1; x <= w; x++) wigtxt(wg, x, 1, "-", FALSE);
+            n = 1+wigmul(w-1, wg->val);
+            wigtxt(wg, n, 1, "#", FALSE);
+            break;
+
+        case wtslidevert:
+            for (y = 1; y <= h; y++) wigtxt(wg, 1, y, "|", FALSE);
+            n = 1+wigmul(h-1, wg->val);
+            wigtxt(wg, 1, n, "#", FALSE);
+            break;
+
+        case wtdropbox:
+            /* closed face: the selection and a drop arrow */
+            wigclr(wg);
+            if (wg->sel >= 1 && wg->sel <= wg->listn)
+                wigtxt(wg, 1, 1, wg->list[wg->sel-1], win->focus);
+            wigtxt(wg, w, 1, "v", FALSE);
+            break;
+
+        case wtdropeditbox:
+            /* an edit box with a drop arrow in the last cell */
+            wigclr(wg);
+            n = strlen(wg->face);
+            i = 0;
+            if (wg->curs >= w-1) i = wg->curs-w+2;
+            for (x = 1; x <= w-1 && i+x-1 < n+1; x++) {
+
+                char c = i+x-1 < n? wg->face[i+x-1]: ' ';
+                rev = win->focus && (i+x-1 == wg->curs);
+                buf[0] = c; buf[1] = 0;
+                wigtxt(wg, x, 1, buf, rev);
+
+            }
+            wigtxt(wg, w, 1, "v", FALSE);
+            break;
+
+        case wttabbar:
+            wigclr(wg);
+            if (wg->tor == ami_totop || wg->tor == ami_tobottom) {
+
+                /* names along a row, separated by bars */
+                x = 1;
+                for (i = 0; i < wg->listn && x <= w; i++) {
+
+                    wigtxt(wg, x, 1, wg->list[i], wg->sel == i+1);
+                    x += strlen(wg->list[i]);
+                    if (i+1 < wg->listn) { wigtxt(wg, x, 1, "|", FALSE); x++; }
+
+                }
+
+            } else {
+
+                /* names down the column, one character per row, with a
+                   separator between tabs */
+                y = 1;
+                for (i = 0; i < wg->listn && y <= h; i++) {
+
+                    const char* p = wg->list[i];
+                    while (*p && y <= h) {
+
+                        buf[0] = *p++; buf[1] = 0;
+                        wigtxt(wg, 1, y++, buf, wg->sel == i+1);
+
+                    }
+                    if (i+1 < wg->listn && y <= h)
+                        wigtxt(wg, 1, y++, "-", FALSE);
+
+                }
+
+            }
+            break;
+
+        case wtmenubar:
+            drwmbar(wg);
+            break;
+
+        case wtpopup:
+            /* the list, one entry per line, current selection reversed */
+            wigclr(wg);
+            for (y = 1; y <= h && y <= wg->listn; y++)
+                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel);
+            break;
+
+    }
+
+}
+
+/* send a widget event to the owner */
+static void wigsig(wigptr wg, ami_evtcod e, long v)
+
+{
+
+    ami_evtrec er;
+
+    er.etype = e;
+    switch (e) { /* fill the union by type */
+
+        case ami_etbutton: er.butid = wg->id; break;
+        case ami_etchkbox: er.ckbxid = wg->id; break;
+        case ami_etradbut: er.radbid = wg->id; break;
+        case ami_etsclull: er.sclulid = wg->id; break;
+        case ami_etscldrl: er.scldrid = wg->id; break;
+        case ami_etsclulp: er.sclupid = wg->id; break;
+        case ami_etscldrp: er.scldpid = wg->id; break;
+        case ami_etsclpos: er.sclpid = wg->id; er.sclpos = v; break;
+        case ami_etedtbox: er.edtbid = wg->id; break;
+        case ami_etnumbox: er.numbid = wg->id; er.numbsl = v; break;
+        case ami_etlstbox: er.lstbid = wg->id; er.lstbsl = v; break;
+        case ami_etsldpos: er.sldpid = wg->id; er.sldpos = v; break;
+        case ami_etdrpbox: er.drpbid = wg->id; er.drpbsl = v; break;
+        case ami_etdrebox: er.drebid = wg->id; break;
+        case ami_ettabbar: er.tabid = wg->id; er.tabsel = v; break;
+        default: break;
+
+    }
+    intsendevent(wg->parent, &er); /* to the owner's queue */
+
+}
+
+/* cells from a full scale value: round(range*val/LONG_MAX), end exact.
+   The previous fixed point form quantized to 1024 steps and floored, so a
+   full scale value always came out one cell short of the end. */
+static long wigmul(long range, long val)
+
+{
+
+    if (val <= 0 || range <= 0) return (0);
+    if (val >= LONG_MAX) return (range);
+
+    return ((long)((double)range*val/(double)LONG_MAX+0.5));
+
+}
+
+/* full scale value from a fraction, guarding the ends */
+static long wigscl(long num, long den)
+
+{
+
+    if (den <= 0) return (0);
+    if (num <= 0) return (0);
+    if (num >= den) return (LONG_MAX);
+
+    return (num*(LONG_MAX/den));
+
+}
+
+/* Track a mouse drag on a value widget: recompute the value from the
+   mouse position, and redraw and notify only when it changes. Sliders
+   take the position directly; scroll bars position the thumb center at
+   the pointer within the track. */
+static void wigdrag(void)
+
+{
+
+    wigptr wg = drgwig;
+    winptr win;
+    long   n, ts, p, nv;
+
+    if (!wg) return;
+    win = wg->win;
+    nv = wg->val;
+    switch (wg->typ) {
+
+        case wtslidehoriz:
+            p = mousex-win->orgx; /* 0 based position */
+            if (p < 0) p = 0;
+            if (p > win->cmaxx-1) p = win->cmaxx-1;
+            nv = wigscl(p, win->cmaxx-1);
+            break;
+
+        case wtslidevert:
+            p = mousey-win->orgy;
+            if (p < 0) p = 0;
+            if (p > win->cmaxy-1) p = win->cmaxy-1;
+            nv = wigscl(p, win->cmaxy-1);
+            break;
+
+        case wtscrollvert:
+            n = win->cmaxy-2; /* track length */
+            ts = wigmul(n, wg->sclsiz); /* thumb size */
+            if (ts < 1) ts = 1;
+            if (n-ts <= 0) return; /* thumb fills the track */
+            p = mousey-win->orgy-1-ts/2; /* thumb top from pointer */
+            if (p < 0) p = 0;
+            if (p > n-ts) p = n-ts;
+            nv = wigscl(p, n-ts);
+            break;
+
+        case wtscrollhoriz:
+            n = win->cmaxx-2;
+            ts = wigmul(n, wg->sclsiz);
+            if (ts < 1) ts = 1;
+            if (n-ts <= 0) return;
+            p = mousex-win->orgx-1-ts/2;
+            if (p < 0) p = 0;
+            if (p > n-ts) p = n-ts;
+            nv = wigscl(p, n-ts);
+            break;
+
+        default: return; /* not a draggable type */
+
+    }
+    if (nv != wg->val) { /* the value moved */
+
+        wg->val = nv;
+        wigdrw(wg);
+        if (wg->typ == wtscrollvert || wg->typ == wtscrollhoriz)
+            wigsig(wg, ami_etsclpos, nv);
+        else wigsig(wg, ami_etsldpos, nv);
+
+    }
+
+}
+
+/* widget window event processor. Called from intsendevent for any event
+   whose target window is a widget. */
+static void wigevt(wigptr wg, ami_evtrec* er)
+
+{
+
+    winptr win = wg->win;
+    long   lx, ly, n;
+
+    switch (er->etype) {
+
+        case ami_etfocus:
+        case ami_etnofocus:
+        case ami_etredraw:
+            wigdrw(wg); /* focus look changed, or repaint */
+            break;
+
+        case ami_etmouba: /* click in the widget */
+            if (!wg->enb) break; /* disabled, dead */
+            lx = mousex-win->orgx+1; /* local position */
+            ly = mousey-win->orgy+1;
+            switch (wg->typ) {
+
+                case wtbutton: wigsig(wg, ami_etbutton, 0); break;
+                case wtcheckbox: wigsig(wg, ami_etchkbox, 0); break;
+                case wtradio: wigsig(wg, ami_etradbut, 0); break;
+                case wtscrollvert:
+                    if (ly == 1) wigsig(wg, ami_etsclull, 0);
+                    else if (ly == win->cmaxy) wigsig(wg, ami_etscldrl, 0);
+                    else { /* in the track */
+
+                        n = win->cmaxy-2;
+                        if (n > 0) {
+
+                            long ts = wigmul(n, wg->sclsiz);
+                            long tp;
+                            if (ts < 1) ts = 1;
+                            tp = wigmul(n-ts, wg->val);
+                            if (ly-2 >= tp && ly-2 < tp+ts)
+                                drgwig = wg; /* on the thumb: drag it */
+                            else if (ly-2 < tp) wigsig(wg, ami_etsclulp, 0);
+                            else wigsig(wg, ami_etscldrp, 0);
+
+                        }
+
+                    }
+                    break;
+                case wtscrollhoriz:
+                    if (lx == 1) wigsig(wg, ami_etsclull, 0);
+                    else if (lx == win->cmaxx) wigsig(wg, ami_etscldrl, 0);
+                    else { /* in the track */
+
+                        n = win->cmaxx-2;
+                        if (n > 0) {
+
+                            long ts = wigmul(n, wg->sclsiz);
+                            long tp;
+                            if (ts < 1) ts = 1;
+                            tp = wigmul(n-ts, wg->val);
+                            if (lx-2 >= tp && lx-2 < tp+ts)
+                                drgwig = wg; /* on the thumb: drag it */
+                            else if (lx-2 < tp) wigsig(wg, ami_etsclulp, 0);
+                            else wigsig(wg, ami_etscldrp, 0);
+
+                        }
+
+                    }
+                    break;
+                case wtnumselbox:
+                    if (lx == 1 && wg->val > wg->low) wg->val--;
+                    else if (lx == win->cmaxx && wg->val < wg->high) wg->val++;
+                    else break;
+                    wigdrw(wg);
+                    wigsig(wg, ami_etnumbox, wg->val);
+                    break;
+                case wteditbox:
+                    n = strlen(wg->face);
+                    wg->curs = lx-1 <= n? lx-1: n; /* place cursor by click */
+                    wigdrw(wg);
+                    break;
+                case wtlistbox:
+                    if (ly >= 1 && ly <= wg->listn) {
+
+                        wg->sel = ly;
+                        wigdrw(wg);
+                        wigsig(wg, ami_etlstbox, ly);
+
+                    }
+                    break;
+                case wtslidehoriz:
+                    wg->val = wigscl(lx-1, win->cmaxx-1);
+                    wigdrw(wg);
+                    wigsig(wg, ami_etsldpos, wg->val);
+                    drgwig = wg; /* and follow the mouse until release */
+                    break;
+                case wtslidevert:
+                    wg->val = wigscl(ly-1, win->cmaxy-1);
+                    wigdrw(wg);
+                    wigsig(wg, ami_etsldpos, wg->val);
+                    drgwig = wg; /* and follow the mouse until release */
+                    break;
+                case wtdropbox:
+                    /* click toggles the drop list */
+                    if (popcnt && popstk[popcnt-1]->owner == wg) clspops(0);
+                    else {
+
+                        clspops(0);
+                        opnpop(wg->parent, win->orgx, win->orgy+1,
+                               wg->list, wg->listn, wg, NULL);
+
+                    }
+                    break;
+                case wtdropeditbox:
+                    if (lx == win->cmaxx) { /* the drop arrow */
+
+                        if (popcnt && popstk[popcnt-1]->owner == wg)
+                            clspops(0);
+                        else {
+
+                            clspops(0);
+                            opnpop(wg->parent, win->orgx, win->orgy+1,
+                                   wg->list, wg->listn, wg, NULL);
+
+                        }
+
+                    } else { /* place the edit cursor */
+
+                        n = strlen(wg->face);
+                        wg->curs = lx-1 <= n? lx-1: n;
+                        wigdrw(wg);
+
+                    }
+                    break;
+                case wttabbar: { /* find the tab under the click */
+
+                    long i, p = 1, hit = 0;
+
+                    if (wg->tor == ami_totop || wg->tor == ami_tobottom) {
+
+                        for (i = 0; i < wg->listn && !hit; i++) {
+
+                            long tw = strlen(wg->list[i]);
+                            if (lx >= p && lx < p+tw) hit = i+1;
+                            p += tw+1; /* name and separator */
+
+                        }
+
+                    } else {
+
+                        for (i = 0; i < wg->listn && !hit; i++) {
+
+                            long th = strlen(wg->list[i]);
+                            if (ly >= p && ly < p+th) hit = i+1;
+                            p += th+1;
+
+                        }
+
+                    }
+                    if (hit && hit != wg->sel) {
+
+                        wg->sel = hit;
+                        wigdrw(wg);
+                        wigsig(wg, ami_ettabbar, hit);
+
+                    }
+                    break;
+
+                }
+                case wtmenubar: { /* open a pulldown */
+
+                    long sx;
+                    ami_menuptr mp = mbarhit(wg, lx, &sx);
+
+                    clspops(0);
+                    wg->sel = 0;
+                    if (mp && menenb(wg->parent, mp->id)) {
+
+                        if (mp->branch) { /* open the pulldown under it */
+
+                            char** strs;
+                            long n = mencol(wg->parent, mp->branch, &strs);
+                            long i;
+
+                            wg->sel = sx; /* show the open title */
+                            opnpop(wg->parent, win->orgx+sx-1, win->orgy+1,
+                                   strs, n, wg, mp->branch);
+                            for (i = 0; i < n; i++) free(strs[i]);
+                            free(strs);
+
+                        } else { /* a bare top level item selects */
+
+                            ami_evtrec er2;
+
+                            er2.etype = ami_etmenus;
+                            er2.menuid = mp->id;
+                            intsendevent(wg->parent, &er2);
+
+                        }
+
+                    }
+                    wigdrw(wg);
+                    break;
+
+                }
+                case wtpopup: { /* selection in a popup list */
+
+                    long row = ly;
+                    wigptr ow = wg->owner;
+
+                    if (row < 1 || row > wg->listn) break;
+                    if (wg->mitems) { /* a menu level */
+
+                        ami_menuptr item = mennth(wg->mitems, row);
+                        int depth;
+
+                        if (!item || !menenb(wg->parent, item->id)) break;
+                        /* find this popup's depth for cascade control */
+                        for (depth = 0; depth < popcnt; depth++)
+                            if (popstk[depth] == wg) break;
+                        if (item->branch) { /* cascade a submenu */
+
+                            char** strs;
+                            long n = mencol(wg->parent, item->branch, &strs);
+                            long i;
+
+                            clspops(depth+1); /* drop deeper levels */
+                            wg->sel = row;
+                            wigdrw(wg);
+                            opnpop(wg->parent,
+                                   win->orgx+win->pmaxx-1, win->orgy+row-1,
+                                   strs, n, wg->owner, item->branch);
+                            for (i = 0; i < n; i++) free(strs[i]);
+                            free(strs);
+
+                        } else { /* an item: select and close the menu */
+
+                            ami_evtrec er2;
+                            winptr mown = wg->parent;
+
+                            er2.etype = ami_etmenus;
+                            er2.menuid = item->id;
+                            clspops(0);
+                            if (mown->mbar) {
+
+                                mown->mbar->sel = 0;
+                                wigdrw(mown->mbar);
+
+                            }
+                            intsendevent(mown, &er2);
+
+                        }
+
+                    } else if (ow) { /* a drop box list */
+
+                        if (ow->typ == wtdropbox) {
+
+                            ow->sel = row;
+                            clspops(0);
+                            wigdrw(ow);
+                            wigsig(ow, ami_etdrpbox, row);
+
+                        } else if (ow->typ == wtdropeditbox) {
+
+                            snprintf(ow->face, MAXLIN, "%s", wg->list[row-1]);
+                            ow->curs = strlen(ow->face);
+                            clspops(0);
+                            wigdrw(ow);
+                            wigsig(ow, ami_etdrebox, 0);
+
+                        }
+
+                    }
+                    break;
+
+                }
+                default: break;
+
+            }
+            break;
+
+        case ami_etchar: /* keys to the focused widget */
+            if (!wg->enb) break;
+            if (wg->typ == wteditbox || wg->typ == wtdropeditbox) {
+
+                n = strlen(wg->face);
+                if (er->echar >= ' ' && er->echar != 0x7f && n < MAXLIN-1) {
+
+                    /* insert at the cursor */
+                    memmove(wg->face+wg->curs+1, wg->face+wg->curs,
+                            n-wg->curs+1);
+                    wg->face[wg->curs++] = er->echar;
+                    wigdrw(wg);
+
+                }
+
+            } else if (er->echar == ' ') { /* space activates */
+
+                if (wg->typ == wtbutton) wigsig(wg, ami_etbutton, 0);
+                else if (wg->typ == wtcheckbox) wigsig(wg, ami_etchkbox, 0);
+                else if (wg->typ == wtradio) wigsig(wg, ami_etradbut, 0);
+
+            }
+            break;
+
+        case ami_etenter:
+            if (!wg->enb) break;
+            if (wg->typ == wteditbox) wigsig(wg, ami_etedtbox, 0);
+            else if (wg->typ == wtdropeditbox) wigsig(wg, ami_etdrebox, 0);
+            else if (wg->typ == wtnumselbox) wigsig(wg, ami_etnumbox, wg->val);
+            else if (wg->typ == wtbutton) wigsig(wg, ami_etbutton, 0);
+            break;
+
+        case ami_etdelcb: /* backspace */
+            if ((wg->typ == wteditbox || wg->typ == wtdropeditbox) &&
+                wg->curs > 0) {
+
+                n = strlen(wg->face);
+                memmove(wg->face+wg->curs-1, wg->face+wg->curs, n-wg->curs+1);
+                wg->curs--;
+                wigdrw(wg);
+
+            }
+            break;
+
+        case ami_etdelcf: /* delete forward */
+            if (wg->typ == wteditbox || wg->typ == wtdropeditbox) {
+
+                n = strlen(wg->face);
+                if (wg->curs < n) {
+
+                    memmove(wg->face+wg->curs, wg->face+wg->curs+1,
+                            n-wg->curs);
+                    wigdrw(wg);
+
+                }
+
+            }
+            break;
+
+        case ami_etleft:
+            if ((wg->typ == wteditbox || wg->typ == wtdropeditbox) &&
+                wg->curs > 0)
+                { wg->curs--; wigdrw(wg); }
+            break;
+
+        case ami_etright:
+            if ((wg->typ == wteditbox || wg->typ == wtdropeditbox) &&
+                wg->curs < (long)strlen(wg->face))
+                { wg->curs++; wigdrw(wg); }
+            break;
+
+        case ami_ethomel:
+            if (wg->typ == wteditbox || wg->typ == wtdropeditbox)
+                { wg->curs = 0; wigdrw(wg); }
+            break;
+
+        case ami_etendl:
+            if (wg->typ == wteditbox || wg->typ == wtdropeditbox)
+                { wg->curs = strlen(wg->face); wigdrw(wg); }
+            break;
+
+        case ami_etup:
+            if (!wg->enb) break;
+            if (wg->typ == wtnumselbox && wg->val < wg->high)
+                { wg->val++; wigdrw(wg); wigsig(wg, ami_etnumbox, wg->val); }
+            else if (wg->typ == wtlistbox && wg->sel > 1)
+                { wg->sel--; wigdrw(wg); wigsig(wg, ami_etlstbox, wg->sel); }
+            break;
+
+        case ami_etdown:
+            if (!wg->enb) break;
+            if (wg->typ == wtnumselbox && wg->val > wg->low)
+                { wg->val--; wigdrw(wg); wigsig(wg, ami_etnumbox, wg->val); }
+            else if (wg->typ == wtlistbox && wg->sel < wg->listn)
+                { wg->sel++; wigdrw(wg); wigsig(wg, ami_etlstbox, wg->sel); }
+            break;
+
+        default: break; /* other events are of no interest */
+
+    }
+
+}
+
+/* create a widget: subwindow plus tracking record */
+static wigptr wigcre(FILE* f, long x1, long y1, long x2, long y2, long id,
+                     wigtyp typ)
+
+{
+
+    winptr par;  /* owning window */
+    wigptr wg;   /* new widget */
+    FILE*  wf;
+
+    par = txt2win(f); /* index owner */
+    if (!id) error("Invalid widget id");
+    if (fndwig(par, id)) error("Widget by id already in use");
+    if (x2 < x1 || y2 < y1) error("Invalid widget rectangle");
+    wg = malloc(sizeof(wigrec));
+    if (!wg) error("Out of memory");
+    /* open the face window as an anonymous subwindow of the owner */
+    iopenwin(&stdin, &wf, f, igetwinid());
+    wg->id = id;
+    wg->typ = typ;
+    wg->parent = par;
+    wg->wf = wf;
+    wg->win = txt2win(wf);
+    wg->face = NULL;
+    wg->list = NULL;
+    wg->listn = 0;
+    wg->enb = TRUE;
+    wg->sel = FALSE;
+    wg->val = 0;
+    wg->low = 0;
+    wg->high = 0;
+    wg->sclsiz = LONG_MAX/8; /* nominal thumb */
+    wg->curs = 0;
+    wg->win->widget = TRUE; /* mark as widget window */
+    wg->win->wig = wg;
+    wg->next = par->wiglst; /* push onto the owner's list */
+    par->wiglst = wg;
+    /* Shape the face: no decorations at all, sized and placed in owner
+       client terms. The flags are set directly and the geometry recomputed
+       once, rather than through the API calls, which would repaint after
+       each flag. */
+    wg->win->frame = FALSE;
+    wg->win->size = FALSE;
+    wg->win->sysbar = FALSE;
+    recompcli(wg->win);
+    intsetsiz(wg->win, x2-x1+1, y2-y1+1);
+    intsetpos(wg->win, par->orgx+par->coffx+x1-1, par->orgy+par->coffy+y1-1);
+    /* widget colors follow the owner */
+    wg->win->fcolor = par->fcolor;
+    wg->win->bcolor = par->bcolor;
+
+    return (wg);
+
+}
+
+/* set the face text of a widget */
+static void wigfac(wigptr wg, const char* s)
+
+{
+
+    if (wg->face) free(wg->face);
+    wg->face = malloc(strlen(s)+1);
+    if (!wg->face) error("Out of memory");
+    strcpy(wg->face, s);
+
+}
+
+/** ****************************************************************************
+
+Widget API
+
+*******************************************************************************/
+
+long ami_getwigid(FILE* f)
+
+{
+
+    winptr win = txt2win(f);
+    long   id = -1;
+
+    while (fndwig(win, id)) id--; /* find a free negative id */
+
+    return (id);
+
+}
+
+void ami_killwidget(FILE* f, long id)
+
+{
+
+    winptr win = txt2win(f);
+    wigptr wg = fndwig(win, id);
+    wigptr* lp;
+
+    if (!wg) error("No widget by given id");
+    /* unlink from the owner */
+    lp = &win->wiglst;
+    while (*lp != wg) lp = &(*lp)->next;
+    *lp = wg->next;
+    fclose(wg->wf); /* close the face window, which erases it */
+    if (wg->face) free(wg->face);
+    if (wg->list) {
+
+        long i;
+        for (i = 0; i < wg->listn; i++) free(wg->list[i]);
+        free(wg->list);
+
+    }
+    free(wg);
+
+}
+
+void ami_selectwidget(FILE* f, long id, long e)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    wg->sel = !!e;
+    wigdrw(wg);
+
+}
+
+void ami_enablewidget(FILE* f, long id, long e)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    wg->enb = !!e;
+    wigdrw(wg);
+
+}
+
+void ami_getwidgettext(FILE* f, long id, char* s, long sl)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+    long   l;
+
+    if (!wg) error("No widget by given id");
+    l = wg->face? strlen(wg->face): 0;
+    /* critical output buffer: error if it does not fit, no terminator on
+       an exact fit */
+    if (l > sl) error("String too large for destination");
+    if (l) memcpy(s, wg->face, l);
+    if (l < sl) s[l] = 0;
+
+}
+
+void ami_putwidgettext(FILE* f, long id, char* s)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    wigfac(wg, s);
+    wg->curs = strlen(s);
+    wigdrw(wg);
+
+}
+
+void ami_sizwidget(FILE* f, long id, long x, long y)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    intsetsiz(wg->win, x, y);
+    wigdrw(wg);
+
+}
+
+void ami_poswidget(FILE* f, long id, long x, long y)
+
+{
+
+    winptr win = txt2win(f);
+    wigptr wg = fndwig(win, id);
+
+    if (!wg) error("No widget by given id");
+    intsetpos(wg->win, win->orgx+win->coffx+x-1, win->orgy+win->coffy+y-1);
+
+}
+
+void ami_backwidget(FILE* f, long id)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    intback(wg->win);
+
+}
+
+void ami_frontwidget(FILE* f, long id)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    intfront(wg->win);
+
+}
+
+void ami_focuswidget(FILE* f, long id)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+    ami_evtrec er;
+
+    if (!wg) error("No widget by given id");
+    remfocus(); /* drop focus elsewhere */
+    wg->win->focus = TRUE;
+    curfocus = wg->win;
+    er.etype = ami_etfocus; /* let the widget show it */
+    intsendevent(wg->win, &er);
+    setcur(wg->win); /* and place the cursor */
+
+}
+
+void ami_buttonsiz(FILE* f, char* s, long* w, long* h)
+
+{
+
+    *w = strlen(s)+4; /* label, brackets and breathing room */
+    *h = 1;
+
+}
+
+void ami_button(FILE* f, long x1, long y1, long x2, long y2, char* s, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtbutton);
+
+    wigfac(wg, s);
+    wigdrw(wg);
+
+}
+
+void ami_checkboxsiz(FILE* f, char* s, long* w, long* h)
+
+{
+
+    *w = strlen(s)+4; /* box, space and label */
+    *h = 1;
+
+}
+
+void ami_checkbox(FILE* f, long x1, long y1, long x2, long y2, char* s, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtcheckbox);
+
+    wigfac(wg, s);
+    wigdrw(wg);
+
+}
+
+void ami_radiobuttonsiz(FILE* f, char* s, long* w, long* h)
+
+{
+
+    *w = strlen(s)+4;
+    *h = 1;
+
+}
+
+void ami_radiobutton(FILE* f, long x1, long y1, long x2, long y2, char* s,
+                     long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtradio);
+
+    wigfac(wg, s);
+    wigdrw(wg);
+
+}
+
+void ami_groupsiz(FILE* f, char* s, long cw, long ch, long* w, long* h,
+                  long* ox, long* oy)
+
+{
+
+    long tw = strlen(s)+4; /* title needs the top run */
+
+    *w = cw+2; /* client plus frame */
+    if (*w < tw) *w = tw;
+    *h = ch+2;
+    *ox = 1; /* client offset within the group */
+    *oy = 1;
+
+}
+
+void ami_group(FILE* f, long x1, long y1, long x2, long y2, char* s, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtgroup);
+
+    wigfac(wg, s);
+    wigdrw(wg);
+
+}
+
+void ami_background(FILE* f, long x1, long y1, long x2, long y2, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtbackground);
+
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_scrollvertsiz(FILE* f, long* w, long* h)
+
+{
+
+    *w = 1; /* a column */
+    *h = 4; /* arrows and some track; usually overridden by the caller */
+
+}
+
+void ami_scrollvert(FILE* f, long x1, long y1, long x2, long y2, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtscrollvert);
+
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_scrollhorizsiz(FILE* f, long* w, long* h)
+
+{
+
+    *w = 4;
+    *h = 1;
+
+}
+
+void ami_scrollhoriz(FILE* f, long x1, long y1, long x2, long y2, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtscrollhoriz);
+
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_scrollpos(FILE* f, long id, long r)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    if (r < 0) r = 0;
+    wg->val = r;
+    wigdrw(wg);
+
+}
+
+void ami_scrollsiz(FILE* f, long id, long r)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    if (r < 0) r = 0;
+    wg->sclsiz = r;
+    wigdrw(wg);
+
+}
+
+void ami_numselboxsiz(FILE* f, long l, long u, long* w, long* h)
+
+{
+
+    char buf[40];
+    long wl, wu;
+
+    snprintf(buf, sizeof(buf), "%ld", l); wl = strlen(buf);
+    snprintf(buf, sizeof(buf), "%ld", u); wu = strlen(buf);
+    if (wl > wu) wu = wl;
+    *w = wu+2; /* digits plus the spin cells */
+    *h = 1;
+
+}
+
+void ami_numselbox(FILE* f, long x1, long y1, long x2, long y2, long l, long u,
+                   long id)
+
+{
+
+    wigptr wg;
+
+    if (l > u) error("Invalid number range");
+    wg = wigcre(f, x1, y1, x2, y2, id, wtnumselbox);
+    wg->low = l;
+    wg->high = u;
+    wg->val = l;
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_editboxsiz(FILE* f, char* s, long* w, long* h)
+
+{
+
+    *w = strlen(s)+2;
+    *h = 1;
+
+}
+
+void ami_editbox(FILE* f, long x1, long y1, long x2, long y2, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wteditbox);
+
+    wg->face = malloc(MAXLIN); /* edit content buffer */
+    if (!wg->face) error("Out of memory");
+    wg->face[0] = 0;
+    wigdrw(wg);
+
+}
+
+void ami_progbarsiz(FILE* f, long* w, long* h)
+
+{
+
+    *w = 10;
+    *h = 1;
+
+}
+
+void ami_progbar(FILE* f, long x1, long y1, long x2, long y2, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtprogbar);
+
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_progbarpos(FILE* f, long id, long pos)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    if (pos < 0) pos = 0;
+    wg->val = pos;
+    wigdrw(wg);
+
+}
+
+void ami_listboxsiz(FILE* f, ami_strptr sp, long* w, long* h)
+
+{
+
+    long mw = 0, n = 0, l;
+
+    while (sp) {
+
+        l = strlen(sp->str);
+        if (l > mw) mw = l;
+        n++;
+        sp = sp->next;
+
+    }
+    *w = mw? mw: 1;
+    *h = n? n: 1;
+
+}
+
+void ami_listbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtlistbox);
+    ami_strptr p;
+    long n = 0, i;
+
+    for (p = sp; p; p = p->next) n++; /* count strings */
+    wg->list = malloc(sizeof(char*)*(n? n: 1));
+    if (!wg->list) error("Out of memory");
+    i = 0;
+    for (p = sp; p; p = p->next) {
+
+        wg->list[i] = malloc(strlen(p->str)+1);
+        if (!wg->list[i]) error("Out of memory");
+        strcpy(wg->list[i], p->str);
+        i++;
+
+    }
+    wg->listn = n;
+    wg->sel = 0; /* no selection */
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_slidehorizsiz(FILE* f, long* w, long* h)
+
+{
+
+    *w = 10;
+    *h = 1;
+
+}
+
+void ami_slidehoriz(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                    long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtslidehoriz);
+
+    (void)mark; /* tick marks are not drawn in character cells */
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_slidevertsiz(FILE* f, long* w, long* h)
+
+{
+
+    *w = 1;
+    *h = 10;
+
+}
+
+void ami_slidevert(FILE* f, long x1, long y1, long x2, long y2, long mark,
+                   long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtslidevert);
+
+    (void)mark;
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+/** ****************************************************************************
+
+Drop box, drop edit box and tab bar API
+
+*******************************************************************************/
+
+/* copy a string list into a widget */
+static void wiglst(wigptr wg, ami_strptr sp)
+
+{
+
+    ami_strptr p;
+    long n = 0, i = 0;
+
+    for (p = sp; p; p = p->next) n++;
+    wg->list = malloc(sizeof(char*)*(n? n: 1));
+    if (!wg->list) error("Out of memory");
+    for (p = sp; p; p = p->next) {
+
+        wg->list[i] = malloc(strlen(p->str)+1);
+        if (!wg->list[i]) error("Out of memory");
+        strcpy(wg->list[i], p->str);
+        i++;
+
+    }
+    wg->listn = n;
+
+}
+
+/* widest string in a list */
+static long lstwid(ami_strptr sp)
+
+{
+
+    long w = 0;
+
+    while (sp) {
+
+        if ((long)strlen(sp->str) > w) w = strlen(sp->str);
+        sp = sp->next;
+
+    }
+
+    return (w);
+
+}
+
+/* count of strings in a list */
+static long lstcnt(ami_strptr sp)
+
+{
+
+    long n = 0;
+
+    while (sp) { n++; sp = sp->next; }
+
+    return (n);
+
+}
+
+void ami_dropboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                    long* oh)
+
+{
+
+    *cw = lstwid(sp)+1; /* the face: widest entry and the arrow */
+    *ch = 1;
+    *ow = lstwid(sp)+3; /* the open list: entries and the frame */
+    *oh = lstcnt(sp)+2;
+
+}
+
+void ami_dropbox(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                 long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtdropbox);
+
+    wiglst(wg, sp);
+    wg->sel = wg->listn? 1: 0; /* first entry shows by default */
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_dropeditboxsiz(FILE* f, ami_strptr sp, long* cw, long* ch, long* ow,
+                        long* oh)
+
+{
+
+    *cw = lstwid(sp)+1;
+    *ch = 1;
+    *ow = lstwid(sp)+3;
+    *oh = lstcnt(sp)+2;
+
+}
+
+void ami_dropeditbox(FILE* f, long x1, long y1, long x2, long y2,
+                     ami_strptr sp, long id)
+
+{
+
+    wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtdropeditbox);
+
+    wiglst(wg, sp);
+    wg->face = malloc(MAXLIN); /* edit content */
+    if (!wg->face) error("Out of memory");
+    wg->face[0] = 0;
+    if (wg->listn) { /* start on the first entry */
+
+        snprintf(wg->face, MAXLIN, "%s", wg->list[0]);
+        wg->curs = strlen(wg->face);
+
+    }
+    wigdrw(wg);
+
+}
+
+void ami_tabbarsiz(FILE* f, ami_tabori tor, long cw, long ch, long* w, long* h,
+                   long* ox, long* oy)
+
+{
+
+    if (tor == ami_totop || tor == ami_tobottom) {
+
+        *w = cw+2; /* client plus the frame sides */
+        *h = ch+3; /* client, the tab row and the frame */
+        *ox = 1;
+        *oy = tor == ami_totop? 2: 0;
+
+    } else {
+
+        *w = cw+3; /* client, the tab column and the frame */
+        *h = ch+2;
+        *ox = tor == ami_toleft? 2: 0;
+        *oy = 1;
+
+    }
+
+}
+
+void ami_tabbarclient(FILE* f, ami_tabori tor, long w, long h, long* cw,
+                      long* ch, long* ox, long* oy)
+
+{
+
+    if (tor == ami_totop || tor == ami_tobottom) {
+
+        *cw = w-2;
+        *ch = h-3;
+        *ox = 1;
+        *oy = tor == ami_totop? 2: 0;
+
+    } else {
+
+        *cw = w-3;
+        *ch = h-2;
+        *ox = tor == ami_toleft? 2: 0;
+        *oy = 1;
+
+    }
+
+}
+
+void ami_tabbar(FILE* f, long x1, long y1, long x2, long y2, ami_strptr sp,
+                ami_tabori tor, long id)
+
+{
+
+    wigptr wg;
+
+    /* The bar occupies only the tab strip: a row for top or bottom
+       orientation, a column for left or right. The client area beside it
+       belongs to the caller, which is what tabbarclient describes. */
+    if (tor == ami_totop) y2 = y1;
+    else if (tor == ami_tobottom) y1 = y2;
+    else if (tor == ami_toleft) x2 = x1;
+    else x1 = x2;
+    wg = wigcre(f, x1, y1, x2, y2, id, wttabbar);
+    wg->tor = tor;
+    wiglst(wg, sp);
+    wg->sel = wg->listn? 1: 0; /* first tab selected */
+    wigfac(wg, "");
+    wigdrw(wg);
+
+}
+
+void ami_tabsel(FILE* f, long id, long tn)
+
+{
+
+    wigptr wg = fndwig(txt2win(f), id);
+
+    if (!wg) error("No widget by given id");
+    if (tn < 1 || tn > wg->listn) error("Invalid tab number");
+    wg->sel = tn;
+    wigdrw(wg);
+
+}
+
+/** ****************************************************************************
+
+Menus
+
+The menu bar is a widget across the top of the window's client area. Its
+pulldowns are popups, cascading for submenus. Selections are returned to the
+client as etmenus events, as the graphical implementations do.
+
+*******************************************************************************/
+
+static void imenu(FILE* f, ami_menuptr m)
+
+{
+
+    winptr win = txt2win(f);
+    wigptr wg;
+    long   id;
+
+    if (win->mbar) { /* remove the previous bar */
+
+        wigptr* lp = &win->wiglst;
+        while (*lp && *lp != win->mbar) lp = &(*lp)->next;
+        if (*lp) *lp = win->mbar->next;
+        fclose(win->mbar->wf);
+        if (win->mbar->face) free(win->mbar->face);
+        free(win->mbar);
+        win->mbar = NULL;
+
+    }
+    win->amenu = m;
+    if (!m) return; /* menu removed */
+    /* the bar spans the client width at its first row */
+    id = ami_getwigid(f);
+    wg = wigcre(f, 1, 1, win->cmaxx, 1, id, wtmenubar);
+    wg->mitems = m;
+    wg->sel = 0;
+    wigfac(wg, "");
+    win->mbar = wg;
+    wigdrw(wg);
+
+}
+
+static void imenuena(FILE* f, long id, long onoff)
+
+{
+
+    winptr    win = txt2win(f);
+    menenaptr me;
+
+    for (me = win->menena; me; me = me->next) if (me->id == id) break;
+    if (!me) { /* no entry yet, make one */
+
+        me = malloc(sizeof(menena));
+        if (!me) error("Out of memory");
+        me->id = id;
+        me->next = win->menena;
+        win->menena = me;
+
+    }
+    me->ena = !!onoff;
+    if (win->mbar) wigdrw(win->mbar);
+
+}
+
+/* find a menu item by id anywhere in a menu tree */
+static ami_menuptr fndmen(ami_menuptr m, long id)
+
+{
+
+    ami_menuptr p, r;
+
+    for (p = m; p; p = p->next) {
+
+        if (p->id == id) return (p);
+        if (p->branch) { r = fndmen(p->branch, id); if (r) return (r); }
+
+    }
+
+    return (NULL);
+
+}
+
+static void imenusel(FILE* f, long id, long select)
+
+{
+
+    winptr      win = txt2win(f);
+    ami_menuptr p = fndmen(win->amenu, id);
+
+    if (!p) error("No menu item by given id");
+    /* Set the check state in the caller's record, which is where the
+       drawing reads it. For a "one of" item, clear its chain first. */
+    if (p->oneof) {
+
+        ami_menuptr q;
+        /* the chain is the run of oneof items this one sits in */
+        for (q = win->amenu; q; q = q->next)
+            if (q->oneof && q != p) q->onoff = FALSE;
+
+    }
+    p->onoff = !!select;
+    if (win->mbar) wigdrw(win->mbar);
+
+}
+
+static void istdmenu(ami_stdmenusel sms, ami_menuptr* sm, ami_menuptr pm)
+
+{
+
+    static const struct { long sel; long id; char* face; } std[] = {
+
+        { AMI_SMNEW,        AMI_SMNEW,        "New" },
+        { AMI_SMOPEN,       AMI_SMOPEN,       "Open" },
+        { AMI_SMCLOSE,      AMI_SMCLOSE,      "Close" },
+        { AMI_SMSAVE,       AMI_SMSAVE,       "Save" },
+        { AMI_SMSAVEAS,     AMI_SMSAVEAS,     "Save As" },
+        { AMI_SMPAGESET,    AMI_SMPAGESET,    "Page Setup" },
+        { AMI_SMPRINT,      AMI_SMPRINT,      "Print" },
+        { AMI_SMEXIT,       AMI_SMEXIT,       "Exit" },
+        { AMI_SMUNDO,       AMI_SMUNDO,       "Undo" },
+        { AMI_SMCUT,        AMI_SMCUT,        "Cut" },
+        { AMI_SMPASTE,      AMI_SMPASTE,      "Paste" },
+        { AMI_SMDELETE,     AMI_SMDELETE,     "Delete" },
+        { AMI_SMFIND,       AMI_SMFIND,       "Find" },
+        { AMI_SMFINDNEXT,   AMI_SMFINDNEXT,   "Find Next" },
+        { AMI_SMREPLACE,    AMI_SMREPLACE,    "Replace" },
+        { AMI_SMGOTO,       AMI_SMGOTO,       "Goto" },
+        { AMI_SMSELECTALL,  AMI_SMSELECTALL,  "Select All" },
+        { AMI_SMNEWWINDOW,  AMI_SMNEWWINDOW,  "New Window" },
+        { AMI_SMTILEHORIZ,  AMI_SMTILEHORIZ,  "Tile Horizontally" },
+        { AMI_SMTILEVERT,   AMI_SMTILEVERT,   "Tile Vertically" },
+        { AMI_SMCASCADE,    AMI_SMCASCADE,    "Cascade" },
+        { AMI_SMCLOSEALL,   AMI_SMCLOSEALL,   "Close All" },
+        { AMI_SMHELPTOPIC,  AMI_SMHELPTOPIC,  "Help Topics" },
+        { AMI_SMABOUT,      AMI_SMABOUT,      "About" },
+
+    };
+    /* which standard items belong to which top level list */
+    static const long filist[] = { AMI_SMNEW, AMI_SMOPEN, AMI_SMCLOSE,
+        AMI_SMSAVE, AMI_SMSAVEAS, AMI_SMPAGESET, AMI_SMPRINT, AMI_SMEXIT, 0 };
+    static const long edlist[] = { AMI_SMUNDO, AMI_SMCUT, AMI_SMPASTE,
+        AMI_SMDELETE, AMI_SMFIND, AMI_SMFINDNEXT, AMI_SMREPLACE, AMI_SMGOTO,
+        AMI_SMSELECTALL, 0 };
+    static const long wilist[] = { AMI_SMNEWWINDOW, AMI_SMTILEHORIZ,
+        AMI_SMTILEVERT, AMI_SMCASCADE, AMI_SMCLOSEALL, 0 };
+    static const long helist[] = { AMI_SMHELPTOPIC, AMI_SMABOUT, 0 };
+    static const struct { const long* lst; char* face; } tops[] = {
+
+        { filist, "File" }, { edlist, "Edit" }, { NULL, NULL },
+        { wilist, "Window" }, { helist, "Help" },
+
+    };
+    ami_menuptr root = NULL, rtl = NULL;
+    long ti, i;
+
+    /* Build the standard lists, in the documented order:
+       file edit <program> window help */
+    for (ti = 0; ti < 5; ti++) {
+
+        ami_menuptr sub = NULL, subl = NULL, top;
+
+        if (!tops[ti].lst) { /* the program's own menu goes here */
+
+            if (pm) {
+
+                if (rtl) rtl->next = pm; else root = pm;
+                /* walk to the end of the program list */
+                rtl = pm;
+                while (rtl->next) rtl = rtl->next;
+
+            }
+            continue;
+
+        }
+        for (i = 0; tops[ti].lst[i]; i++) {
+
+            long sel = tops[ti].lst[i];
+            long si;
+
+            if (!(sms & (1L<<sel))) continue; /* not selected */
+            for (si = 0; si < AMI_SMMAX; si++) if (std[si].sel == sel) break;
+            if (si >= AMI_SMMAX) continue;
+            {
+                ami_menuptr e = malloc(sizeof(ami_menurec));
+                if (!e) error("Out of memory");
+                e->next = NULL;
+                e->branch = NULL;
+                e->onoff = FALSE;
+                e->oneof = FALSE;
+                e->bar = FALSE;
+                e->id = std[si].id;
+                e->face = std[si].face;
+                if (subl) subl->next = e; else sub = e;
+                subl = e;
+            }
+
+        }
+        if (sub) { /* the list has entries, make its top level entry */
+
+            top = malloc(sizeof(ami_menurec));
+            if (!top) error("Out of memory");
+            top->next = NULL;
+            top->branch = sub;
+            top->onoff = FALSE;
+            top->oneof = FALSE;
+            top->bar = FALSE;
+            top->id = 0;
+            top->face = tops[ti].face;
+            if (rtl) rtl->next = top; else root = top;
+            rtl = top;
+
+        }
+
+    }
+    *sm = root;
+
+}
+
+/** ****************************************************************************
+
+                            STANDARD DIALOGS
+
+Unlike the graphical implementations, which call up host system dialogs,
+these are presented inside the terminal surface as managed windows built
+from the character widgets. Each runs its own event loop until dismissed,
+which is what makes them modal.
+
+A dialog that is terminated from outside, by the window system rather than
+by its own controls, passes the terminate on to the program after closing,
+so a quit request is not swallowed by the dialog.
+
+*******************************************************************************/
+
+/* Run a dialog window until its done flag is set. Returns the id of the
+   widget that ended it, or 0 for an outside terminate. */
+static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid)
+
+{
+
+    ami_evtrec er;
+    long       res = 0;
+    int        done = FALSE;
+    int        realterm = FALSE;
+
+    ifocus(wf); /* the dialog takes the focus */
+    do {
+
+        ievent(stdin, &er);
+        if (er.etype == ami_etterm) { realterm = TRUE; done = TRUE; }
+        else if (er.etype == ami_etbutton) {
+
+            if (er.butid == okid || er.butid == cancelid) {
+
+                res = er.butid;
+                done = TRUE;
+
+            }
+
+        } else if (er.etype == ami_etedtbox || er.etype == ami_etdrebox) {
+
+            /* enter in a text field completes as the ok button does */
+            res = okid;
+            done = TRUE;
+
+        }
+
+    } while (!done);
+    if (realterm) { /* pass the terminate on to the program */
+
+        er.etype = ami_etterm;
+        enquepaevt(&er);
+
+    }
+
+    return (res);
+
+}
+
+/* Create a dialog window centered on the surface. Returns its file, and
+   the window record through the pointer. */
+static FILE* dlgcre(char* title, long w, long h, winptr* dwin)
+
+{
+
+    FILE*  wf;
+    winptr win;
+
+    iopenwin(&stdin, &wf, NULL, igetwinid()); /* parentless: floats */
+    win = txt2win(wf);
+    win->frame = TRUE;
+    win->size = FALSE;
+    win->sysbar = TRUE;
+    recompcli(win);
+    intsetsiz(win, w, h);
+    intsetpos(win, (dimx-w)/2+1, (dimy-h)/2+1);
+    ititle(wf, title);
+    intfront(win);
+    *dwin = win;
+
+    return (wf);
+
+}
+
+void ami_alert(char* title, char* message)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   w, h, bw, bh;
+    long   ml = strlen(message);
+    long   tl = strlen(title);
+
+    w = (ml > tl? ml: tl)+6;
+    if (w < 20) w = 20;
+    if (w > dimx-2) w = dimx-2;
+    h = 7;
+    wf = dlgcre(title, w, h, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "%.*s", (int)(dwin->cmaxx-2), message);
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, (dwin->cmaxx-bw)/2+1, dwin->cmaxy-1,
+                   (dwin->cmaxx-bw)/2+bw, dwin->cmaxy-1, "Ok", 1);
+    dlgloop(wf, dwin, 1, 0);
+    fclose(wf);
+
+}
+
+void ami_querycolor(long* r, long* g, long* b)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   res;
+    /* the eight terminal colors are the palette here */
+    static char* const cnam[] = { "black", "white", "red", "green", "blue",
+                                  "cyan", "yellow", "magenta" };
+    static const long cval[8][3] = {
+
+        { 0, 0, 0 }, { INT_MAX, INT_MAX, INT_MAX }, { INT_MAX, 0, 0 },
+        { 0, INT_MAX, 0 }, { 0, 0, INT_MAX }, { 0, INT_MAX, INT_MAX },
+        { INT_MAX, INT_MAX, 0 }, { INT_MAX, 0, INT_MAX },
+
+    };
+    ami_strrec sr[8];
+    long   i, bw, bh, sel;
+    wigptr wg;
+
+    for (i = 0; i < 8; i++) {
+
+        sr[i].str = cnam[i];
+        sr[i].next = i < 7? &sr[i+1]: NULL;
+
+    }
+    wf = dlgcre("Choose color", 26, 14, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Color:");
+    ami_listbox(wf, 2, 3, 20, 10, &sr[0], 1);
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, 3, 12, 3+bw-1, 12, "Ok", 2);
+    ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
+    res = dlgloop(wf, dwin, 2, 3);
+    sel = 0;
+    wg = fndwig(dwin, 1); /* read the list selection */
+    if (wg) sel = wg->sel;
+    if (res == 2 && sel >= 1 && sel <= 8) { /* accepted */
+
+        *r = cval[sel-1][0];
+        *g = cval[sel-1][1];
+        *b = cval[sel-1][2];
+
+    }
+    fclose(wf);
+
+}
+
+/* shared file name query for open and save */
+static void qryfile(char* title, char* s, long sl)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   res, bw, bh;
+    wigptr wg;
+    long   w = dimx-10;
+
+    if (w > 60) w = 60;
+    if (w < 24) w = 24;
+    wf = dlgcre(title, w, 8, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "File name:");
+    ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
+    /* seed with what the caller passed, if anything */
+    if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, 3, 5, 3+bw-1, 5, "Ok", 2);
+    ami_button(wf, 12, 5, 12+bw+4, 5, "Cancel", 3);
+    ami_focuswidget(wf, 1); /* start in the name field */
+    res = dlgloop(wf, dwin, 2, 3);
+    if (res == 2) { /* accepted: hand back the name */
+
+        wg = fndwig(dwin, 1);
+        if (wg && wg->face) {
+
+            long l = strlen(wg->face);
+            if (l > sl) error("String too large for destination");
+            memcpy(s, wg->face, l);
+            if (l < sl) s[l] = 0;
+
+        }
+
+    }
+    fclose(wf);
+
+}
+
+void ami_queryopen(char* s, long sl) { qryfile("Open file", s, sl); }
+
+void ami_querysave(char* s, long sl) { qryfile("Save file", s, sl); }
+
+void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   res, bw, bh;
+    wigptr wg;
+    long   w = dimx-10;
+
+    if (w > 50) w = 50;
+    if (w < 30) w = 30;
+    wf = dlgcre("Find", w, 11, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Find:");
+    ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
+    if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
+    ami_checkbox(wf, 2, 5, 20, 5, "Match case", 4);
+    ami_checkbox(wf, 2, 6, 20, 6, "Search up", 5);
+    ami_checkbox(wf, 2, 7, 24, 7, "Regular expression", 6);
+    ami_selectwidget(wf, 4, !!(*opt & (1L<<ami_qfncase)));
+    ami_selectwidget(wf, 5, !!(*opt & (1L<<ami_qfnup)));
+    ami_selectwidget(wf, 6, !!(*opt & (1L<<ami_qfnre)));
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, 3, 9, 3+bw-1, 9, "Ok", 2);
+    ami_button(wf, 12, 9, 12+bw+4, 9, "Cancel", 3);
+    ami_focuswidget(wf, 1);
+    res = dlgloop(wf, dwin, 2, 3);
+    if (res == 2) {
+
+        wg = fndwig(dwin, 1);
+        if (wg && wg->face) {
+
+            long l = strlen(wg->face);
+            if (l > sl) error("String too large for destination");
+            memcpy(s, wg->face, l);
+            if (l < sl) s[l] = 0;
+
+        }
+        *opt = 0; /* rebuild the option set from the boxes */
+        wg = fndwig(dwin, 4); if (wg && wg->sel) *opt |= 1L<<ami_qfncase;
+        wg = fndwig(dwin, 5); if (wg && wg->sel) *opt |= 1L<<ami_qfnup;
+        wg = fndwig(dwin, 6); if (wg && wg->sel) *opt |= 1L<<ami_qfnre;
+
+    }
+    fclose(wf);
+
+}
+
+void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   res, bw, bh;
+    wigptr wg;
+    long   w = dimx-10;
+
+    if (w > 50) w = 50;
+    if (w < 30) w = 30;
+    wf = dlgcre("Find and replace", w, 14, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Find:");
+    ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
+    if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
+    ami_cursor(wf, 2, 5);
+    fprintf(wf, "Replace with:");
+    ami_editbox(wf, 2, 6, dwin->cmaxx-1, 6, 7);
+    if (rl > 0 && *r) ami_putwidgettext(wf, 7, r);
+    ami_checkbox(wf, 2, 8, 20, 8, "Match case", 4);
+    ami_checkbox(wf, 2, 9, 20, 9, "Search up", 5);
+    ami_checkbox(wf, 2, 10, 24, 10, "All in line", 6);
+    ami_selectwidget(wf, 4, !!(*opt & (1L<<ami_qfrcase)));
+    ami_selectwidget(wf, 5, !!(*opt & (1L<<ami_qfrup)));
+    ami_selectwidget(wf, 6, !!(*opt & (1L<<ami_qfralllin)));
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, 3, 12, 3+bw-1, 12, "Ok", 2);
+    ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
+    ami_focuswidget(wf, 1);
+    res = dlgloop(wf, dwin, 2, 3);
+    if (res == 2) {
+
+        wg = fndwig(dwin, 1);
+        if (wg && wg->face) {
+
+            long l = strlen(wg->face);
+            if (l > sl) error("String too large for destination");
+            memcpy(s, wg->face, l);
+            if (l < sl) s[l] = 0;
+
+        }
+        wg = fndwig(dwin, 7);
+        if (wg && wg->face) {
+
+            long l = strlen(wg->face);
+            if (l > rl) error("String too large for destination");
+            memcpy(r, wg->face, l);
+            if (l < rl) r[l] = 0;
+
+        }
+        *opt = 0;
+        wg = fndwig(dwin, 4); if (wg && wg->sel) *opt |= 1L<<ami_qfrcase;
+        wg = fndwig(dwin, 5); if (wg && wg->sel) *opt |= 1L<<ami_qfrup;
+        wg = fndwig(dwin, 6); if (wg && wg->sel) *opt |= 1L<<ami_qfralllin;
+
+    }
+    fclose(wf);
+
+}
+
+void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
+                   long* br, long* bg, long* bb, ami_qfteffects* effect)
+
+{
+
+    FILE*  wf;
+    winptr dwin;
+    long   res, bw, bh;
+    wigptr wg;
+    /* A character terminal has one font at one size, so the font and size
+       are reported back unchanged; what can be chosen are the colors and
+       the effects the terminal can actually present. */
+    static char* const cnam[] = { "black", "white", "red", "green", "blue",
+                                  "cyan", "yellow", "magenta" };
+    static const long cval[8][3] = {
+
+        { 0, 0, 0 }, { INT_MAX, INT_MAX, INT_MAX }, { INT_MAX, 0, 0 },
+        { 0, INT_MAX, 0 }, { 0, 0, INT_MAX }, { 0, INT_MAX, INT_MAX },
+        { INT_MAX, INT_MAX, 0 }, { INT_MAX, 0, INT_MAX },
+
+    };
+    ami_strrec fr_[8], br_[8];
+    long i;
+
+    for (i = 0; i < 8; i++) {
+
+        fr_[i].str = cnam[i]; fr_[i].next = i < 7? &fr_[i+1]: NULL;
+        br_[i].str = cnam[i]; br_[i].next = i < 7? &br_[i+1]: NULL;
+
+    }
+    wf = dlgcre("Font", 46, 16, &dwin);
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Foreground:");
+    ami_dropbox(wf, 14, 2, 26, 2, &fr_[0], 1);
+    ami_cursor(wf, 2, 4);
+    fprintf(wf, "Background:");
+    ami_dropbox(wf, 14, 4, 26, 4, &br_[0], 8);
+    ami_cursor(wf, 2, 6);
+    fprintf(wf, "Effects:");
+    ami_checkbox(wf, 2, 7, 20, 7, "Bold", 4);
+    ami_checkbox(wf, 2, 8, 20, 8, "Underline", 5);
+    ami_checkbox(wf, 2, 9, 20, 9, "Italic", 6);
+    ami_checkbox(wf, 2, 10, 20, 10, "Reverse", 9);
+    ami_checkbox(wf, 2, 11, 20, 11, "Blink", 10);
+    ami_selectwidget(wf, 4, !!(*effect & (1L<<ami_qftebold)));
+    ami_selectwidget(wf, 5, !!(*effect & (1L<<ami_qfteunderline)));
+    ami_selectwidget(wf, 6, !!(*effect & (1L<<ami_qfteitalic)));
+    ami_selectwidget(wf, 9, !!(*effect & (1L<<ami_qftereverse)));
+    ami_selectwidget(wf, 10, !!(*effect & (1L<<ami_qfteblink)));
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    ami_button(wf, 3, 14, 3+bw-1, 14, "Ok", 2);
+    ami_button(wf, 12, 14, 12+bw+4, 14, "Cancel", 3);
+    res = dlgloop(wf, dwin, 2, 3);
+    if (res == 2) {
+
+        wg = fndwig(dwin, 1);
+        if (wg && wg->sel >= 1 && wg->sel <= 8) {
+
+            *fr = cval[wg->sel-1][0];
+            *fg = cval[wg->sel-1][1];
+            *fb = cval[wg->sel-1][2];
+
+        }
+        wg = fndwig(dwin, 8);
+        if (wg && wg->sel >= 1 && wg->sel <= 8) {
+
+            *br = cval[wg->sel-1][0];
+            *bg = cval[wg->sel-1][1];
+            *bb = cval[wg->sel-1][2];
+
+        }
+        *effect = 0;
+        wg = fndwig(dwin, 4); if (wg && wg->sel) *effect |= 1L<<ami_qftebold;
+        wg = fndwig(dwin, 5);
+        if (wg && wg->sel) *effect |= 1L<<ami_qfteunderline;
+        wg = fndwig(dwin, 6); if (wg && wg->sel) *effect |= 1L<<ami_qfteitalic;
+        wg = fndwig(dwin, 9);
+        if (wg && wg->sel) *effect |= 1L<<ami_qftereverse;
+        wg = fndwig(dwin, 10); if (wg && wg->sel) *effect |= 1L<<ami_qfteblink;
+
+    }
+    fclose(wf);
+
+}
+
+/** ****************************************************************************
+
 Managerc startup
 
 *******************************************************************************/
 
-static void init_managerc(void) __attribute__((constructor (104)));
+/* Managerc overrides the terminal API, so it must initialize after terminal
+   (constructor 106) and deinitialize before it: 107 on both, since
+   constructors run ascending and destructors descending. It was 104, which
+   worked when terminal was 103; when terminal moved to 106 the order
+   inverted and managerc captured null vectors at startup. */
+static void init_managerc(void) __attribute__((constructor (107)));
 static void init_managerc()
 
 {
@@ -6177,7 +8999,7 @@ Managerc shutdown
 
 *******************************************************************************/
 
-static void deinit_managerc(void) __attribute__((destructor (104)));
+static void deinit_managerc(void) __attribute__((destructor (107)));
 static void deinit_managerc()
 
 {

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -81,7 +81,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* local definitions */
 #include <localdefs.h>
 #include <config.h>
-#include <terminal.h>
+#include <terminalw.h>
 
 #include <diag.h>
 

--- a/test_manager.c
+++ b/test_manager.c
@@ -1,0 +1,184 @@
+/*******************************************************************************
+*                                                                              *
+*                    MANAGERC SUBWINDOW BEHAVIOR TEST                          *
+*                                                                              *
+* Opens two subwindows over the character mode window manager (managerc),      *
+* labels them, and fills each with this program's own source text, so the      *
+* behavior of subwindows can be examined by hand: moving, resizing,            *
+* minimize/maximize from the system bar, focus changes, occlusion between     *
+* the two overlapping windows, and the performance of the surface updates      *
+* while doing all of that. Filling the windows scrolls the text through        *
+* them, which exercises the scroll path as well; the windows are buffered,     *
+* so the manager keeps the text present over any rearrangement.                *
+*                                                                              *
+* Build (managerc is off in the default build, so the terminal library must    *
+* be built with it on):                                                        *
+*                                                                              *
+*     make lib/petit_ami_term.so USEMANAGERC=1                                 *
+*     make test_manager                                                        *
+*     ./test_manager                                                           *
+*                                                                              *
+* The main (root) window holds instructions and a running event trace at the   *
+* bottom, so window management events can be watched as they arrive. Press     *
+* "f" to refill both windows with the source text, repeating the scroll load   *
+* on demand; press "q" in any window to quit.                                  *
+*                                                                              *
+* Note: rebuilding without USEMANAGERC=1 afterwards restores the plain         *
+* terminal library.                                                            *
+*                                                                              *
+*******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+
+#include <localdefs.h>
+#include <terminal.h>
+
+#define OFF 0
+#define ON  1
+
+/* event names for the trace, indexed by ami_evtcod */
+static const char* evtnam(ami_evtcod e)
+
+{
+
+    switch (e) {
+
+        case ami_etchar:   return "char";
+        case ami_etenter:  return "enter";
+        case ami_etterm:   return "term";
+        case ami_etmoumov: return "moumov";
+        case ami_etmouba:  return "mouba";
+        case ami_etmoubd:  return "moubd";
+        case ami_etredraw: return "redraw";
+        case ami_etresize: return "resize";
+        case ami_etfocus:  return "focus";
+        case ami_etnofocus: return "nofocus";
+        case ami_ethover:  return "hover";
+        case ami_etnohover: return "nohover";
+        case ami_etmax:    return "max";
+        case ami_etmin:    return "min";
+        case ami_etnorm:   return "norm";
+        default:           return NULL; /* don't trace the rest */
+
+    }
+
+}
+
+/* fill both windows with this program's own source text */
+static void fillwin(FILE* win1, FILE* win2)
+
+{
+
+    FILE* fp;
+    char  buff[250];
+
+    fp = fopen(__FILE__, "r");
+    if (fp) {
+
+        while (fgets(buff, sizeof(buff), fp)) {
+
+            fputs(buff, win1);
+            fputs(buff, win2);
+
+        }
+        fclose(fp);
+
+    } else {
+
+        fprintf(win1, "cannot open %s: run from the repo root\n", __FILE__);
+        fprintf(win2, "cannot open %s: run from the repo root\n", __FILE__);
+
+    }
+
+}
+
+int main(void)
+
+{
+
+    FILE*      win1;  /* subwindow 1 */
+    FILE*      win2;  /* subwindow 2 */
+    ami_evtrec er;    /* event record */
+    long       done;
+    long       evline; /* trace line in root window */
+    long       evcnt;  /* events traced */
+    const char* en;
+    char       buff[250];
+
+    /* the root window: instructions, and it stays behind the subwindows */
+    ami_curvis(stdout, OFF);
+    ami_auto(stdout, OFF);
+    printf("\f");
+    printf("Managerc subwindow test\n");
+    printf("\n");
+    printf("Two subwindows should be present, each labeled.\n");
+    printf("Try: dragging by the system bar, resizing by the edges,\n");
+    printf("minimize/maximize/close from the system bar buttons,\n");
+    printf("clicking between windows for focus.\n");
+    printf("\n");
+    printf("Press f to refill both windows (repeat the scroll load).\n");
+    printf("Press q in any window to quit.\n");
+    evline = ami_maxy(stdout)-10; /* trace area at the bottom */
+    ami_cursor(stdout, 1, evline-1);
+    printf("--- window management events ---");
+    evcnt = 0;
+
+    /* first subwindow */
+    ami_openwin(&stdin, &win1, stdout, 2);
+    ami_setsiz(win1, 60, 16);
+    /* Match the buffer to the client area (window less frame and system
+       bar). The default buffer is near full screen, and managerc's scroll
+       and restore paths misdraw when the buffer is larger than the client:
+       they paint the entire buffer at the window position. */
+    ami_sizbuf(win1, 58, 12);
+    ami_setpos(win1, 4, 3);
+    fprintf(win1, "I am window 1\n");
+
+    /* second subwindow, overlapping the first so the occlusion redraw is
+       exercised when they move over each other */
+    ami_openwin(&stdin, &win2, stdout, 3);
+    ami_setsiz(win2, 60, 16);
+    ami_sizbuf(win2, 58, 12);
+    ami_setpos(win2, 40, 10);
+    fprintf(win2, "I am window 2\n");
+
+    /* Fill both windows with this program's own source. The text scrolls
+       through each window, which exercises the scroll path on the way in,
+       and the windows are buffered, so the text stays put over moves,
+       resizes, and occlusion by the other window. */
+    fillwin(win1, win2);
+
+    done = FALSE;
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etterm) done = TRUE;
+        else if (er.etype == ami_etchar && (er.echar == 'q' || er.echar == 'Q'))
+            done = TRUE;
+        else if (er.etype == ami_etchar && (er.echar == 'f' || er.echar == 'F'))
+            /* refill on demand, so the scroll load can be repeated while
+               watching (and timed) */
+            fillwin(win1, win2);
+        else {
+
+            /* trace interesting events in the root window */
+            en = evtnam(er.etype);
+            if (en) {
+
+                sprintf(buff, "%4ld: window %ld: %-8s", ++evcnt, er.winid, en);
+                ami_cursor(stdout, 1, evline+(evcnt%10));
+                printf("%-40s", buff);
+
+            }
+
+        }
+
+    } while (!done);
+
+    fclose(win2);
+    fclose(win1);
+
+    return (0);
+
+}

--- a/test_manager.c
+++ b/test_manager.c
@@ -11,10 +11,8 @@
 * them, which exercises the scroll path as well; the windows are buffered,     *
 * so the manager keeps the text present over any rearrangement.                *
 *                                                                              *
-* Build (managerc is off in the default build, so the terminal library must    *
-* be built with it on):                                                        *
+* Build:                                                                       *
 *                                                                              *
-*     make lib/petit_ami_term.so USEMANAGERC=1                                 *
 *     make test_manager                                                        *
 *     ./test_manager                                                           *
 *                                                                              *
@@ -23,16 +21,13 @@
 * "f" to refill both windows with the source text, repeating the scroll load   *
 * on demand; press "q" in any window to quit.                                  *
 *                                                                              *
-* Note: rebuilding without USEMANAGERC=1 afterwards restores the plain         *
-* terminal library.                                                            *
-*                                                                              *
 *******************************************************************************/
 
 #include <stdio.h>
 #include <string.h>
 
 #include <localdefs.h>
-#include <terminal.h>
+#include <terminalw.h>
 
 #define OFF 0
 #define ON  1

--- a/test_manager2.c
+++ b/test_manager2.c
@@ -16,9 +16,8 @@
 * scroll bar positions are echoed into the progress bar, so dragging value     *
 * widgets shows visible effect.                                                *
 *                                                                              *
-* Build (managerc is off in the default build):                                *
+* Build:                                                                       *
 *                                                                              *
-*     make lib/petit_ami_term.so USEMANAGERC=1                                 *
 *     make test_manager2                                                       *
 *     ./test_manager2                                                          *
 *                                                                              *
@@ -31,7 +30,7 @@
 #include <limits.h>
 
 #include <localdefs.h>
-#include <terminal.h>
+#include <terminalw.h>
 
 /* widget ids */
 #define WBUTTON   1

--- a/test_manager2.c
+++ b/test_manager2.c
@@ -1,0 +1,219 @@
+/*******************************************************************************
+*                                                                              *
+*                    MANAGERC CHARACTER WIDGETS TEST                           *
+*                                                                              *
+* Places one of each implemented widget type directly in the main window,     *
+* the surface that occupies the whole terminal. Widget notifications are       *
+* reported in the root window as they arrive, so each widget can be exercised *
+* by hand and its events watched: click the widgets, or focus one (click it)   *
+* and use the keyboard: space activates buttons and toggles, arrows work the   *
+* number select and list boxes, and the edit box takes full line editing      *
+* with enter to complete.                                                      *
+*                                                                              *
+* The program keeps the widget states current itself: the checkbox and radio   *
+* button select when their events arrive, which is the standard Petit-Ami      *
+* division of labor (widgets notify, the program sets state). The slider and   *
+* scroll bar positions are echoed into the progress bar, so dragging value     *
+* widgets shows visible effect.                                                *
+*                                                                              *
+* Build (managerc is off in the default build):                                *
+*                                                                              *
+*     make lib/petit_ami_term.so USEMANAGERC=1                                 *
+*     make test_manager2                                                       *
+*     ./test_manager2                                                          *
+*                                                                              *
+* Press q in the main window to quit.                                          *
+*                                                                              *
+*******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+
+#include <localdefs.h>
+#include <terminal.h>
+
+/* widget ids */
+#define WBUTTON   1
+#define WCHECK    2
+#define WRADIO1   3
+#define WRADIO2   4
+#define WGROUP    5
+#define WEDIT     6
+#define WNUMSEL   7
+#define WPROG     8
+#define WLIST     9
+#define WSCROLLV  10
+#define WSCROLLH  11
+#define WSLIDEH   12
+
+static FILE* win;          /* where the widgets live: the main window */
+static long  evcnt;        /* number of reports made */
+
+/* Report a widget notification in the root window. Reports flow like
+   terminal output: when they reach the bottom of the terminal the root
+   window scrolls, and the widgets, which are free floating windows, stay
+   where they are while the text passes beneath them. */
+static void report(const char* msg)
+
+{
+
+    printf("%4ld: %s\n", ++evcnt, msg);
+
+}
+
+int main(void)
+
+{
+
+    ami_evtrec er;
+    ami_strrec s1, s2, s3, s4;
+    char       buff[250];
+    char       text[250];
+    int        done;
+
+    ami_curvis(stdout, FALSE);
+    /* auto stays on: the root window behaves as a terminal, scrolling at
+       the bottom */
+    printf("\f");
+    printf("Managerc widget test\n");
+    printf("\n");
+    printf("One of each widget is presented at the right. Exercise\n");
+    printf("them and watch the notifications below. Click focuses a\n");
+    printf("widget; space, arrows and editing keys work on the focus.\n");
+    printf("The scroll bars and slider echo their position into the\n");
+    printf("progress bar.\n");
+    printf("\n");
+    printf("Press q in the main window to quit.\n");
+    printf("\n");
+    printf("--- widget notifications ---\n");
+    evcnt = 0;
+
+    /* the widgets live directly in the main window, to the right of the
+       instructions and report area */
+    win = stdout;
+
+    /* left column of the widget area: the click widgets */
+    ami_button(win, 56, 3, 69, 3, "Press me", WBUTTON);
+    ami_checkbox(win, 56, 5, 70, 5, "Check me", WCHECK);
+    ami_radiobutton(win, 56, 7, 70, 7, "Radio one", WRADIO1);
+    ami_radiobutton(win, 56, 8, 70, 8, "Radio two", WRADIO2);
+    ami_progbar(win, 56, 10, 70, 10, WPROG);
+
+    /* a group holding the value widgets */
+    ami_group(win, 73, 2, 98, 9, "Values", WGROUP);
+    ami_editbox(win, 75, 4, 96, 4, WEDIT);
+    ami_putwidgettext(win, WEDIT, "edit me");
+    ami_numselbox(win, 75, 6, 83, 6, 1, 99, WNUMSEL);
+    s1.str = "apple";  s1.next = &s2;
+    s2.str = "banana"; s2.next = &s3;
+    s3.str = "cherry"; s3.next = &s4;
+    s4.str = "damson"; s4.next = NULL;
+    ami_listbox(win, 56, 12, 68, 15, &s1, WLIST);
+
+    /* bars */
+    ami_scrollvert(win, 100, 2, 100, 15, WSCROLLV);
+    ami_scrollsiz(win, WSCROLLV, LONG_MAX/4);
+    ami_scrollhoriz(win, 56, 17, 98, 17, WSCROLLH);
+    ami_scrollsiz(win, WSCROLLH, LONG_MAX/4);
+    ami_slidehoriz(win, 56, 19, 98, 19, 0, WSLIDEH);
+
+    done = FALSE;
+    do {
+
+        ami_event(stdin, &er);
+        switch (er.etype) {
+
+            case ami_etterm: done = TRUE; break;
+
+            case ami_etchar:
+                if (er.echar == 'q' || er.echar == 'Q') done = TRUE;
+                break;
+
+            case ami_etbutton:
+                snprintf(buff, sizeof(buff), "button %ld pressed", er.butid);
+                report(buff);
+                break;
+
+            case ami_etchkbox:
+                /* the program owns the state: toggle it */
+                ami_selectwidget(win, er.ckbxid, evcnt%2 == 0);
+                snprintf(buff, sizeof(buff), "checkbox %ld clicked", er.ckbxid);
+                report(buff);
+                break;
+
+            case ami_etradbut:
+                /* select the clicked one, clear the other */
+                ami_selectwidget(win, WRADIO1, er.radbid == WRADIO1);
+                ami_selectwidget(win, WRADIO2, er.radbid == WRADIO2);
+                snprintf(buff, sizeof(buff), "radio button %ld selected",
+                         er.radbid);
+                report(buff);
+                break;
+
+            case ami_etsclull:
+                snprintf(buff, sizeof(buff), "scroll %ld up/left line",
+                         er.sclulid);
+                report(buff);
+                break;
+
+            case ami_etscldrl:
+                snprintf(buff, sizeof(buff), "scroll %ld down/right line",
+                         er.scldrid);
+                report(buff);
+                break;
+
+            case ami_etsclulp:
+                snprintf(buff, sizeof(buff), "scroll %ld up/left page",
+                         er.sclupid);
+                report(buff);
+                break;
+
+            case ami_etscldrp:
+                snprintf(buff, sizeof(buff), "scroll %ld down/right page",
+                         er.scldpid);
+                report(buff);
+                break;
+
+            case ami_etsclpos:
+                snprintf(buff, sizeof(buff), "scroll %ld position %ld%%",
+                         er.sclpid, er.sclpos/(LONG_MAX/100+1));
+                report(buff);
+                ami_progbarpos(win, WPROG, er.sclpos);
+                break;
+
+            case ami_etedtbox:
+                ami_getwidgettext(win, er.edtbid, text, sizeof(text));
+                snprintf(buff, sizeof(buff), "edit box %ld: \"%s\"",
+                         er.edtbid, text);
+                report(buff);
+                break;
+
+            case ami_etnumbox:
+                snprintf(buff, sizeof(buff), "number box %ld value %ld",
+                         er.numbid, er.numbsl);
+                report(buff);
+                break;
+
+            case ami_etlstbox:
+                snprintf(buff, sizeof(buff), "list box %ld entry %ld",
+                         er.lstbid, er.lstbsl);
+                report(buff);
+                break;
+
+            case ami_etsldpos:
+                snprintf(buff, sizeof(buff), "slider %ld position %ld%%",
+                         er.sldpid, er.sldpos/(LONG_MAX/100+1));
+                report(buff);
+                ami_progbarpos(win, WPROG, er.sldpos);
+                break;
+
+            default: ;
+
+        }
+
+    } while (!done);
+
+    return (0);
+
+}


### PR DESCRIPTION
The character mode window manager hadn't been run since the constructor priorities were reassigned in April. It **faulted at startup**, and behind that fault sat a set of long-standing defects in drawing, buffering and event handling. This repairs those, then builds the widget set, menus and standard dialogs on top — so a terminal program gets the same interface a graphical one has.

## Why it was broken at all

Managerc initialized at constructor priority **104** (set in 2022, when terminal was 103). Terminal moved to **106** in April, inverting the order: managerc captured null override vectors and faulted on the first call. Since `USEMANAGERC=0` is the build default, nothing exercised it and the total breakage went unnoticed.

## Drawing and buffering

- **`plcchr` gated the buffer store on the client area *and* the mask together** — so anything written below the visible rows, or under another window, was discarded from the buffer as well as the screen. Store is bounded by the buffer; display by the client area and mask. Different things.
- **`plcchr`/`iwrtstrn` wrote to the *display* screen, not the *update* screen.** A program preparing one buffer while showing another — what `select()` exists for — left every prepared buffer empty. This is the `managerc.not` note *"buffer switching test fails"*, open since 2022.
- **The scroll display phase** kept a private unclipped paint loop over the whole buffer, diffed against a saved copy on the assumption the screen still matched it. Clipping by other windows made that false long ago, so window contents flashed in then blanked out. Now repaints through the same clipped path everything else uses. Its arbitrary-scroll case cleared the *entire root surface* with a form feed, taking every other window with it.
- **`restoreclp` ignored the occlusion mask**, so restoring a lower window painted over the windows above it.
- **`isizbuf` tore out every screen buffer and reallocated only the first** — any other selected screen left a null pointer and faulted on the next write. It also never took the new size.

## Four ordering faults of one shape

State read before it was settled:

| | symptom |
|---|---|
| masks recalculated *after* the repaints that consult them (move, resize) | moved window's old frame left behind |
| masks not recalculated on Z-order change at all | window brought to front repaints with holes |
| `iframe`/`isizable`/`isysbar` didn't recompute derived client geometry | phantom offsets, one-row windows vanish |
| `remfocus` announced focus loss *before* clearing the flag | every widget drawn as focused simultaneously |

A window's buffer now always covers at least its client area, which removes a class of faults — a window sized larger than its buffer had client cells that could never be restored, and the mask calculation indexed those cells into a buffer-sized mask, **writing outside the allocation**.

## Terminal surface

- The manager **didn't follow a terminal resize** — it kept the startup size, clipped to old bounds, and never recovered the composition. Now tracks the size, grows the root buffer, redoes masks, repaints, and forwards the resize to the client.
- **Terminal's own screen buffers never grew either**, so output past the original bounds was clipped regardless of what the manager believed.
- **Focus and hover events were dropped entirely** — terminal generates both, the manager's switch had no case for them.

## Output rate (helps every terminal program)

- With auto off, the physical cursor tracker was invalidated after **every character**, emitting a full cursor-position sequence per character — roughly a **12× expansion** of all output. The comment said "at the extreme right"; the condition was missing.
- Output was **one `write()` syscall per byte**. Bytes now batch and flush when full, before input/event waits, and at shutdown. Identical byte stream, far fewer pieces.
- Errors in both modules printed to the alternate screen then exited — and the exit sequence switches away from that screen, discarding the message. They now leave it first, so errors are actually readable.

## Widgets, menus, dialogs

Each widget is a frameless subwindow of its owner, so existing machinery gives buffering, occlusion, Z-order and repaint for free; the new code supplies faces and behavior. Widget-window events are intercepted and translated into widget events for the owner.

Implemented: button, checkbox, radio button, group, background, edit box, number select box, progress bar, list box, both scroll bars, both sliders, drop box, drop edit box, and **tab bars in all four orientations** — the side ones with vertical text, as befits a character surface. Sliders and thumbs track the mouse while held. Widgets act on the click that focuses them (a scroll bar needing two clicks isn't etiquette, it's a defect).

**Menus** were four empty stubs. Now: a menu bar widget across the client top, pulldowns as popups, cascading submenus, selections returned as menu events, and `stdmenu` building the documented standard lists.

**The standard dialogs** — `alert` and the query dialogs — are presented **inside the terminal** as managed windows built from these widgets, each running its own modal loop, rather than as host dialogs. A dialog terminated from outside passes the terminate on rather than swallowing it.

Positions use a rounding full-scale multiply so a full-scale value lands on the last cell; the previous fixed-point form quantized to 1024 steps and floored, leaving every slider, thumb and progress bar one cell short of its end.

## Build

The plain and managed configurations were **the same library file** selected by a build flag, so building one silently replaced the other (this bit us twice during development). The manager-carrying library is now `lib/petit_ami_termc.so`, built alongside the plain one. **`terminal_testc`** is `terminal_test` stacked on managerc-over-terminal for direct comparison; the manager tests link the same library and need no flag.

`test_manager.c` exercises subwindows; `test_manager2.c` presents one of each widget with its notifications reported.

## Verification

Full build clean, `bin/regress` 3/3, and the terminal test's buffer switching, buffer follow, writethrough and focus/hover tests behave the same under the manager as without it — verified by driving both libraries with identical synthetic input and comparing.

**Interactive testing was done by the repo owner throughout**; several of these defects were found that way and fixed in response. What I verified headlessly is rendering, event delivery and the absence of crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to