### PR TITLE
widget_testc, widget feedback, and the dialog overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,7 @@ all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig pla
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
      connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      management_testc \
+     widget_testc \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -611,6 +612,7 @@ all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig pla
      connectmidig connectwave \
      connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      management_testc \
+     widget_testc \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -628,6 +630,7 @@ all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig pla
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
      connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      management_testc \
+     widget_testc \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -645,6 +648,7 @@ all: dumpmidi dif css2theme play playg keyboard keyboardg playmidi playmidig pla
      playwaveg printdev printdevg connectmidi connectmidig connectwave \
      connectwaveg random randomg genwave genwaveg terminal_test terminal_testc terminal_testg \
      management_testc \
+     widget_testc \
      graphics_test testviewer management_test widget_test \
      sound_test sound_testg network_test services_test stdio_test event eventg term termg snake snakeg mine mineg \
      wator watorg pong pongg breakout backgammon checkers chess defenders editor editorg getpage getpageg getmail \
@@ -1312,6 +1316,16 @@ endif
 #
 widget_test: $(GLIBSD) tests/widget_test.c
 	$(CC) $(CFLAGS) tests/widget_test.c $(GLIBS) -o bin/widget_test 
+
+#
+# Test widget compliant output, character mode
+#
+# The widget test applied to the character mode window manager over the
+# terminal. Every widget test has a character form and a graphical form;
+# only the character forms can run on a character surface.
+#
+widget_testc: lib/petit_ami_termc.so tests/widget_testc.c
+	$(CC) $(CFLAGS) tests/widget_testc.c $(CLIBSC) -o bin/widget_testc
 	
 #
 # Test sound model compliant input/output (uses console timers)

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -10209,6 +10209,22 @@ static void qrycollay(FILE* wf, winptr dwin, void* ctx)
     for (i = 1; i <= n; i++) fputc('-', wf);
     ami_cursor(wf, (n-7)/2+1, 1);
     fprintf(wf, " Color ");
+    /* the swatch border: the swatch starts white, the dialog's own
+       background, and without this there is no telling it is there */
+    ami_cursor(wf, 35, 2);
+    fputc('+', wf);
+    for (i = 36; i <= 54; i++) fputc('-', wf);
+    fputc('+', wf);
+    for (i = 3; i <= 10; i++) {
+
+        ami_cursor(wf, 35, i); fputc('|', wf);
+        ami_cursor(wf, 55, i); fputc('|', wf);
+
+    }
+    ami_cursor(wf, 35, 11);
+    fputc('+', wf);
+    for (i = 36; i <= 54; i++) fputc('-', wf);
+    fputc('+', wf);
     ami_cursor(wf, 3, 12); fprintf(wf, "Red");
     ami_cursor(wf, 3, 14); fprintf(wf, "Green");
     ami_cursor(wf, 3, 16); fprintf(wf, "Blue");

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -430,6 +430,9 @@ typedef struct wigrec {
     char** list;    /* list box strings */
     long   listn;   /* number of list strings */
     long   top;     /* list box scroll offset, 0 based */
+    ami_color* lcol; /* per entry face colors, or NULL: entries showing
+                        their own color (internal, the dialogs' use) */
+    long   fatt;    /* extra face attributes (internal, the dialogs' use) */
     int    enb;     /* enabled */
     int    sel;     /* selected state */
     long   val;     /* value: numsel, progress, scroll and slider position */
@@ -3814,6 +3817,7 @@ static void closewin(int ofn)
         if (hovwig == wg) hovwig = NULL; /* the highlight dies with it */
         if (xltwin[wg->win->wid+MAXFIL] >= 0) fclose(wg->wf);
         if (wg->face) free(wg->face);
+        if (wg->lcol) free(wg->lcol);
         if (wg->list) {
 
             long i;
@@ -7652,11 +7656,14 @@ static void wigtxt(wigptr wg, long x, long y, const char* s, int rev)
 
     winptr win = wg->win;
     long   n = win->cmaxx-x+1; /* room to the edge: never run past it */
+    long   sat = win->attr; /* restored whole: a face can carry its own
+                               attributes, and clearing just the reverse
+                               bit was dropping them */
 
     icursor(wg->wf, x, y); /* place cursor */
     if (rev) win->attr |= BIT(sarev);
     while (*s && n-- > 0) plcchr(wg->wf, *s++);
-    win->attr &= ~BIT(sarev);
+    win->attr = sat;
 
 }
 
@@ -7727,6 +7734,7 @@ static void clspops(int downto)
         }
         fclose(wg->wf); /* close the popup window */
         if (wg->face) free(wg->face);
+        if (wg->lcol) free(wg->lcol);
         if (wg->list) {
 
             long i;
@@ -7743,7 +7751,7 @@ static void clspops(int downto)
 /* Open a popup list at a root position. The strings are copied. Returns the
    popup widget, which is pushed on the popup stack. */
 static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
-                     wigptr owner, ami_menuptr mitems)
+                     wigptr owner, ami_menuptr mitems, ami_color* lcol)
 
 {
 
@@ -7786,6 +7794,15 @@ static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
     wg->sclsiz = 0;
     wg->marks = 0;
     wg->top = 0;
+    wg->lcol = NULL;
+    if (lcol && n) { /* the entries keep their own colors */
+
+        wg->lcol = malloc(sizeof(ami_color)*n);
+        if (!wg->lcol) error("Out of memory");
+        memcpy(wg->lcol, lcol, sizeof(ami_color)*n);
+
+    }
+    wg->fatt = 0;
     wg->curs = 0;
     wg->tor = ami_totop;
     wg->owner = owner;
@@ -7940,8 +7957,9 @@ static void wigdrw(wigptr wg)
     long   hp = wg == hovwig? hovwprt: 0;
 
     /* a disabled widget shows its whole face grey, as a disabled menu
-       item does */
+       item does; a face carrying its own attributes shows them */
     if (!wg->enb) win->attr |= BIT(sagrey);
+    win->attr |= wg->fatt;
     switch (wg->typ) {
 
         case wtbutton:
@@ -8121,10 +8139,25 @@ static void wigdrw(wigptr wg)
             break;
 
         case wtdropbox:
-            /* closed face: the selection and a drop arrow */
+            /* closed face: the selection and a drop arrow; an entry
+               carrying its own color shows in it, light ones grounded
+               on black so they read on the light face */
             wigclr(wg);
-            if (wg->sel >= 1 && wg->sel <= wg->listn)
+            if (wg->sel >= 1 && wg->sel <= wg->listn) {
+
+                ami_color sf = win->fcolor, sb = win->bcolor;
+
+                if (wg->lcol) {
+
+                    win->fcolor = wg->lcol[wg->sel-1];
+                    if (win->fcolor == ami_white) win->bcolor = ami_black;
+
+                }
                 wigtxt(wg, 1, 1, wg->list[wg->sel-1], win->focus || hp);
+                win->fcolor = sf;
+                win->bcolor = sb;
+
+            }
             wigtxt(wg, w, 1, "v", hp != 0);
             break;
 
@@ -8203,14 +8236,25 @@ static void wigdrw(wigptr wg)
 
                 }
                 if (!enb) wg->win->attr |= BIT(sagrey);
-                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
+                if (wg->lcol) { /* the entry in its own color */
+
+                    ami_color sf = win->fcolor, sb = win->bcolor;
+
+                    win->fcolor = wg->lcol[y-1];
+                    if (win->fcolor == ami_white) win->bcolor = ami_black;
+                    wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
+                    win->fcolor = sf;
+                    win->bcolor = sb;
+
+                } else
+                    wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
                 wg->win->attr &= ~BIT(sagrey);
 
             }
             break;
 
     }
-    win->attr &= ~BIT(sagrey);
+    win->attr &= ~(BIT(sagrey)|wg->fatt);
     /* The drawing walked the physical cursor over the widget face; it
        belongs to the focus window. Without this the cursor was left
        sitting at the end of whatever widget drew last -- the menu bar
@@ -8569,7 +8613,7 @@ static void wigevt(wigptr wg, ami_evtrec* er)
 
                         clspops(0);
                         opnpop(wg->parent, absx(win), absy(win)+1,
-                               wg->list, wg->listn, wg, NULL);
+                               wg->list, wg->listn, wg, NULL, wg->lcol);
 
                     }
                     break;
@@ -8582,7 +8626,7 @@ static void wigevt(wigptr wg, ami_evtrec* er)
 
                             clspops(0);
                             opnpop(wg->parent, absx(win), absy(win)+1,
-                                   wg->list, wg->listn, wg, NULL);
+                                   wg->list, wg->listn, wg, NULL, wg->lcol);
 
                         }
 
@@ -8646,7 +8690,7 @@ static void wigevt(wigptr wg, ami_evtrec* er)
 
                             wg->sel = sx; /* show the open title */
                             opnpop(wg->parent, absx(win)+sx-1, absy(win)+1,
-                                   strs, n, wg, mp->branch);
+                                   strs, n, wg, mp->branch, NULL);
                             for (i = 0; i < n; i++) free(strs[i]);
                             free(strs);
 
@@ -8691,7 +8735,7 @@ static void wigevt(wigptr wg, ami_evtrec* er)
                             wigdrw(wg);
                             opnpop(wg->parent,
                                    absx(win)+win->pmaxx-1, absy(win)+row-1,
-                                   strs, n, wg->owner, item->branch);
+                                   strs, n, wg->owner, item->branch, NULL);
                             for (i = 0; i < n; i++) free(strs[i]);
                             free(strs);
 
@@ -8937,6 +8981,8 @@ static wigptr wigcre(FILE* f, long x1, long y1, long x2, long y2, long id,
     wg->sclsiz = LONG_MAX/8; /* nominal thumb */
     wg->marks = 0;
     wg->top = 0;
+    wg->lcol = NULL;
+    wg->fatt = 0;
     wg->curs = 0;
     wg->win->widget = TRUE; /* mark as widget window */
     wg->win->wig = wg;
@@ -9011,6 +9057,7 @@ void ami_killwidget(FILE* f, long id)
     *lp = wg->next;
     fclose(wg->wf); /* close the face window, which erases it */
     if (wg->face) free(wg->face);
+    if (wg->lcol) free(wg->lcol);
     if (wg->list) {
 
         long i;
@@ -9957,20 +10004,24 @@ static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid,
     do {
 
         ievent(stdin, &er);
+        /* Everything here minds its window id: dialogs nest (the font
+           query opens the color query), and both loops read the same
+           queue, so an event for the one must not act on the other. */
         if (er.etype == ami_etterm) { realterm = TRUE; done = TRUE; }
         else if (er.etype == ami_etresize && er.winid == dwin->wid && lay)
             /* the dialog was resized: flow the layout to the new client */
             lay(wf, dwin, ctx);
-        else if (er.etype == ami_etbutton) {
+        else if (er.etype == ami_etbutton && er.winid == dwin->wid) {
 
             if (er.butid == okid || er.butid == cancelid) {
 
                 res = er.butid;
                 done = TRUE;
 
-            }
+            } else if (evt) evt(wf, dwin, &er, ctx); /* its own extras */
 
-        } else if (er.etype == ami_etedtbox || er.etype == ami_etdrebox) {
+        } else if ((er.etype == ami_etedtbox || er.etype == ami_etdrebox) &&
+                   er.winid == dwin->wid) {
 
             /* enter in a text field completes as the ok button does */
             res = okid;
@@ -10280,6 +10331,7 @@ static void qrycolevt(FILE* wf, winptr dwin, ami_evtrec* er, void* ctx)
     qcolst* st = (qcolst*)ctx;
     double  h, s, l;
 
+    if (er->winid != dwin->wid) return; /* dialogs nest: not ours */
     if (er->etype == ami_etlstbox && er->lstbid == 1) {
 
         if (er->lstbsl >= 1 && er->lstbsl <= 8) {
@@ -10400,6 +10452,7 @@ static void lstput(winptr dwin, long id, char** strs, long n)
         free(wg->list);
 
     }
+    if (wg->lcol) { free(wg->lcol); wg->lcol = NULL; }
     wg->list = malloc(sizeof(char*)*(n? n: 1));
     if (!wg->list) error("Out of memory");
     for (i = 0; i < n; i++) {
@@ -10601,6 +10654,7 @@ static void qryfileevt(FILE* wf, winptr dwin, ami_evtrec* er, void* ctx)
     wigptr  wg;
     long    bid = 0, pos = 0;
 
+    if (er->winid != dwin->wid) return; /* dialogs nest: not ours */
     switch (er->etype) {
 
         case ami_etlstbox:
@@ -10846,11 +10900,91 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
 
 }
 
-/* flow the font query: the labels and boxes hold their rows, the buttons
-   keep the bottom row */
+/* The font query holds the terminal's one font at its one size; what it
+   chooses are the colors and the effects. The color names show in their
+   colors, the effect names show in their effects, and the rgb buttons
+   open the full color query for a 24 bit pick, shown in the swatch by
+   each color's row. */
+typedef struct { long fr, fg, fb, br, bg, bb; } qfntst;
+
+/* the drop entries take the preset colors, so each name shows in it */
+static void qfntcol(winptr dwin, long id)
+
+{
+
+    static const ami_color pc[8] = {
+
+        ami_black, ami_white, ami_red, ami_green, ami_blue, ami_cyan,
+        ami_yellow, ami_magenta
+
+    };
+    wigptr wg = fndwig(dwin, id);
+    long   i;
+
+    if (!wg) return;
+    if (wg->lcol) free(wg->lcol);
+    wg->lcol = malloc(sizeof(ami_color)*8);
+    if (!wg->lcol) error("Out of memory");
+    for (i = 0; i < 8; i++) wg->lcol[i] = pc[i];
+    wigdrw(wg);
+
+}
+
+/* the effect faces show their own effects */
+static void qfnteff(winptr dwin, long id, long att)
+
+{
+
+    wigptr wg = fndwig(dwin, id);
+
+    if (!wg) return;
+    wg->fatt = att;
+    wigdrw(wg);
+
+}
+
+/* keep a color drop box marking the held color: selected while it is a
+   preset, unmarked while it is a 24 bit pick */
+static void qfntsel(winptr dwin, long id, long r, long g, long b)
+
+{
+
+    wigptr wg = fndwig(dwin, id);
+    long   i, sel = 0;
+
+    for (i = 0; i < 8; i++)
+        if (r == qcolpre[i][0] && g == qcolpre[i][1] && b == qcolpre[i][2])
+            sel = i+1;
+    if (wg && wg->sel != sel) {
+
+        wg->sel = sel;
+        wigdrw(wg);
+
+    }
+
+}
+
+/* the swatches by each color row show the held colors exactly */
+static void qfntshow(FILE* wf, winptr dwin, qfntst* st)
+
+{
+
+    ami_bcolorc(wf, col8full(st->fr), col8full(st->fg), col8full(st->fb));
+    ami_cursor(wf, 38, 2);
+    fprintf(wf, "   ");
+    ami_bcolorc(wf, col8full(st->br), col8full(st->bg), col8full(st->bb));
+    ami_cursor(wf, 38, 4);
+    fprintf(wf, "   ");
+    ami_bcolor(wf, ami_white);
+
+}
+
+/* flow the font query face */
 static void qryfntlay(FILE* wf, winptr dwin, void* ctx)
 
 {
+
+    qfntst* st = (qfntst*)ctx;
 
     fprintf(wf, "\f");
     ami_cursor(wf, 2, 2);
@@ -10861,6 +10995,70 @@ static void qryfntlay(FILE* wf, winptr dwin, void* ctx)
     fprintf(wf, "Effects:");
     ami_poswidget(wf, 2, 3, dwin->cmaxy);
     ami_poswidget(wf, 3, 12, dwin->cmaxy);
+    qfntshow(wf, dwin, st);
+
+}
+
+/* the dialog's live logic: the drop boxes pick presets, the rgb buttons
+   open the full color query over this one */
+static void qryfntevt(FILE* wf, winptr dwin, ami_evtrec* er, void* ctx)
+
+{
+
+    qfntst* st = (qfntst*)ctx;
+    long    r, g, b;
+
+    if (er->winid != dwin->wid) return; /* dialogs nest: not ours */
+    if (er->etype == ami_etdrpbox) {
+
+        if (er->drpbsl >= 1 && er->drpbsl <= 8) {
+
+            if (er->drpbid == 1) {
+
+                st->fr = qcolpre[er->drpbsl-1][0];
+                st->fg = qcolpre[er->drpbsl-1][1];
+                st->fb = qcolpre[er->drpbsl-1][2];
+
+            } else if (er->drpbid == 8) {
+
+                st->br = qcolpre[er->drpbsl-1][0];
+                st->bg = qcolpre[er->drpbsl-1][1];
+                st->bb = qcolpre[er->drpbsl-1][2];
+
+            }
+            qfntshow(wf, dwin, st);
+
+        }
+
+    } else if (er->etype == ami_etbutton) {
+
+        if (er->butid == 11) { /* a 24 bit foreground */
+
+            r = col8full(st->fr);
+            g = col8full(st->fg);
+            b = col8full(st->fb);
+            ami_querycolor(&r, &g, &b);
+            st->fr = colc8(r);
+            st->fg = colc8(g);
+            st->fb = colc8(b);
+            qfntsel(dwin, 1, st->fr, st->fg, st->fb);
+            qfntshow(wf, dwin, st);
+
+        } else if (er->butid == 12) { /* a 24 bit background */
+
+            r = col8full(st->br);
+            g = col8full(st->bg);
+            b = col8full(st->bb);
+            ami_querycolor(&r, &g, &b);
+            st->br = colc8(r);
+            st->bg = colc8(g);
+            st->bb = colc8(b);
+            qfntsel(dwin, 8, st->br, st->bg, st->bb);
+            qfntshow(wf, dwin, st);
+
+        }
+
+    }
 
 }
 
@@ -10878,15 +11076,9 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
        the effects the terminal can actually present. */
     static char* const cnam[] = { "black", "white", "red", "green", "blue",
                                   "cyan", "yellow", "magenta" };
-    static const long cval[8][3] = {
-
-        { 0, 0, 0 }, { INT_MAX, INT_MAX, INT_MAX }, { INT_MAX, 0, 0 },
-        { 0, INT_MAX, 0 }, { 0, 0, INT_MAX }, { 0, INT_MAX, INT_MAX },
-        { INT_MAX, INT_MAX, 0 }, { INT_MAX, 0, INT_MAX },
-
-    };
     ami_strrec fr_[8], br_[8];
     long i;
+    qfntst st;
 
     for (i = 0; i < 8; i++) {
 
@@ -10894,14 +11086,29 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
         br_[i].str = cnam[i]; br_[i].next = i < 7? &br_[i+1]: NULL;
 
     }
+    /* the colors passed in are where the dialog starts */
+    st.fr = colc8(*fr); st.fg = colc8(*fg); st.fb = colc8(*fb);
+    st.br = colc8(*br); st.bg = colc8(*bg); st.bb = colc8(*bb);
     wf = dlgcre("Font", 46, 16, &dwin);
     ami_dropbox(wf, 14, 2, 26, 2, &fr_[0], 1);
     ami_dropbox(wf, 14, 4, 26, 4, &br_[0], 8);
+    qfntcol(dwin, 1);
+    qfntcol(dwin, 8);
+    qfntsel(dwin, 1, st.fr, st.fg, st.fb);
+    qfntsel(dwin, 8, st.br, st.bg, st.bb);
+    ami_buttonsiz(wf, "rgb", &bw, &bh);
+    ami_button(wf, 29, 2, 29+bw-1, 2, "rgb", 11);
+    ami_button(wf, 29, 4, 29+bw-1, 4, "rgb", 12);
     ami_checkbox(wf, 2, 7, 20, 7, "Bold", 4);
     ami_checkbox(wf, 2, 8, 20, 8, "Underline", 5);
     ami_checkbox(wf, 2, 9, 20, 9, "Italic", 6);
     ami_checkbox(wf, 2, 10, 20, 10, "Reverse", 9);
     ami_checkbox(wf, 2, 11, 20, 11, "Blink", 10);
+    qfnteff(dwin, 4, BIT(sabold));
+    qfnteff(dwin, 5, BIT(saundl));
+    qfnteff(dwin, 6, BIT(saital));
+    qfnteff(dwin, 9, BIT(sarev));
+    qfnteff(dwin, 10, BIT(sablink));
     ami_selectwidget(wf, 4, !!(*effect & (1L<<ami_qftebold)));
     ami_selectwidget(wf, 5, !!(*effect & (1L<<ami_qfteunderline)));
     ami_selectwidget(wf, 6, !!(*effect & (1L<<ami_qfteitalic)));
@@ -10910,26 +11117,12 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 14, 3+bw-1, 14, "Ok", 2);
     ami_button(wf, 12, 14, 12+bw+4, 14, "Cancel", 3);
-    qryfntlay(wf, dwin, NULL);
-    res = dlgloop(wf, dwin, 2, 3, qryfntlay, NULL, NULL);
+    qryfntlay(wf, dwin, &st);
+    res = dlgloop(wf, dwin, 2, 3, qryfntlay, qryfntevt, &st);
     if (res == 2) {
 
-        wg = fndwig(dwin, 1);
-        if (wg && wg->sel >= 1 && wg->sel <= 8) {
-
-            *fr = cval[wg->sel-1][0];
-            *fg = cval[wg->sel-1][1];
-            *fb = cval[wg->sel-1][2];
-
-        }
-        wg = fndwig(dwin, 8);
-        if (wg && wg->sel >= 1 && wg->sel <= 8) {
-
-            *br = cval[wg->sel-1][0];
-            *bg = cval[wg->sel-1][1];
-            *bb = cval[wg->sel-1][2];
-
-        }
+        *fr = col8full(st.fr); *fg = col8full(st.fg); *fb = col8full(st.fb);
+        *br = col8full(st.br); *bg = col8full(st.bg); *bb = col8full(st.bb);
         *effect = 0;
         wg = fndwig(dwin, 4); if (wg && wg->sel) *effect |= 1L<<ami_qftebold;
         wg = fndwig(dwin, 5);

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -381,6 +381,7 @@ typedef struct winrec {
     int      frame;             /* frame on/off */
     int      size;              /* size bars on/off */
     int      sysbar;            /* system bar on/off */
+    int      fixed;             /* size bars draw but sizing is ignored */
     char     inpbuf[MAXLIN];    /* input line buffer */
     int      inpptr;            /* input line index */
     int      visible;           /* window is visible */
@@ -3516,6 +3517,7 @@ static void opnwin(int fn, int pfn, long wid, int subclient, int root)
     win->fcolor = ami_black; /*foreground black */
     win->bcolor = ami_white; /* background white */
     win->frmcolor = ami_blue; /* frame color blue */
+    win->fixed = FALSE; /* sizing works where the bars show */
     win->curv = TRUE; /* cursor visible */
     win->orgx = 1;  /* set origin to root */
     win->orgy = 1;
@@ -5072,19 +5074,24 @@ static void frmclick(winptr win)
 
         } else if (mousex-absx(win) == win->pmaxx-5) {
 
-            /* maximize, or restore a maximized window */
-            if (win->maxed) {
+            /* maximize, or restore a maximized window; a fixed window
+               ignores it, as it ignores all sizing */
+            if (!win->fixed) {
 
-                intnorm(win);
-                er.etype = ami_etnorm;
+                if (win->maxed) {
 
-            } else {
+                    intnorm(win);
+                    er.etype = ami_etnorm;
 
-                intmax(win);
-                er.etype = ami_etmax;
+                } else {
+
+                    intmax(win);
+                    er.etype = ami_etmax;
+
+                }
+                intsendevent(win, &er); /* issue event */
 
             }
-            intsendevent(win, &er); /* issue event */
 
         } else if (mousex-absx(win) == win->pmaxx-7) {
 
@@ -5113,7 +5120,7 @@ static void frmclick(winptr win)
 
         }
 
-    } else if (win->frame && win->size) {
+    } else if (win->frame && win->size && !win->fixed) {
 
         /* frame and sizebars are enabled */
         if (mousey-absy(win) == 0 &&
@@ -5536,8 +5543,15 @@ static void intevent(FILE* f)
                                         mousey-absy(hw)+1);
                     if (!wp) ww = NULL;
 
-                } else if (hw && !hw->root && hw->frame)
+                } else if (hw && !hw->root && hw->frame) {
+
                     hp = frmhit(hw, mousex, mousey);
+                    /* a fixed window ignores sizing: its size bars and
+                       maximize button are not live, so no highlight */
+                    if (hw->fixed && (hp >= fp_top || hp == fp_max))
+                        hp = fp_none;
+
+                }
                 if (hp == fp_none) hw = NULL;
                 if (hw != hovfwin || hp != hovfpart) {
 
@@ -9907,7 +9921,8 @@ static FILE* dlgcre(char* title, long w, long h, winptr* dwin)
     iopenwin(&stdin, &wf, NULL, igetwinid()); /* parentless: floats */
     win = txt2win(wf);
     win->frame = TRUE;
-    win->size = TRUE; /* a complete frame, and the size bars work */
+    win->size = TRUE; /* a complete frame... */
+    win->fixed = TRUE; /* ...but a dialog does not resize */
     win->sysbar = TRUE;
     win->curv = FALSE; /* a dialog never shows the cursor */
     recompcli(win);

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -1356,6 +1356,41 @@ static void setcurvis(int e)
 
 }
 
+/* Full color cells: a cell color is either a primary code or an encoded
+   24 bit rgb color, marked by the flag bit. Exact primaries stay primary
+   codes, so the common paths and the run batching see the same values
+   the primary calls set; everything else the full color calls set is
+   carried exactly and emitted through the full color vector. */
+#define RGBFLG (1L<<30)
+#define RGBENC(r, g, b) (RGBFLG|(r) << 16|(g) << 8|(b))
+#define ISRGB(c) (((c)&RGBFLG) != 0)
+#define RGBR(c) ((c) >> 16&0xff)
+#define RGBG(c) ((c) >> 8&0xff)
+#define RGBB(c) ((c)&0xff)
+
+/* full scale color component to 8 bits, and back */
+static long colc8(long v)
+
+{
+
+    if (v <= 0) return (0);
+    if (v >= LONG_MAX-LONG_MAX/255) return (255);
+
+    return (v/(LONG_MAX/255));
+
+}
+
+static long col8full(long v)
+
+{
+
+    if (v <= 0) return (0);
+    if (v >= 255) return (LONG_MAX);
+
+    return (v*(LONG_MAX/255));
+
+}
+
 /*******************************************************************************
 
 Set foreground color cached
@@ -1370,7 +1405,10 @@ static int setfcolor(ami_color c)
 
     if (c != fcolor) {
 
-        (*fcolor_vect)(stdout, c); /* set new color */
+        if (ISRGB(c)) /* an encoded color emits through the full color call */
+            (*fcolorc_vect)(stdout, col8full(RGBR(c)), col8full(RGBG(c)),
+                                    col8full(RGBB(c)));
+        else (*fcolor_vect)(stdout, c); /* set new color */
         fcolor = c; /* cache that */
 
     }
@@ -1391,7 +1429,10 @@ static int setbcolor(ami_color c)
 
     if (c != bcolor) {
 
-        (*bcolor_vect)(stdout, c); /* set new color */
+        if (ISRGB(c)) /* an encoded color emits through the full color call */
+            (*bcolorc_vect)(stdout, col8full(RGBR(c)), col8full(RGBG(c)),
+                                    col8full(RGBB(c)));
+        else (*bcolor_vect)(stdout, c); /* set new color */
         bcolor = c; /* cache that */
 
     }
@@ -1411,11 +1452,20 @@ color the cache cannot represent.
 
 *******************************************************************************/
 
-/* primary color code to full color components */
+/* primary or encoded color code to full color components */
 static void colnumrgb(ami_color c, long* r, long* g, long* b)
 
 {
 
+    if (ISRGB(c)) {
+
+        *r = col8full(RGBR(c));
+        *g = col8full(RGBG(c));
+        *b = col8full(RGBB(c));
+
+        return;
+
+    }
     *r = (c == ami_red || c == ami_yellow || c == ami_magenta ||
           c == ami_white)? LONG_MAX: 0;
     *g = (c == ami_green || c == ami_yellow || c == ami_cyan ||
@@ -4776,10 +4826,14 @@ static void ifcolorc(FILE* f, long r, long g, long b)
 
 {
 
-    winptr win; /* windows record pointer */
+    winptr win = txt2win(f); /* get window from file */
+    long r8 = colc8(r), g8 = colc8(g), b8 = colc8(b);
 
-    win = txt2win(f); /* get window from file */
-    win->fcolor = colrgbnum(r, g, b); /* set color */
+    /* an exact primary stays a primary code; the rest carry exactly */
+    if ((r8 == 0 || r8 == 255) && (g8 == 0 || g8 == 255) &&
+        (b8 == 0 || b8 == 255))
+        win->fcolor = colrgbnum(r, g, b);
+    else win->fcolor = RGBENC(r8, g8, b8);
 
 }
 
@@ -4814,10 +4868,14 @@ static void ibcolorc(FILE* f, long r, long g, long b)
 
 {
 
-    winptr win; /* windows record pointer */
+    winptr win = txt2win(f); /* get window from file */
+    long r8 = colc8(r), g8 = colc8(g), b8 = colc8(b);
 
-    win = txt2win(f); /* get window from file */
-    win->bcolor = colrgbnum(r, g, b); /* set color */
+    /* an exact primary stays a primary code; the rest carry exactly */
+    if ((r8 == 0 || r8 == 255) && (g8 == 0 || g8 == 255) &&
+        (b8 == 0 || b8 == 255))
+        win->bcolor = colrgbnum(r, g, b);
+    else win->bcolor = RGBENC(r8, g8, b8);
 
 }
 
@@ -9861,7 +9919,10 @@ so a quit request is not swallowed by the dialog.
 /* Run a dialog window until its done flag is set. Returns the id of the
    widget that ended it, or 0 for an outside terminate. */
 static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid,
-                    void (*lay)(FILE* wf, winptr dwin, void* ctx), void* ctx)
+                    void (*lay)(FILE* wf, winptr dwin, void* ctx),
+                    void (*evt)(FILE* wf, winptr dwin, ami_evtrec* er,
+                                void* ctx),
+                    void* ctx)
 
 {
 
@@ -9893,7 +9954,7 @@ static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid,
             res = okid;
             done = TRUE;
 
-        }
+        } else if (evt) evt(wf, dwin, &er, ctx); /* to the dialog's logic */
 
     } while (!done);
     if (realterm) { /* pass the terminate on to the program */
@@ -9978,31 +10039,236 @@ void ami_alert(char* title, char* message)
     ami_button(wf, (dwin->cmaxx-bw)/2+1, dwin->cmaxy-1,
                    (dwin->cmaxx-bw)/2+bw, dwin->cmaxy-1, "Ok", 1);
     alertlay(wf, dwin, message);
-    dlgloop(wf, dwin, 1, 0, alertlay, message);
+    dlgloop(wf, dwin, 1, 0, alertlay, NULL, message);
     fclose(wf);
 
 }
 
-/* flow the color query: the list fills the middle, the buttons keep the
-   bottom row */
+/* The color query holds a full 24 bit color, 8 bits per component. The
+   preset list picks the primaries, the R, G and B sliders enter any
+   color directly, the luminosity slider runs the color from black to
+   white holding its hue, and the swatch shows the result exactly. */
+typedef struct { long r, g, b; } qcolst;
+
+/* the presets, matching the primary color codes */
+static char* const qcolnam[] = { "black", "white", "red", "green", "blue",
+                                 "cyan", "yellow", "magenta" };
+static const long qcolpre[8][3] = {
+
+    { 0, 0, 0 }, { 255, 255, 255 }, { 255, 0, 0 }, { 0, 255, 0 },
+    { 0, 0, 255 }, { 0, 255, 255 }, { 255, 255, 0 }, { 255, 0, 255 },
+
+};
+
+/* rgb (0..255) to hsl (h 0..6, s and l 0..1) and back, for the
+   luminosity slider: lightness moves, the hue holds */
+static void rgbhsl(long r, long g, long b, double* h, double* s, double* l)
+
+{
+
+    double rr = r/255.0, gg = g/255.0, bb = b/255.0;
+    double mx = rr, mn = rr, d;
+
+    if (gg > mx) mx = gg;
+    if (bb > mx) mx = bb;
+    if (gg < mn) mn = gg;
+    if (bb < mn) mn = bb;
+    d = mx-mn;
+    *l = (mx+mn)/2;
+    *s = 0;
+    *h = 0;
+    if (d > 0) {
+
+        *s = *l > 0.5? d/(2-mx-mn): d/(mx+mn);
+        if (mx == rr) *h = (gg-bb)/d+(gg < bb? 6: 0);
+        else if (mx == gg) *h = (bb-rr)/d+2;
+        else *h = (rr-gg)/d+4;
+
+    }
+
+}
+
+static double qcolhue(double p, double q, double t)
+
+{
+
+    if (t < 0) t += 6;
+    if (t >= 6) t -= 6;
+    if (t < 1) return (p+(q-p)*t);
+    if (t < 3) return (q);
+    if (t < 4) return (p+(q-p)*(4-t));
+
+    return (p);
+
+}
+
+static void hslrgb(double h, double s, double l, long* r, long* g, long* b)
+
+{
+
+    if (s <= 0) *r = *g = *b = (long)(l*255+0.5);
+    else {
+
+        double q = l < 0.5? l*(1+s): l+s-l*s;
+        double p = 2*l-q;
+
+        *r = (long)(qcolhue(p, q, h+2)*255+0.5);
+        *g = (long)(qcolhue(p, q, h)*255+0.5);
+        *b = (long)(qcolhue(p, q, h-2)*255+0.5);
+
+    }
+
+}
+
+/* the luminosity of the held color, 0..255 */
+static long qcollum(qcolst* st)
+
+{
+
+    long mx = st->r, mn = st->r;
+
+    if (st->g > mx) mx = st->g;
+    if (st->b > mx) mx = st->b;
+    if (st->g < mn) mn = st->g;
+    if (st->b < mn) mn = st->b;
+
+    return ((mx+mn)/2);
+
+}
+
+/* place a slider on an 8 bit value */
+static void qcolsld(winptr dwin, long id, long v8)
+
+{
+
+    wigptr wg = fndwig(dwin, id);
+
+    if (wg) {
+
+        wg->val = wigscl(v8, 255);
+        wigdrw(wg);
+
+    }
+
+}
+
+/* keep the preset list marking the held color: selected while the color
+   is one of its entries, unmarked while it is not */
+static void qcolsel(winptr dwin, qcolst* st)
+
+{
+
+    wigptr wg = fndwig(dwin, 1);
+    long   i, sel = 0;
+
+    for (i = 0; i < 8; i++)
+        if (st->r == qcolpre[i][0] && st->g == qcolpre[i][1] &&
+            st->b == qcolpre[i][2]) sel = i+1;
+    if (wg && wg->sel != sel) {
+
+        wg->sel = sel;
+        wigdrw(wg);
+
+    }
+
+}
+
+/* show the held color: the swatch paints it exactly, and the component
+   readouts follow the sliders */
+static void qcolshow(FILE* wf, winptr dwin, qcolst* st)
+
+{
+
+    long x, y;
+
+    ami_bcolorc(wf, col8full(st->r), col8full(st->g), col8full(st->b));
+    for (y = 3; y <= 10; y++) {
+
+        ami_cursor(wf, 36, y);
+        for (x = 36; x <= 54; x++) fputc(' ', wf);
+
+    }
+    ami_bcolor(wf, ami_white);
+    ami_cursor(wf, 47, 12); fprintf(wf, "%3ld", st->r);
+    ami_cursor(wf, 47, 14); fprintf(wf, "%3ld", st->g);
+    ami_cursor(wf, 47, 16); fprintf(wf, "%3ld", st->b);
+
+}
+
+/* flow the color query face */
 static void qrycollay(FILE* wf, winptr dwin, void* ctx)
 
 {
 
-    long lw, lh;
+    qcolst* st = (qcolst*)ctx;
+    long    i, n = dwin->cmaxx;
 
     fprintf(wf, "\f");
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "Color:");
-    lw = dwin->cmaxx-7;
-    if (lw > 19) lw = 19;
-    if (lw < 1) lw = 1;
-    lh = dwin->cmaxy-4;
-    if (lh < 1) lh = 1;
-    ami_sizwidget(wf, 1, lw, lh);
-    ami_poswidget(wf, 1, 2, 3);
+    /* the section header, marked off and centered */
+    ami_cursor(wf, 1, 1);
+    for (i = 1; i <= n; i++) fputc('-', wf);
+    ami_cursor(wf, (n-7)/2+1, 1);
+    fprintf(wf, " Color ");
+    ami_cursor(wf, 3, 12); fprintf(wf, "Red");
+    ami_cursor(wf, 3, 14); fprintf(wf, "Green");
+    ami_cursor(wf, 3, 16); fprintf(wf, "Blue");
+    ami_cursor(wf, 3, 18); fprintf(wf, "Lum");
     ami_poswidget(wf, 2, 3, dwin->cmaxy);
     ami_poswidget(wf, 3, 12, dwin->cmaxy);
+    qcolshow(wf, dwin, st);
+
+}
+
+/* the dialog's live logic: presets, component sliders and the luminosity
+   slider all hold one color, and every control follows it */
+static void qrycolevt(FILE* wf, winptr dwin, ami_evtrec* er, void* ctx)
+
+{
+
+    qcolst* st = (qcolst*)ctx;
+    double  h, s, l;
+
+    if (er->etype == ami_etlstbox && er->lstbid == 1) {
+
+        if (er->lstbsl >= 1 && er->lstbsl <= 8) {
+
+            st->r = qcolpre[er->lstbsl-1][0];
+            st->g = qcolpre[er->lstbsl-1][1];
+            st->b = qcolpre[er->lstbsl-1][2];
+            qcolsld(dwin, 4, st->r);
+            qcolsld(dwin, 5, st->g);
+            qcolsld(dwin, 6, st->b);
+            qcolsld(dwin, 9, qcollum(st));
+            qcolshow(wf, dwin, st);
+
+        }
+
+    } else if (er->etype == ami_etsldpos) {
+
+        long v8 = wigmul(255, er->sldpos);
+
+        if (er->sldpid >= 4 && er->sldpid <= 6) {
+
+            if (er->sldpid == 4) st->r = v8;
+            else if (er->sldpid == 5) st->g = v8;
+            else st->b = v8;
+            qcolsld(dwin, 9, qcollum(st));
+            qcolsel(dwin, st);
+            qcolshow(wf, dwin, st);
+
+        } else if (er->sldpid == 9) {
+
+            rgbhsl(st->r, st->g, st->b, &h, &s, &l);
+            hslrgb(h, s, v8/255.0, &st->r, &st->g, &st->b);
+            qcolsld(dwin, 4, st->r);
+            qcolsld(dwin, 5, st->g);
+            qcolsld(dwin, 6, st->b);
+            qcolsel(dwin, st);
+            qcolshow(wf, dwin, st);
+
+        }
+
+    }
 
 }
 
@@ -10013,41 +10279,41 @@ void ami_querycolor(long* r, long* g, long* b)
     FILE*  wf;
     winptr dwin;
     long   res;
-    /* the eight terminal colors are the palette here */
-    static char* const cnam[] = { "black", "white", "red", "green", "blue",
-                                  "cyan", "yellow", "magenta" };
-    static const long cval[8][3] = {
-
-        { 0, 0, 0 }, { INT_MAX, INT_MAX, INT_MAX }, { INT_MAX, 0, 0 },
-        { 0, INT_MAX, 0 }, { 0, 0, INT_MAX }, { 0, INT_MAX, INT_MAX },
-        { INT_MAX, INT_MAX, 0 }, { INT_MAX, 0, INT_MAX },
-
-    };
     ami_strrec sr[8];
-    long   i, bw, bh, sel;
-    wigptr wg;
+    long   i, bw, bh;
+    qcolst st;
 
     for (i = 0; i < 8; i++) {
 
-        sr[i].str = cnam[i];
+        sr[i].str = qcolnam[i];
         sr[i].next = i < 7? &sr[i+1]: NULL;
 
     }
-    wf = dlgcre("Choose color", 26, 14, &dwin);
-    ami_listbox(wf, 2, 3, 20, 10, &sr[0], 1);
+    /* the color passed in is where the dialog starts */
+    st.r = colc8(*r);
+    st.g = colc8(*g);
+    st.b = colc8(*b);
+    wf = dlgcre("Choose color", 56, 23, &dwin);
+    ami_listbox(wf, 3, 3, 13, 10, &sr[0], 1);
+    ami_slidehoriz(wf, 10, 12, 44, 12, 0, 4);
+    ami_slidehoriz(wf, 10, 14, 44, 14, 0, 5);
+    ami_slidehoriz(wf, 10, 16, 44, 16, 0, 6);
+    ami_slidehoriz(wf, 10, 18, 44, 18, 0, 9);
     ami_buttonsiz(wf, "Ok", &bw, &bh);
-    ami_button(wf, 3, 12, 3+bw-1, 12, "Ok", 2);
-    ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
-    qrycollay(wf, dwin, NULL);
-    res = dlgloop(wf, dwin, 2, 3, qrycollay, NULL);
-    sel = 0;
-    wg = fndwig(dwin, 1); /* read the list selection */
-    if (wg) sel = wg->sel;
-    if (res == 2 && sel >= 1 && sel <= 8) { /* accepted */
+    ami_button(wf, 3, dwin->cmaxy, 3+bw-1, dwin->cmaxy, "Ok", 2);
+    ami_button(wf, 12, dwin->cmaxy, 12+bw+4, dwin->cmaxy, "Cancel", 3);
+    qcolsld(dwin, 4, st.r);
+    qcolsld(dwin, 5, st.g);
+    qcolsld(dwin, 6, st.b);
+    qcolsld(dwin, 9, qcollum(&st));
+    qcolsel(dwin, &st);
+    qrycollay(wf, dwin, &st);
+    res = dlgloop(wf, dwin, 2, 3, qrycollay, qrycolevt, &st);
+    if (res == 2) { /* accepted */
 
-        *r = cval[sel-1][0];
-        *g = cval[sel-1][1];
-        *b = cval[sel-1][2];
+        *r = col8full(st.r);
+        *g = col8full(st.g);
+        *b = col8full(st.b);
 
     }
     fclose(wf);
@@ -10096,7 +10362,7 @@ static void qryfile(char* title, char* s, long sl)
     ami_button(wf, 12, 5, 12+bw+4, 5, "Cancel", 3);
     qryfilelay(wf, dwin, NULL);
     ami_focuswidget(wf, 1); /* start in the name field */
-    res = dlgloop(wf, dwin, 2, 3, qryfilelay, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfilelay, NULL, NULL);
     if (res == 2) { /* accepted: hand back the name */
 
         wg = fndwig(dwin, 1);
@@ -10164,7 +10430,7 @@ void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
     ami_button(wf, 12, 9, 12+bw+4, 9, "Cancel", 3);
     qryfndlay(wf, dwin, NULL);
     ami_focuswidget(wf, 1);
-    res = dlgloop(wf, dwin, 2, 3, qryfndlay, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfndlay, NULL, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);
@@ -10238,7 +10504,7 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
     ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
     qryfrplay(wf, dwin, NULL);
     ami_focuswidget(wf, 1);
-    res = dlgloop(wf, dwin, 2, 3, qryfrplay, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfrplay, NULL, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);
@@ -10334,7 +10600,7 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
     ami_button(wf, 3, 14, 3+bw-1, 14, "Ok", 2);
     ami_button(wf, 12, 14, 12+bw+4, 14, "Cancel", 3);
     qryfntlay(wf, dwin, NULL);
-    res = dlgloop(wf, dwin, 2, 3, qryfntlay, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfntlay, NULL, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -3568,7 +3568,12 @@ static void opnwin(int fn, int pfn, long wid, int subclient, int root)
     win->cmaxy = win->maxy;
     win->mpx = 0; /* set mouse relative position invalid */
     win->mpy = 0;
-    win->attr = attr; /* no attribute */
+    /* No attribute. This copied the root emission cache, which is
+       whatever attribute the terminal was last left on: a window created
+       right after a blinking face drew stored its whole face blinking,
+       and a dialog created after a reversed face drew came up reversed
+       whole -- black, with a black swatch no color could change. */
+    win->attr = 0;
     win->autof = TRUE; /* auto on */
     win->fcolor = ami_black; /*foreground black */
     win->bcolor = ami_white; /* background white */
@@ -7667,19 +7672,23 @@ static void wigtxt(wigptr wg, long x, long y, const char* s, int rev)
 
 }
 
-/* clear a widget face to spaces */
+/* clear a widget face to spaces. The face attributes stay off the
+   blanks: an underlined label underlines its text, not the whole row */
 static void wigclr(wigptr wg)
 
 {
 
     long x, y;
+    long sat = wg->win->attr;
 
+    wg->win->attr &= ~wg->fatt;
     for (y = 1; y <= wg->win->cmaxy; y++) {
 
         icursor(wg->wf, 1, y);
         for (x = 1; x <= wg->win->cmaxx; x++) plcchr(wg->wf, ' ');
 
     }
+    wg->win->attr = sat;
 
 }
 

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -75,6 +75,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <sys/stat.h>
 #include <ctype.h>
 #include <math.h>
 
@@ -427,6 +429,7 @@ typedef struct wigrec {
     char*  face;    /* label, or edit box content */
     char** list;    /* list box strings */
     long   listn;   /* number of list strings */
+    long   top;     /* list box scroll offset, 0 based */
     int    enb;     /* enabled */
     int    sel;     /* selected state */
     long   val;     /* value: numsel, progress, scroll and slider position */
@@ -7648,10 +7651,11 @@ static void wigtxt(wigptr wg, long x, long y, const char* s, int rev)
 {
 
     winptr win = wg->win;
+    long   n = win->cmaxx-x+1; /* room to the edge: never run past it */
 
     icursor(wg->wf, x, y); /* place cursor */
     if (rev) win->attr |= BIT(sarev);
-    while (*s) plcchr(wg->wf, *s++);
+    while (*s && n-- > 0) plcchr(wg->wf, *s++);
     win->attr &= ~BIT(sarev);
 
 }
@@ -7781,6 +7785,7 @@ static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
     wg->high = 0;
     wg->sclsiz = 0;
     wg->marks = 0;
+    wg->top = 0;
     wg->curs = 0;
     wg->tor = ami_totop;
     wg->owner = owner;
@@ -8089,8 +8094,9 @@ static void wigdrw(wigptr wg)
 
         case wtlistbox:
             wigclr(wg);
-            for (y = 1; y <= h && y <= wg->listn; y++)
-                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
+            for (y = 1; y <= h && wg->top+y <= wg->listn; y++)
+                wigtxt(wg, 1, y, wg->list[wg->top+y-1],
+                       wg->top+y == wg->sel || y == hp);
             break;
 
         case wtslidehoriz:
@@ -8266,7 +8272,7 @@ static long wighit(wigptr wg, long lx, long ly)
             return (0); /* the value cell is dead */
 
         case wtlistbox: /* the entry row */
-            return (ly >= 1 && ly <= wg->listn? ly: 0);
+            return (ly >= 1 && wg->top+ly <= wg->listn? ly: 0);
 
         case wtdropeditbox: /* drop arrow, or the edit area */
             return (lx == win->cmaxx? 2: 1);
@@ -8536,11 +8542,11 @@ static void wigevt(wigptr wg, ami_evtrec* er)
                     wigdrw(wg);
                     break;
                 case wtlistbox:
-                    if (ly >= 1 && ly <= wg->listn) {
+                    if (ly >= 1 && wg->top+ly <= wg->listn) {
 
-                        wg->sel = ly;
+                        wg->sel = wg->top+ly;
                         wigdrw(wg);
-                        wigsig(wg, ami_etlstbox, ly);
+                        wigsig(wg, ami_etlstbox, wg->sel);
 
                     }
                     break;
@@ -8860,16 +8866,31 @@ static void wigevt(wigptr wg, ami_evtrec* er)
             if (!wg->enb) break;
             if (wg->typ == wtnumselbox && wg->val < wg->high)
                 { wg->val++; wigdrw(wg); wigsig(wg, ami_etnumbox, wg->val); }
-            else if (wg->typ == wtlistbox && wg->sel > 1)
-                { wg->sel--; wigdrw(wg); wigsig(wg, ami_etlstbox, wg->sel); }
+            else if (wg->typ == wtlistbox && wg->sel > 1) {
+
+                wg->sel--;
+                /* scroll to keep the selection shown */
+                if (wg->sel-1 < wg->top) wg->top = wg->sel-1;
+                wigdrw(wg);
+                wigsig(wg, ami_etlstbox, wg->sel);
+
+            }
             break;
 
         case ami_etdown:
             if (!wg->enb) break;
             if (wg->typ == wtnumselbox && wg->val > wg->low)
                 { wg->val--; wigdrw(wg); wigsig(wg, ami_etnumbox, wg->val); }
-            else if (wg->typ == wtlistbox && wg->sel < wg->listn)
-                { wg->sel++; wigdrw(wg); wigsig(wg, ami_etlstbox, wg->sel); }
+            else if (wg->typ == wtlistbox && wg->sel < wg->listn) {
+
+                wg->sel++;
+                /* scroll to keep the selection shown */
+                if (wg->sel > wg->top+wg->win->cmaxy)
+                    wg->top = wg->sel-wg->win->cmaxy;
+                wigdrw(wg);
+                wigsig(wg, ami_etlstbox, wg->sel);
+
+            }
             break;
 
         default: break; /* other events are of no interest */
@@ -8915,6 +8936,7 @@ static wigptr wigcre(FILE* f, long x1, long y1, long x2, long y2, long id,
     wg->high = 0;
     wg->sclsiz = LONG_MAX/8; /* nominal thumb */
     wg->marks = 0;
+    wg->top = 0;
     wg->curs = 0;
     wg->win->widget = TRUE; /* mark as widget window */
     wg->win->wig = wg;
@@ -10336,23 +10358,263 @@ void ami_querycolor(long* r, long* g, long* b)
 
 }
 
-/* flow the file query: the name field takes the width, the buttons keep
-   the bottom row */
+/* The file queries are a browser: the current directory across the top,
+   the directories within it in a pane at the left, the files within it
+   in a pane at the right, each with a scroll bar, and the name field at
+   the bottom. Picking a directory enters it, picking a file takes its
+   name, and a name can always just be typed. */
+#define QFPTH 1024 /* directory path length */
+typedef struct {
+
+    char dir[QFPTH];  /* the directory the browser is in */
+    char home[QFPTH]; /* the directory the dialog opened in */
+
+} qfilst;
+
+/* replace a list box's contents */
+static void lstput(winptr dwin, long id, char** strs, long n)
+
+{
+
+    wigptr wg = fndwig(dwin, id);
+    long   i;
+
+    if (!wg) return;
+    if (wg->list) {
+
+        for (i = 0; i < wg->listn; i++) free(wg->list[i]);
+        free(wg->list);
+
+    }
+    wg->list = malloc(sizeof(char*)*(n? n: 1));
+    if (!wg->list) error("Out of memory");
+    for (i = 0; i < n; i++) {
+
+        wg->list[i] = malloc(strlen(strs[i])+1);
+        if (!wg->list[i]) error("Out of memory");
+        strcpy(wg->list[i], strs[i]);
+
+    }
+    wg->listn = n;
+    wg->sel = 0;
+    wg->top = 0;
+    wigdrw(wg);
+
+}
+
+/* set a pane's scroll bar from its list: the thumb is the visible share,
+   at the scrolled position */
+static void qfilbar(winptr dwin, long lid, long bid)
+
+{
+
+    wigptr lw = fndwig(dwin, lid);
+    wigptr bw = fndwig(dwin, bid);
+    long   vis, max;
+
+    if (!lw || !bw) return;
+    vis = lw->win->cmaxy;
+    max = lw->listn-vis;
+    if (max < 0) max = 0;
+    bw->sclsiz = lw->listn > vis? wigscl(vis, lw->listn): LONG_MAX;
+    bw->val = max? wigscl(lw->top, max): 0;
+    wigdrw(bw);
+
+}
+
+/* scroll a pane by its scroll bar's report */
+static void qfilscl(winptr dwin, long lid, long bid, ami_evtcod e, long pos)
+
+{
+
+    wigptr lw = fndwig(dwin, lid);
+    long   vis, max;
+
+    if (!lw) return;
+    vis = lw->win->cmaxy;
+    max = lw->listn-vis;
+    if (max < 0) max = 0;
+    switch (e) {
+
+        case ami_etsclull: lw->top--; break;
+        case ami_etscldrl: lw->top++; break;
+        case ami_etsclulp: lw->top -= vis; break;
+        case ami_etscldrp: lw->top += vis; break;
+        case ami_etsclpos: lw->top = wigmul(max, pos); break;
+        default: break;
+
+    }
+    if (lw->top < 0) lw->top = 0;
+    if (lw->top > max) lw->top = max;
+    wigdrw(lw);
+    qfilbar(dwin, lid, bid);
+
+}
+
+/* show the directory the browser is in, tail first when it is long */
+static void qfilpath(FILE* wf, winptr dwin, qfilst* st)
+
+{
+
+    long max = dwin->cmaxx-8;
+    long l = strlen(st->dir);
+    long i;
+
+    ami_cursor(wf, 2, 1);
+    fprintf(wf, "Path: ");
+    if (l <= max) {
+
+        fprintf(wf, "%s", st->dir);
+        for (i = l; i < max; i++) fputc(' ', wf); /* blank the rest */
+
+    } else fprintf(wf, "...%s", st->dir+l-(max-3));
+
+}
+
+/* Read the browser's directory into the panes: the directories within it
+   at the left, dot-dot included, the files at the right, both sorted.
+   Hidden entries stay hidden. */
+static int qfilcmp(const void* a, const void* b)
+
+{
+
+    return (strcmp(*(char* const*)a, *(char* const*)b));
+
+}
+
+static void qfilread(FILE* wf, winptr dwin, qfilst* st)
+
+{
+
+    DIR*           dp;
+    struct dirent* de;
+    struct stat    sb;
+    char**         nm[2] = { NULL, NULL }; /* directories, then files */
+    long           nc[2] = { 0, 0 };
+    long           na[2] = { 0, 0 };
+    char           pth[QFPTH+300];
+    long           i, w;
+
+    dp = opendir(st->dir);
+    if (dp) {
+
+        while ((de = readdir(dp))) {
+
+            if (de->d_name[0] == '.' && strcmp(de->d_name, ".."))
+                continue; /* hidden, and the directory itself */
+            snprintf(pth, sizeof(pth), "%s/%s", st->dir, de->d_name);
+            if (stat(pth, &sb)) continue; /* unreadable: not offered */
+            w = !S_ISDIR(sb.st_mode);
+            if (nc[w] == na[w]) {
+
+                na[w] = na[w]? na[w]*2: 32;
+                nm[w] = realloc(nm[w], sizeof(char*)*na[w]);
+                if (!nm[w]) error("Out of memory");
+
+            }
+            nm[w][nc[w]] = malloc(strlen(de->d_name)+1);
+            if (!nm[w][nc[w]]) error("Out of memory");
+            strcpy(nm[w][nc[w]++], de->d_name);
+
+        }
+        closedir(dp);
+
+    }
+    for (w = 0; w < 2; w++) {
+
+        qsort(nm[w], nc[w], sizeof(char*), qfilcmp);
+        lstput(dwin, 4+w, nm[w], nc[w]);
+        qfilbar(dwin, 4+w, 6+w);
+        for (i = 0; i < nc[w]; i++) free(nm[w][i]);
+        free(nm[w]);
+
+    }
+    qfilpath(wf, dwin, st);
+
+}
+
+/* enter a directory from the pane */
+static void qfilnav(FILE* wf, winptr dwin, qfilst* st, const char* name)
+
+{
+
+    if (!strcmp(name, "..")) { /* up: drop the last component */
+
+        char* p = strrchr(st->dir, '/');
+
+        if (p && p != st->dir) *p = 0;
+        else strcpy(st->dir, "/");
+
+    } else {
+
+        long l = strlen(st->dir);
+
+        if (l+1+(long)strlen(name)+1 > QFPTH) return; /* cannot hold it */
+        snprintf(st->dir+l, QFPTH-l, "%s%s",
+                 l && st->dir[l-1] == '/'? "": "/", name);
+
+    }
+    qfilread(wf, dwin, st);
+
+}
+
+/* flow the file query face */
 static void qryfilelay(FILE* wf, winptr dwin, void* ctx)
 
 {
 
-    long ew;
+    qfilst* st = (qfilst*)ctx;
 
     fprintf(wf, "\f");
-    ami_cursor(wf, 2, 2);
+    ami_cursor(wf, 2, 3);
+    fprintf(wf, "Directories:");
+    ami_cursor(wf, 26, 3);
+    fprintf(wf, "Files:");
+    ami_cursor(wf, 2, 16);
     fprintf(wf, "File name:");
-    ew = dwin->cmaxx-2;
-    if (ew < 1) ew = 1;
-    ami_sizwidget(wf, 1, ew, 1);
-    ami_poswidget(wf, 1, 2, 3);
-    ami_poswidget(wf, 2, 3, dwin->cmaxy-1);
-    ami_poswidget(wf, 3, 12, dwin->cmaxy-1);
+    ami_poswidget(wf, 2, 3, dwin->cmaxy);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy);
+    qfilpath(wf, dwin, st);
+
+}
+
+/* the browser's live logic */
+static void qryfileevt(FILE* wf, winptr dwin, ami_evtrec* er, void* ctx)
+
+{
+
+    qfilst* st = (qfilst*)ctx;
+    wigptr  wg;
+    long    bid = 0, pos = 0;
+
+    switch (er->etype) {
+
+        case ami_etlstbox:
+            if (er->lstbid == 4) { /* a directory: enter it */
+
+                wg = fndwig(dwin, 4);
+                if (wg && er->lstbsl >= 1 && er->lstbsl <= wg->listn)
+                    qfilnav(wf, dwin, st, wg->list[er->lstbsl-1]);
+
+            } else if (er->lstbid == 5) { /* a file: take its name */
+
+                wg = fndwig(dwin, 5);
+                if (wg && er->lstbsl >= 1 && er->lstbsl <= wg->listn)
+                    ami_putwidgettext(wf, 1, wg->list[er->lstbsl-1]);
+
+            }
+            break;
+
+        case ami_etsclull: bid = er->sclulid; break;
+        case ami_etscldrl: bid = er->scldrid; break;
+        case ami_etsclulp: bid = er->sclupid; break;
+        case ami_etscldrp: bid = er->scldpid; break;
+        case ami_etsclpos: bid = er->sclpid; pos = er->sclpos; break;
+        default: break;
+
+    }
+    if (bid == 6) qfilscl(dwin, 4, 6, er->etype, pos);
+    else if (bid == 7) qfilscl(dwin, 5, 7, er->etype, pos);
 
 }
 
@@ -10365,28 +10627,47 @@ static void qryfile(char* title, char* s, long sl)
     winptr dwin;
     long   res, bw, bh;
     wigptr wg;
-    long   w = dimx-10;
+    qfilst st;
 
-    if (w > 60) w = 60;
-    if (w < 24) w = 24;
-    wf = dlgcre(title, w, 8, &dwin);
-    ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
+    if (!getcwd(st.dir, sizeof(st.dir))) strcpy(st.dir, "/");
+    strcpy(st.home, st.dir);
+    wf = dlgcre(title, 58, 22, &dwin);
+    ami_listbox(wf, 2, 4, 20, 14, NULL, 4);
+    ami_scrollvert(wf, 22, 4, 22, 14, 6);
+    ami_listbox(wf, 26, 4, 52, 14, NULL, 5);
+    ami_scrollvert(wf, 54, 4, 54, 14, 7);
+    ami_editbox(wf, 2, 17, 57, 17, 1);
     /* seed with what the caller passed, if anything */
     if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
     ami_buttonsiz(wf, "Ok", &bw, &bh);
-    ami_button(wf, 3, 5, 3+bw-1, 5, "Ok", 2);
-    ami_button(wf, 12, 5, 12+bw+4, 5, "Cancel", 3);
-    qryfilelay(wf, dwin, NULL);
+    ami_button(wf, 3, dwin->cmaxy, 3+bw-1, dwin->cmaxy, "Ok", 2);
+    ami_button(wf, 12, dwin->cmaxy, 12+bw+4, dwin->cmaxy, "Cancel", 3);
+    qryfilelay(wf, dwin, &st);
+    qfilread(wf, dwin, &st);
     ami_focuswidget(wf, 1); /* start in the name field */
-    res = dlgloop(wf, dwin, 2, 3, qryfilelay, NULL, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfilelay, qryfileevt, &st);
     if (res == 2) { /* accepted: hand back the name */
 
         wg = fndwig(dwin, 1);
-        if (wg && wg->face) {
+        if (wg && wg->face && *wg->face) {
 
-            long l = strlen(wg->face);
+            char  pth[QFPTH+MAXLIN];
+            char* rp = wg->face;
+            long  l;
+
+            /* A name picked where the dialog opened, or typed absolute,
+               goes back as it stands; browsing elsewhere hands back the
+               full path there. */
+            if (rp[0] != '/' && strcmp(st.dir, st.home)) {
+
+                snprintf(pth, sizeof(pth), "%s%s%s", st.dir,
+                         !strcmp(st.dir, "/")? "": "/", rp);
+                rp = pth;
+
+            }
+            l = strlen(rp);
             if (l > sl) error("String too large for destination");
-            memcpy(s, wg->face, l);
+            memcpy(s, rp, l);
             if (l < sl) s[l] = 0;
 
         }

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -431,6 +431,7 @@ typedef struct wigrec {
     long   val;     /* value: numsel, progress, scroll and slider position */
     long   low, high; /* numsel range */
     long   sclsiz;  /* scroll bar thumb size, full scale */
+    long   marks;   /* slider tick mark count */
     long   curs;    /* edit box cursor index, 0 based */
     ami_tabori tor; /* tab bar orientation */
     wigptr owner;   /* for popups, the widget or bar that opened it */
@@ -7707,6 +7708,7 @@ static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
     wg->low = 0;
     wg->high = 0;
     wg->sclsiz = 0;
+    wg->marks = 0;
     wg->curs = 0;
     wg->tor = ami_totop;
     wg->owner = owner;
@@ -8021,12 +8023,21 @@ static void wigdrw(wigptr wg)
 
         case wtslidehoriz:
             for (x = 1; x <= w; x++) wigtxt(wg, x, 1, "-", FALSE);
+            /* tick marks spaced evenly along the rail, ends included */
+            if (wg->marks > 1)
+                for (i = 0; i < wg->marks; i++)
+                    wigtxt(wg, 1+((w-1)*i+(wg->marks-1)/2)/(wg->marks-1), 1,
+                           "+", FALSE);
             n = 1+wigmul(w-1, wg->val);
             wigtxt(wg, n, 1, "#", hp != 0);
             break;
 
         case wtslidevert:
             for (y = 1; y <= h; y++) wigtxt(wg, 1, y, "|", FALSE);
+            if (wg->marks > 1)
+                for (i = 0; i < wg->marks; i++)
+                    wigtxt(wg, 1, 1+((h-1)*i+(wg->marks-1)/2)/(wg->marks-1),
+                           "+", FALSE);
             n = 1+wigmul(h-1, wg->val);
             wigtxt(wg, 1, n, "#", hp != 0);
             break;
@@ -8667,6 +8678,35 @@ static void wigevt(wigptr wg, ami_evtrec* er)
 
                 }
 
+            } else if (wg->typ == wtnumselbox &&
+                       er->echar >= '0' && er->echar <= '9') {
+
+                /* digits shift into the value; a digit that would run
+                   past the range starts a new number, so a full value
+                   types over without clearing first */
+                long d = er->echar-'0';
+                long nv = wg->val*10+(wg->val < 0? -d: d);
+
+                if (nv > wg->high || (wg->val < 0 && nv < wg->low))
+                    nv = wg->val < 0? -d: d;
+                if (nv <= wg->high) {
+
+                    wg->val = nv;
+                    wigdrw(wg);
+                    /* a partial entry can sit under the range bottom;
+                       it reports only once it is a valid value */
+                    if (nv >= wg->low) wigsig(wg, ami_etnumbox, nv);
+
+                }
+
+            } else if (wg->typ == wtnumselbox && er->echar == '-' &&
+                       wg->low < 0) {
+
+                wg->val = -wg->val;
+                wigdrw(wg);
+                if (wg->val >= wg->low && wg->val <= wg->high)
+                    wigsig(wg, ami_etnumbox, wg->val);
+
             } else if (er->echar == ' ') { /* space activates */
 
                 if (wg->typ == wtbutton) wigsig(wg, ami_etbutton, 0);
@@ -8680,8 +8720,13 @@ static void wigevt(wigptr wg, ami_evtrec* er)
             if (!wg->enb) break;
             if (wg->typ == wteditbox) wigsig(wg, ami_etedtbox, 0);
             else if (wg->typ == wtdropeditbox) wigsig(wg, ami_etdrebox, 0);
-            else if (wg->typ == wtnumselbox) wigsig(wg, ami_etnumbox, wg->val);
-            else if (wg->typ == wtbutton) wigsig(wg, ami_etbutton, 0);
+            else if (wg->typ == wtnumselbox) {
+
+                /* a partial entry left under the range clamps to it */
+                if (wg->val < wg->low) { wg->val = wg->low; wigdrw(wg); }
+                wigsig(wg, ami_etnumbox, wg->val);
+
+            } else if (wg->typ == wtbutton) wigsig(wg, ami_etbutton, 0);
             break;
 
         case ami_etdelcb: /* backspace */
@@ -8692,6 +8737,12 @@ static void wigevt(wigptr wg, ami_evtrec* er)
                 memmove(wg->face+wg->curs-1, wg->face+wg->curs, n-wg->curs+1);
                 wg->curs--;
                 wigdrw(wg);
+
+            } else if (wg->typ == wtnumselbox) {
+
+                wg->val /= 10; /* drop the last digit */
+                wigdrw(wg);
+                if (wg->val >= wg->low) wigsig(wg, ami_etnumbox, wg->val);
 
             }
             break;
@@ -8791,6 +8842,7 @@ static wigptr wigcre(FILE* f, long x1, long y1, long x2, long y2, long id,
     wg->low = 0;
     wg->high = 0;
     wg->sclsiz = LONG_MAX/8; /* nominal thumb */
+    wg->marks = 0;
     wg->curs = 0;
     wg->win->widget = TRUE; /* mark as widget window */
     wg->win->wig = wg;
@@ -9309,7 +9361,7 @@ void ami_slidehoriz(FILE* f, long x1, long y1, long x2, long y2, long mark,
 
     wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtslidehoriz);
 
-    (void)mark; /* tick marks are not drawn in character cells */
+    wg->marks = mark;
     wigfac(wg, "");
     wigdrw(wg);
 
@@ -9331,7 +9383,7 @@ void ami_slidevert(FILE* f, long x1, long y1, long x2, long y2, long mark,
 
     wigptr wg = wigcre(f, x1, y1, x2, y2, id, wtslidevert);
 
-    (void)mark;
+    wg->marks = mark;
     wigfac(wg, "");
     wigdrw(wg);
 
@@ -9794,7 +9846,8 @@ so a quit request is not swallowed by the dialog.
 
 /* Run a dialog window until its done flag is set. Returns the id of the
    widget that ended it, or 0 for an outside terminate. */
-static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid)
+static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid,
+                    void (*lay)(FILE* wf, winptr dwin, void* ctx), void* ctx)
 
 {
 
@@ -9808,6 +9861,9 @@ static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid)
 
         ievent(stdin, &er);
         if (er.etype == ami_etterm) { realterm = TRUE; done = TRUE; }
+        else if (er.etype == ami_etresize && er.winid == dwin->wid && lay)
+            /* the dialog was resized: flow the layout to the new client */
+            lay(wf, dwin, ctx);
         else if (er.etype == ami_etbutton) {
 
             if (er.butid == okid || er.butid == cancelid) {
@@ -9838,7 +9894,9 @@ static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid)
 }
 
 /* Create a dialog window centered on the surface. Returns its file, and
-   the window record through the pointer. */
+   the window record through the pointer. The given size is in the terms
+   the dialogs were laid out in, sysbar only: the sizing border grows the
+   window around it, keeping the client those layouts expect. */
 static FILE* dlgcre(char* title, long w, long h, winptr* dwin)
 
 {
@@ -9849,9 +9907,14 @@ static FILE* dlgcre(char* title, long w, long h, winptr* dwin)
     iopenwin(&stdin, &wf, NULL, igetwinid()); /* parentless: floats */
     win = txt2win(wf);
     win->frame = TRUE;
-    win->size = FALSE;
+    win->size = TRUE; /* a complete frame, and the size bars work */
     win->sysbar = TRUE;
+    win->curv = FALSE; /* a dialog never shows the cursor */
     recompcli(win);
+    w += 2; /* the sizing border */
+    h += 2;
+    if (w > dimx) w = dimx;
+    if (h > dimy) h = dimy;
     intsetsiz(win, w, h);
     intsetpos(win, (dimx-w)/2+1, (dimy-h)/2+1);
     ititle(wf, title);
@@ -9859,6 +9922,25 @@ static FILE* dlgcre(char* title, long w, long h, winptr* dwin)
     *dwin = win;
 
     return (wf);
+
+}
+
+/* flow the alert to its client: the message at the top, the button
+   centered on the bottom row */
+static void alertlay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    char* message = (char*)ctx;
+    long  bw, bh, bx;
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "%.*s", (int)(dwin->cmaxx-2), message);
+    ami_buttonsiz(wf, "Ok", &bw, &bh);
+    bx = (dwin->cmaxx-bw)/2+1;
+    if (bx < 1) bx = 1;
+    ami_poswidget(wf, 1, bx, dwin->cmaxy-1);
 
 }
 
@@ -9877,13 +9959,35 @@ void ami_alert(char* title, char* message)
     if (w > dimx-2) w = dimx-2;
     h = 7;
     wf = dlgcre(title, w, h, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "%.*s", (int)(dwin->cmaxx-2), message);
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, (dwin->cmaxx-bw)/2+1, dwin->cmaxy-1,
                    (dwin->cmaxx-bw)/2+bw, dwin->cmaxy-1, "Ok", 1);
-    dlgloop(wf, dwin, 1, 0);
+    alertlay(wf, dwin, message);
+    dlgloop(wf, dwin, 1, 0, alertlay, message);
     fclose(wf);
+
+}
+
+/* flow the color query: the list fills the middle, the buttons keep the
+   bottom row */
+static void qrycollay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    long lw, lh;
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Color:");
+    lw = dwin->cmaxx-7;
+    if (lw > 19) lw = 19;
+    if (lw < 1) lw = 1;
+    lh = dwin->cmaxy-4;
+    if (lh < 1) lh = 1;
+    ami_sizwidget(wf, 1, lw, lh);
+    ami_poswidget(wf, 1, 2, 3);
+    ami_poswidget(wf, 2, 3, dwin->cmaxy);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy);
 
 }
 
@@ -9915,13 +10019,12 @@ void ami_querycolor(long* r, long* g, long* b)
 
     }
     wf = dlgcre("Choose color", 26, 14, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "Color:");
     ami_listbox(wf, 2, 3, 20, 10, &sr[0], 1);
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 12, 3+bw-1, 12, "Ok", 2);
     ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
-    res = dlgloop(wf, dwin, 2, 3);
+    qrycollay(wf, dwin, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qrycollay, NULL);
     sel = 0;
     wg = fndwig(dwin, 1); /* read the list selection */
     if (wg) sel = wg->sel;
@@ -9933,6 +10036,26 @@ void ami_querycolor(long* r, long* g, long* b)
 
     }
     fclose(wf);
+
+}
+
+/* flow the file query: the name field takes the width, the buttons keep
+   the bottom row */
+static void qryfilelay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    long ew;
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "File name:");
+    ew = dwin->cmaxx-2;
+    if (ew < 1) ew = 1;
+    ami_sizwidget(wf, 1, ew, 1);
+    ami_poswidget(wf, 1, 2, 3);
+    ami_poswidget(wf, 2, 3, dwin->cmaxy-1);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy-1);
 
 }
 
@@ -9950,16 +10073,15 @@ static void qryfile(char* title, char* s, long sl)
     if (w > 60) w = 60;
     if (w < 24) w = 24;
     wf = dlgcre(title, w, 8, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "File name:");
     ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
     /* seed with what the caller passed, if anything */
     if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 5, 3+bw-1, 5, "Ok", 2);
     ami_button(wf, 12, 5, 12+bw+4, 5, "Cancel", 3);
+    qryfilelay(wf, dwin, NULL);
     ami_focuswidget(wf, 1); /* start in the name field */
-    res = dlgloop(wf, dwin, 2, 3);
+    res = dlgloop(wf, dwin, 2, 3, qryfilelay, NULL);
     if (res == 2) { /* accepted: hand back the name */
 
         wg = fndwig(dwin, 1);
@@ -9981,6 +10103,26 @@ void ami_queryopen(char* s, long sl) { qryfile("Open file", s, sl); }
 
 void ami_querysave(char* s, long sl) { qryfile("Save file", s, sl); }
 
+/* flow the find query: the search field takes the width, the option
+   boxes hold their rows, the buttons keep the bottom row */
+static void qryfndlay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    long ew;
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Find:");
+    ew = dwin->cmaxx-2;
+    if (ew < 1) ew = 1;
+    ami_sizwidget(wf, 1, ew, 1);
+    ami_poswidget(wf, 1, 2, 3);
+    ami_poswidget(wf, 2, 3, dwin->cmaxy);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy);
+
+}
+
 void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
 
 {
@@ -9994,8 +10136,6 @@ void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
     if (w > 50) w = 50;
     if (w < 30) w = 30;
     wf = dlgcre("Find", w, 11, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "Find:");
     ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
     if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
     ami_checkbox(wf, 2, 5, 20, 5, "Match case", 4);
@@ -10007,8 +10147,9 @@ void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 9, 3+bw-1, 9, "Ok", 2);
     ami_button(wf, 12, 9, 12+bw+4, 9, "Cancel", 3);
+    qryfndlay(wf, dwin, NULL);
     ami_focuswidget(wf, 1);
-    res = dlgloop(wf, dwin, 2, 3);
+    res = dlgloop(wf, dwin, 2, 3, qryfndlay, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);
@@ -10030,6 +10171,30 @@ void ami_queryfind(char* s, long sl, ami_qfnopts* opt)
 
 }
 
+/* flow the find/replace query: both fields take the width, the option
+   boxes hold their rows, the buttons keep the bottom row */
+static void qryfrplay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    long ew;
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Find:");
+    ami_cursor(wf, 2, 5);
+    fprintf(wf, "Replace with:");
+    ew = dwin->cmaxx-2;
+    if (ew < 1) ew = 1;
+    ami_sizwidget(wf, 1, ew, 1);
+    ami_poswidget(wf, 1, 2, 3);
+    ami_sizwidget(wf, 7, ew, 1);
+    ami_poswidget(wf, 7, 2, 6);
+    ami_poswidget(wf, 2, 3, dwin->cmaxy);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy);
+
+}
+
 void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
 
 {
@@ -10043,12 +10208,8 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
     if (w > 50) w = 50;
     if (w < 30) w = 30;
     wf = dlgcre("Find and replace", w, 14, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "Find:");
     ami_editbox(wf, 2, 3, dwin->cmaxx-1, 3, 1);
     if (sl > 0 && *s) ami_putwidgettext(wf, 1, s);
-    ami_cursor(wf, 2, 5);
-    fprintf(wf, "Replace with:");
     ami_editbox(wf, 2, 6, dwin->cmaxx-1, 6, 7);
     if (rl > 0 && *r) ami_putwidgettext(wf, 7, r);
     ami_checkbox(wf, 2, 8, 20, 8, "Match case", 4);
@@ -10060,8 +10221,9 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 12, 3+bw-1, 12, "Ok", 2);
     ami_button(wf, 12, 12, 12+bw+4, 12, "Cancel", 3);
+    qryfrplay(wf, dwin, NULL);
     ami_focuswidget(wf, 1);
-    res = dlgloop(wf, dwin, 2, 3);
+    res = dlgloop(wf, dwin, 2, 3, qryfrplay, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);
@@ -10089,6 +10251,24 @@ void ami_queryfindrep(char* s, long sl, char* r, long rl, ami_qfropts* opt)
 
     }
     fclose(wf);
+
+}
+
+/* flow the font query: the labels and boxes hold their rows, the buttons
+   keep the bottom row */
+static void qryfntlay(FILE* wf, winptr dwin, void* ctx)
+
+{
+
+    fprintf(wf, "\f");
+    ami_cursor(wf, 2, 2);
+    fprintf(wf, "Foreground:");
+    ami_cursor(wf, 2, 4);
+    fprintf(wf, "Background:");
+    ami_cursor(wf, 2, 6);
+    fprintf(wf, "Effects:");
+    ami_poswidget(wf, 2, 3, dwin->cmaxy);
+    ami_poswidget(wf, 3, 12, dwin->cmaxy);
 
 }
 
@@ -10123,14 +10303,8 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
 
     }
     wf = dlgcre("Font", 46, 16, &dwin);
-    ami_cursor(wf, 2, 2);
-    fprintf(wf, "Foreground:");
     ami_dropbox(wf, 14, 2, 26, 2, &fr_[0], 1);
-    ami_cursor(wf, 2, 4);
-    fprintf(wf, "Background:");
     ami_dropbox(wf, 14, 4, 26, 4, &br_[0], 8);
-    ami_cursor(wf, 2, 6);
-    fprintf(wf, "Effects:");
     ami_checkbox(wf, 2, 7, 20, 7, "Bold", 4);
     ami_checkbox(wf, 2, 8, 20, 8, "Underline", 5);
     ami_checkbox(wf, 2, 9, 20, 9, "Italic", 6);
@@ -10144,7 +10318,8 @@ void ami_queryfont(FILE* f, long* fc, long* s, long* fr, long* fg, long* fb,
     ami_buttonsiz(wf, "Ok", &bw, &bh);
     ami_button(wf, 3, 14, 3+bw-1, 14, "Ok", 2);
     ami_button(wf, 12, 14, 12+bw+4, 14, "Cancel", 3);
-    res = dlgloop(wf, dwin, 2, 3);
+    qryfntlay(wf, dwin, NULL);
+    res = dlgloop(wf, dwin, 2, 3, qryfntlay, NULL);
     if (res == 2) {
 
         wg = fndwig(dwin, 1);

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -599,6 +599,8 @@ typedef enum {
 
 static winptr  hovfwin;  /* window holding the hover highlight, or NULL */
 static frmpart hovfpart; /* the highlighted frame part */
+static wigptr  hovwig;   /* widget holding the hover highlight, or NULL */
+static long    hovwprt;  /* the highlighted widget part, coded per type */
 static int     frmhrev;  /* the frame draws reversed (hover highlight) */
 static winptr  hovflt;   /* frame cells draw only where this window is top */
 static winptr fndtop(long x, long y); /* forward */
@@ -2692,6 +2694,7 @@ window. Thus it is a more complete send of the event.
 *******************************************************************************/
 
 static void wigevt(wigptr wg, ami_evtrec* er); /* forward */
+static long wighit(wigptr wg, long lx, long ly); /* forward */
 static void wigdrag(void); /* forward */
 static void clspops(int downto); /* forward */
 static void wigdrw(wigptr wg); /* forward */
@@ -3752,6 +3755,7 @@ static void closewin(int ofn)
         wg = win->wiglst;
         win->wiglst = wg->next;
         wg->parent = NULL; /* it is being taken down with the owner */
+        if (hovwig == wg) hovwig = NULL; /* the highlight dies with it */
         if (xltwin[wg->win->wid+MAXFIL] >= 0) fclose(wg->wf);
         if (wg->face) free(wg->face);
         if (wg->list) {
@@ -5435,13 +5439,25 @@ static void intevent(FILE* f)
 
                         /* widgets on the root need no fronting: the root
                            is always at the bottom and its widgets above */
-                        if (fw->zorder != ztop && !fw->root)
+                        if (fw->zorder != ztop && !fw->root) {
+
+                            int pi;
+
                             /* Bring the family to the front: the window,
                                then its subtree over it -- widget faces
                                and child windows are all children in the
                                window tree. Fronting the window alone
                                raised it over its own children. */
                             fronttree(fw);
+                            /* Popups float over everything, and the click
+                               being served may just have opened one: a
+                               drop box opened its list, then the fronting
+                               here buried it under the family, and the
+                               box needed a second click to show it. */
+                            for (pi = 0; pi < popcnt; pi++)
+                                fronttree(popstk[pi]->win);
+
+                        }
 
                     }
                     /* A frame click acts on the same click that focuses
@@ -5508,8 +5524,18 @@ static void intevent(FILE* f)
 
                 winptr  hw = fndtop(mousex, mousey);
                 frmpart hp = fp_none;
+                wigptr  ww = NULL;
+                long    wp = 0;
 
-                if (hw && !hw->widget && !hw->root && hw->frame)
+                if (hw && hw->widget) { /* the live widget part reverses */
+
+                    ww = hw->wig;
+                    if (ww->enb)
+                        wp = wighit(ww, mousex-absx(hw)+1,
+                                        mousey-absy(hw)+1);
+                    if (!wp) ww = NULL;
+
+                } else if (hw && !hw->root && hw->frame)
                     hp = frmhit(hw, mousex, mousey);
                 if (hp == fp_none) hw = NULL;
                 if (hw != hovfwin || hp != hovfpart) {
@@ -5518,6 +5544,16 @@ static void intevent(FILE* f)
                     hovfwin = hw; /* note the new holder */
                     hovfpart = hp;
                     if (hovfwin) drwfrmpart(hovfwin, hovfpart, TRUE);
+
+                }
+                if (ww != hovwig || wp != hovwprt) {
+
+                    wigptr ow = hovwig;
+
+                    hovwig = ww; /* the face draw reads these */
+                    hovwprt = wp;
+                    if (ow) wigdrw(ow);
+                    if (ww) wigdrw(ww);
 
                 }
 
@@ -7603,6 +7639,7 @@ static void clspops(int downto)
 
         wg = popstk[--popcnt];
         popstk[popcnt] = NULL;
+        if (hovwig == wg) hovwig = NULL; /* the highlight dies with it */
         /* unlink from its owner's widget list and drop it */
         if (wg->parent) {
 
@@ -7676,6 +7713,7 @@ static wigptr opnpop(winptr par, long rx, long ry, char** strs, long n,
     wg->mitems = mitems;
     wg->win->widget = TRUE;
     wg->win->wig = wg;
+    wg->win->curv = FALSE; /* a widget face never shows the cursor */
     wg->next = par->wiglst; /* on the owner's list for cleanup */
     par->wiglst = wg;
     /* frame it, no system bar: a plain bordered list */
@@ -7764,6 +7802,7 @@ static void drwmbar(wigptr wg)
 
     ami_menuptr p;
     long x = 1;
+    long hp = wg == hovwig? hovwprt: 0; /* hovered title start column */
 
     wigclr(wg);
     for (p = wg->mitems; p; p = p->next) {
@@ -7771,9 +7810,9 @@ static void drwmbar(wigptr wg)
         int enb = menenb(wg->parent, p->id);
 
         wigtxt(wg, x, 1, " ", FALSE);
-        /* a disabled item shows grey; selected shows reversed */
+        /* a disabled item shows grey; selected or hovered shows reversed */
         if (!enb) wg->win->attr |= BIT(sagrey);
-        wigtxt(wg, x+1, 1, p->face, wg->sel == x);
+        wigtxt(wg, x+1, 1, p->face, wg->sel == x || hp == x);
         wg->win->attr &= ~BIT(sagrey);
         x += strlen(p->face)+2;
 
@@ -7818,12 +7857,17 @@ static void wigdrw(wigptr wg)
        the focus window when the face is done. */
     setcurvis(FALSE);
     int    rev;
+    /* the live part under the mouse shows reversed, as frame parts do */
+    long   hp = wg == hovwig? hovwprt: 0;
 
+    /* a disabled widget shows its whole face grey, as a disabled menu
+       item does */
+    if (!wg->enb) win->attr |= BIT(sagrey);
     switch (wg->typ) {
 
         case wtbutton:
             wigclr(wg);
-            rev = wg->sel || (win->focus && wg->enb);
+            rev = wg->sel || hp || (win->focus && wg->enb);
             if (h >= 3) { /* boxed face */
 
                 icursor(wg->wf, 1, 1);
@@ -7854,13 +7898,13 @@ static void wigdrw(wigptr wg)
         case wtcheckbox:
             wigclr(wg);
             snprintf(buf, sizeof(buf), "[%c] %s", wg->sel? 'X': ' ', wg->face);
-            wigtxt(wg, 1, 1, buf, win->focus && wg->enb);
+            wigtxt(wg, 1, 1, buf, hp || (win->focus && wg->enb));
             break;
 
         case wtradio:
             wigclr(wg);
             snprintf(buf, sizeof(buf), "(%c) %s", wg->sel? '*': ' ', wg->face);
-            wigtxt(wg, 1, 1, buf, win->focus && wg->enb);
+            wigtxt(wg, 1, 1, buf, hp || (win->focus && wg->enb));
             break;
 
         case wtgroup:
@@ -7896,42 +7940,48 @@ static void wigdrw(wigptr wg)
             break;
 
         case wtscrollvert:
-            /* arrows at the ends, track between, thumb from size/position */
-            wigtxt(wg, 1, 1, "^", FALSE);
-            for (y = 2; y < h; y++) wigtxt(wg, 1, y, ".", FALSE);
-            wigtxt(wg, 1, h, "v", FALSE);
+            /* arrows at the ends, track between, thumb from size/position;
+               the arrows, the thumb, and the paging runs of the track are
+               each their own hover part */
             n = h-2; /* track length */
+            ts = tp = 0;
             if (n > 0) {
 
                 ts = wigmul(n, wg->sclsiz); /* thumb size */
                 if (ts < 1) ts = 1;
                 if (ts > n) ts = n;
                 tp = wigmul(n-ts, wg->val); /* offset */
-                for (y = 0; y < ts; y++) wigtxt(wg, 1, 2+tp+y, "#", FALSE);
 
             }
+            wigtxt(wg, 1, 1, "^", hp == 1);
+            for (y = 2; y < h; y++)
+                wigtxt(wg, 1, y, ".", y-2 < tp? hp == 4: hp == 5);
+            wigtxt(wg, 1, h, "v", hp == 2);
+            for (y = 0; y < ts; y++) wigtxt(wg, 1, 2+tp+y, "#", hp == 3);
             break;
 
         case wtscrollhoriz:
-            wigtxt(wg, 1, 1, "<", FALSE);
-            for (x = 2; x < w; x++) wigtxt(wg, x, 1, ".", FALSE);
-            wigtxt(wg, w, 1, ">", FALSE);
             n = w-2;
+            ts = tp = 0;
             if (n > 0) {
 
                 ts = wigmul(n, wg->sclsiz);
                 if (ts < 1) ts = 1;
                 if (ts > n) ts = n;
                 tp = wigmul(n-ts, wg->val);
-                for (x = 0; x < ts; x++) wigtxt(wg, 2+tp+x, 1, "#", FALSE);
 
             }
+            wigtxt(wg, 1, 1, "<", hp == 1);
+            for (x = 2; x < w; x++)
+                wigtxt(wg, x, 1, ".", x-2 < tp? hp == 4: hp == 5);
+            wigtxt(wg, w, 1, ">", hp == 2);
+            for (x = 0; x < ts; x++) wigtxt(wg, 2+tp+x, 1, "#", hp == 3);
             break;
 
         case wtnumselbox:
             wigclr(wg);
-            wigtxt(wg, 1, 1, "-", FALSE);
-            wigtxt(wg, w, 1, "+", FALSE);
+            wigtxt(wg, 1, 1, "-", hp == 1);
+            wigtxt(wg, w, 1, "+", hp == 2);
             snprintf(buf, sizeof(buf), "%*ld", (int)(w-2), wg->val);
             wigtxt(wg, 2, 1, buf, win->focus);
             break;
@@ -7942,10 +7992,12 @@ static void wigdrw(wigptr wg)
             /* keep the cursor visible: scroll the text if needed */
             i = 0; /* display start */
             if (wg->curs >= w) i = wg->curs-w+1;
-            for (x = 1; x <= w && i+x-1 < n+1; x++) {
+            for (x = 1; x <= w; x++) {
 
                 char c = i+x-1 < n? wg->face[i+x-1]: ' ';
-                rev = win->focus && (i+x-1 == wg->curs);
+                /* hover reverses the field; the edit cursor cell flips
+                   back, so it stays visible within the highlight */
+                rev = (win->focus && (i+x-1 == wg->curs)) ^ (hp != 0);
                 buf[0] = c; buf[1] = 0;
                 wigtxt(wg, x, 1, buf, rev);
 
@@ -7964,44 +8016,45 @@ static void wigdrw(wigptr wg)
         case wtlistbox:
             wigclr(wg);
             for (y = 1; y <= h && y <= wg->listn; y++)
-                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel);
+                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
             break;
 
         case wtslidehoriz:
             for (x = 1; x <= w; x++) wigtxt(wg, x, 1, "-", FALSE);
             n = 1+wigmul(w-1, wg->val);
-            wigtxt(wg, n, 1, "#", FALSE);
+            wigtxt(wg, n, 1, "#", hp != 0);
             break;
 
         case wtslidevert:
             for (y = 1; y <= h; y++) wigtxt(wg, 1, y, "|", FALSE);
             n = 1+wigmul(h-1, wg->val);
-            wigtxt(wg, 1, n, "#", FALSE);
+            wigtxt(wg, 1, n, "#", hp != 0);
             break;
 
         case wtdropbox:
             /* closed face: the selection and a drop arrow */
             wigclr(wg);
             if (wg->sel >= 1 && wg->sel <= wg->listn)
-                wigtxt(wg, 1, 1, wg->list[wg->sel-1], win->focus);
-            wigtxt(wg, w, 1, "v", FALSE);
+                wigtxt(wg, 1, 1, wg->list[wg->sel-1], win->focus || hp);
+            wigtxt(wg, w, 1, "v", hp != 0);
             break;
 
         case wtdropeditbox:
-            /* an edit box with a drop arrow in the last cell */
+            /* an edit box with a drop arrow in the last cell; the arrow
+               and the edit area are separate hover parts */
             wigclr(wg);
             n = strlen(wg->face);
             i = 0;
             if (wg->curs >= w-1) i = wg->curs-w+2;
-            for (x = 1; x <= w-1 && i+x-1 < n+1; x++) {
+            for (x = 1; x <= w-1; x++) {
 
                 char c = i+x-1 < n? wg->face[i+x-1]: ' ';
-                rev = win->focus && (i+x-1 == wg->curs);
+                rev = (win->focus && (i+x-1 == wg->curs)) ^ (hp == 1);
                 buf[0] = c; buf[1] = 0;
                 wigtxt(wg, x, 1, buf, rev);
 
             }
-            wigtxt(wg, w, 1, "v", FALSE);
+            wigtxt(wg, w, 1, "v", hp == 2);
             break;
 
         case wttabbar:
@@ -8012,7 +8065,8 @@ static void wigdrw(wigptr wg)
                 x = 1;
                 for (i = 0; i < wg->listn && x <= w; i++) {
 
-                    wigtxt(wg, x, 1, wg->list[i], wg->sel == i+1);
+                    wigtxt(wg, x, 1, wg->list[i],
+                           wg->sel == i+1 || hp == i+1);
                     x += strlen(wg->list[i]);
                     if (i+1 < wg->listn) { wigtxt(wg, x, 1, "|", FALSE); x++; }
 
@@ -8029,7 +8083,7 @@ static void wigdrw(wigptr wg)
                     while (*p && y <= h) {
 
                         buf[0] = *p++; buf[1] = 0;
-                        wigtxt(wg, 1, y++, buf, wg->sel == i+1);
+                        wigtxt(wg, 1, y++, buf, wg->sel == i+1 || hp == i+1);
 
                     }
                     if (i+1 < wg->listn && y <= h)
@@ -8060,18 +8114,134 @@ static void wigdrw(wigptr wg)
 
                 }
                 if (!enb) wg->win->attr |= BIT(sagrey);
-                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel);
+                wigtxt(wg, 1, y, wg->list[y-1], y == wg->sel || y == hp);
                 wg->win->attr &= ~BIT(sagrey);
 
             }
             break;
 
     }
+    win->attr &= ~BIT(sagrey);
     /* The drawing walked the physical cursor over the widget face; it
        belongs to the focus window. Without this the cursor was left
        sitting at the end of whatever widget drew last -- the menu bar
        showed it parked after its last title. */
     setcur(curfocus? curfocus: wg->parent);
+
+}
+
+/* Map a position in a widget face to the live part under it, for hover
+   feedback. Zero is no live part, and the codes are per type, matching
+   what a click there does: parts that are dead to clicks (a group box, a
+   progress bar, the value cell of a number select) return zero, so the
+   highlight marks exactly what is live. */
+static long wighit(wigptr wg, long lx, long ly)
+
+{
+
+    winptr win = wg->win;
+    long   n, ts, tp;
+
+    switch (wg->typ) {
+
+        case wtbutton:
+        case wtcheckbox:
+        case wtradio:
+        case wteditbox:
+        case wtslidehoriz:
+        case wtslidevert:
+        case wtdropbox:
+            return (1); /* the whole face is live */
+
+        case wtscrollvert:
+            if (ly == 1) return (1); /* up arrow */
+            if (ly == win->cmaxy) return (2); /* down arrow */
+            n = win->cmaxy-2; /* track length */
+            if (n <= 0) return (0);
+            ts = wigmul(n, wg->sclsiz); /* thumb size */
+            if (ts < 1) ts = 1;
+            if (ts > n) ts = n;
+            tp = wigmul(n-ts, wg->val); /* offset */
+            if (ly-2 >= tp && ly-2 < tp+ts) return (3); /* thumb */
+            return (ly-2 < tp? 4: 5); /* page up/down runs of the track */
+
+        case wtscrollhoriz:
+            if (lx == 1) return (1);
+            if (lx == win->cmaxx) return (2);
+            n = win->cmaxx-2;
+            if (n <= 0) return (0);
+            ts = wigmul(n, wg->sclsiz);
+            if (ts < 1) ts = 1;
+            if (ts > n) ts = n;
+            tp = wigmul(n-ts, wg->val);
+            if (lx-2 >= tp && lx-2 < tp+ts) return (3);
+            return (lx-2 < tp? 4: 5);
+
+        case wtnumselbox:
+            if (lx == 1) return (1); /* decrement */
+            if (lx == win->cmaxx) return (2); /* increment */
+            return (0); /* the value cell is dead */
+
+        case wtlistbox: /* the entry row */
+            return (ly >= 1 && ly <= wg->listn? ly: 0);
+
+        case wtdropeditbox: /* drop arrow, or the edit area */
+            return (lx == win->cmaxx? 2: 1);
+
+        case wttabbar: { /* the tab under the pointer */
+
+            long i, p = 1;
+
+            if (wg->tor == ami_totop || wg->tor == ami_tobottom) {
+
+                for (i = 0; i < wg->listn; i++) {
+
+                    long tw = strlen(wg->list[i]);
+                    if (lx >= p && lx < p+tw) return (i+1);
+                    p += tw+1; /* name and separator */
+
+                }
+
+            } else {
+
+                for (i = 0; i < wg->listn; i++) {
+
+                    long th = strlen(wg->list[i]);
+                    if (ly >= p && ly < p+th) return (i+1);
+                    p += th+1;
+
+                }
+
+            }
+            return (0);
+
+        }
+
+        case wtmenubar: { /* the title under the pointer, by start column,
+                             which is how the bar codes its selection */
+
+            long sx;
+            ami_menuptr mp = mbarhit(wg, lx, &sx);
+
+            return (mp && menenb(wg->parent, mp->id)? sx: 0);
+
+        }
+
+        case wtpopup: /* the entry row, if the item is enabled */
+            if (ly < 1 || ly > wg->listn) return (0);
+            if (wg->mitems) { /* a menu level knows enabled state */
+
+                ami_menuptr item = mennth(wg->mitems, ly);
+
+                if (!item || !menenb(wg->parent, item->id)) return (0);
+
+            }
+            return (ly);
+
+        default: /* group, background, progress bar: nothing is live */
+            return (0);
+
+    }
 
 }
 
@@ -8624,6 +8794,10 @@ static wigptr wigcre(FILE* f, long x1, long y1, long x2, long y2, long id,
     wg->curs = 0;
     wg->win->widget = TRUE; /* mark as widget window */
     wg->win->wig = wg;
+    /* A widget face never shows the physical cursor. It takes the focus
+       when clicked, and the cursor followed it and sat on the face -- on
+       a scroll bar it showed riding the thumb as it dragged. */
+    wg->win->curv = FALSE;
     wg->next = par->wiglst; /* push onto the owner's list */
     par->wiglst = wg;
     /* Shape the face: no decorations at all, sized and placed in owner
@@ -8684,6 +8858,7 @@ void ami_killwidget(FILE* f, long id)
     wigptr* lp;
 
     if (!wg) error("No widget by given id");
+    if (hovwig == wg) hovwig = NULL; /* the highlight dies with it */
     /* unlink from the owner */
     lp = &win->wiglst;
     while (*lp != wg) lp = &(*lp)->next;
@@ -8721,6 +8896,8 @@ void ami_enablewidget(FILE* f, long id, long e)
 
     if (!wg) error("No widget by given id");
     wg->enb = !!e;
+    /* a disabled widget takes no hover highlight */
+    if (!wg->enb && hovwig == wg) hovwig = NULL;
     wigdrw(wg);
 
 }

--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -9976,6 +9976,20 @@ static long dlgloop(FILE* wf, winptr dwin, long okid, long cancelid,
             res = okid;
             done = TRUE;
 
+        } else if (er.etype == ami_etchkbox && er.winid == dwin->wid) {
+
+            /* A checkbox reports its click and leaves the state to its
+               owner, which a program answers with selectwidget. The
+               dialog owns these, so it checks and unchecks them here. */
+            wigptr wg = fndwig(dwin, er.ckbxid);
+
+            if (wg) {
+
+                wg->sel = !wg->sel;
+                wigdrw(wg);
+
+            }
+
         } else if (evt) evt(wf, dwin, &er, ctx); /* to the dialog's logic */
 
     } while (!done);

--- a/tests/widget_testc.c
+++ b/tests/widget_testc.c
@@ -1,0 +1,1210 @@
+/*******************************************************************************
+*                                                                              *
+*                   WIDGET TEST PROGRAM, CHARACTER MODE                        *
+*                                                                              *
+*                    Copyright (C) 2005 Scott A. Franco                        *
+*                                                                              *
+* Tests the character mode widgets and dialogs. The root window serves as the  *
+* desktop: all testing is applied to a child window, a standard 80x25 terminal *
+* surface, the way the graphical form of this test applies to a program window *
+* on the desktop. Maximize the root window to give the test room to work.      *
+*                                                                              *
+*******************************************************************************/
+
+/* base C defines */
+#include <stdlib.h>
+#include <stdio.h>
+#include <setjmp.h>
+#include <string.h>
+#include <math.h>
+#include <limits.h>
+
+/* Petit-ami defines */
+#include <localdefs.h>
+#include <services.h>
+#include <terminalw.h>
+
+/*
+ * Debug print system
+ *
+ * Example use:
+ *
+ * dbg_printf(dlinfo, "There was an error: string: %s\n", bark);
+ *
+ * mydir/test.c:myfunc():12: There was an error: somestring
+ *
+ */
+
+static enum { /* debug levels */
+
+    dlinfo, /* informational */
+    dlwarn, /* warnings */
+    dlfail, /* failure/critical */
+    dlnone  /* no messages */
+
+} dbglvl = dlinfo;
+
+#define dbg_printf(lvl, fmt, ...) \
+        do { if (lvl >= dbglvl) fprintf(stderr, "%s:%s():%d: " fmt, __FILE__, \
+                                __func__, __LINE__, ##__VA_ARGS__); \
+                                fflush(stderr); } while (0)
+
+#define SECOND 10000 /* one second timer */
+
+static jmp_buf       terminate_buf;
+static FILE*         tw; /* the window under test */
+static ami_evtrec     er;
+static int           chk, chk2, chk3;
+static char          s[100];
+static char          ss[100], rs[100];
+static int           prog;
+static ami_strptr     sp, lp;
+static long          x, y, lm, xs, ys, bx, by, ix,iy;
+static long          r, g, b;
+static ami_qfnopts    optf;
+static ami_qfropts    optfr;
+static long          fc;
+static long          fs;
+static long          fr, fg, fb;
+static long          br, bg, bb;
+static ami_qfteffects fe;
+static long          cx, cy;
+static long          ox, oy;
+static long          cox, coy;
+static long          csx, csy;
+
+static long          i;
+static int           cnt;
+static char          fns[100];
+
+/* allocate memory with error checking */
+static void *imalloc(size_t size)
+
+{
+
+    void* p;
+
+    p = malloc(size);
+    if (!p) {
+
+        fprintf(stderr, "*** Out of memory ***\n");
+        exit(1);
+
+    }
+
+    return (p);
+
+}
+
+/* get string in dynamic storage */
+static char* str(char* s)
+
+{
+
+    char* p;
+
+    p = imalloc(strlen(s)+1);
+    strcpy(p, s);
+
+    return (p);
+
+}
+
+static int framenum = 0; /* current frame number */
+
+/* set the window title with the chapter frame number, as graphics_test does;
+   called at the start of each chapter so every screen is numbered, including
+   the interactive ones that wait on their own event loop instead of waitnext */
+static void setframe(void)
+
+{
+
+    char titlebuf[80];
+
+    framenum++;
+    sprintf(titlebuf, "widget_test: frame %d", framenum);
+    ami_title(tw, titlebuf);
+
+}
+
+/* wait return to be pressed, or handle terminate */
+static void waitnext(void)
+
+{
+
+    ami_evtrec er; /* event record */
+
+    do { ami_event(stdin, &er); }
+    while (er.etype != ami_etenter && er.etype != ami_etterm);
+    if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+}
+
+int main(void)
+
+{
+
+    long wx, wy;
+
+    if (setjmp(terminate_buf)) goto terminate;
+
+    /* The root window is the desktop for this test; everything below is
+       applied to a child window on it. */
+    ami_curvis(stdout, FALSE);
+    ami_auto(stdout, FALSE);
+    printf("\f");
+    printf("Character mode widget test -- this window is the desktop\n");
+
+    /* open the window under test, a standard 80x25 terminal surface */
+    ami_openwin(&stdin, &tw, stdout, 2);
+    ami_winclient(tw, 80, 25, &wx, &wy,
+                  BIT(ami_wmframe) | BIT(ami_wmsize) | BIT(ami_wmsysbar));
+    ami_setsiz(tw, wx, wy);
+    ami_setpos(tw, 2, 2);
+    ami_sizbuf(tw, 80, 25);
+    ami_curvis(tw, FALSE);
+
+    fprintf(tw, "Widget test vs. 0.1\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "If this window does not fit the desktop, expand or maximize\n");
+    fprintf(tw, "the desktop window, and/or move this window, before continuing\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "Hit return in any window to continue for each test\n");
+    waitnext();
+
+    /* ************************** Character Button test ************************* */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character buttons test\n");
+    fprintf(tw, "\n");
+    ami_buttonsiz(tw, "Hello, there", &x, &y);
+    ami_button(tw, 10, 7, 10+x-1, 7+y-1, "Hello, there", 1); 
+    ami_buttonsiz(tw, "Bark!", &x, &y);
+    ami_button(tw, 10, 10, 10+x-1, 10+y-1, "Bark!", 2);
+    ami_buttonsiz(tw, "Sniff", &x, &y);
+    ami_button(tw, 10, 13, 10+x-1, 13+y-1, "Sniff", 3);
+    fprintf(tw, "Hit the buttons, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etbutton) {
+
+            if (er.butid == 1) fprintf(tw, "Hello to you, too\n");
+            else if (er.butid == 2) fprintf(tw, "Bark bark\n");
+            else if (er.butid == 3) fprintf(tw, "Sniff sniff\n");
+            else fprintf(tw, "!!! No button with id: %ld !!!\n", er.butid);
+
+        };
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_enablewidget(tw, 2, FALSE);
+    fprintf(tw, "Now the middle button is disabled, and should not be able to\n");
+    fprintf(tw, "be pressed.\n");
+    fprintf(tw, "Hit the buttons, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etbutton) {
+
+            if (er.butid == 1) fprintf(tw, "Hello to you, too\n");
+            else if (er.butid == 2) fprintf(tw, "Bark bark\n");
+            else if (er.butid == 3) fprintf(tw, "Sniff sniff\n");
+            else fprintf(tw, "!!! No button with id: %ld !!!\n", er.butid);
+
+        };
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+
+    /* ************************** Character Checkbox test ************************** */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character checkbox test\n");
+    fprintf(tw, "\n");
+    chk = FALSE;
+    chk2 = FALSE;
+    chk3 = FALSE;
+    ami_checkboxsiz(tw, "Pick me", &x, &y);
+    ami_checkbox(tw, 10, 7, 10+x-1, 7+y-1, "Pick me", 1);
+    ami_checkboxsiz(tw, "Or me", &x, &y);
+    ami_checkbox(tw, 10, 10, 10+x-1, 10+y-1, "Or me", 2);
+    ami_checkboxsiz(tw, "No, me", &x, &y);
+    ami_checkbox(tw, 10, 13, 10+x-1, 13+y-1, "No, me", 3);
+    fprintf(tw, "Hit the checkbox, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etchkbox) {
+
+            if (er.ckbxid == 1) {
+
+                fprintf(tw, "You selected the top checkbox\n");
+                chk = !chk;
+                ami_selectwidget(tw, 1, chk);
+
+            } else if (er.ckbxid == 2) {
+
+                fprintf(tw, "You selected the middle checkbox\n");
+                chk2 = !chk2;
+                ami_selectwidget(tw, 2, chk2);
+
+            } else if (er.ckbxid == 3) {
+
+                fprintf(tw, "You selected the bottom checkbox\n");
+                chk3 = !chk3;
+                ami_selectwidget(tw, 3, chk3);
+
+            } else fprintf(tw, "!!! No button with id: %ld !!!\n", er.butid);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_enablewidget(tw, 2, FALSE);
+    fprintf(tw, "Now the middle checkbox is disabled, and should not be able to\n");
+    fprintf(tw, "be pressed.\n");
+    fprintf(tw, "Hit the checkbox, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etchkbox) {
+
+            if (er.ckbxid == 1) {
+
+                fprintf(tw, "You selected the top checkbox\n");
+                chk = !chk;
+                ami_selectwidget(tw, 1, chk);
+
+            } else if (er.ckbxid == 2) {
+
+                fprintf(tw, "You selected the middle checkbox\n");
+                chk2 = !chk2;
+                ami_selectwidget(tw, 2, chk2);
+
+            } else if (er.ckbxid == 3) {
+
+                fprintf(tw, "You selected the bottom checkbox\n");
+                chk3 = !chk3;
+                ami_selectwidget(tw, 3, chk3);
+
+            } else fprintf(tw, "!!! No button with id: %ld !!!\n", er.butid);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+
+    /* *********************** Character radio button test ********************* */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character radio button test\n");
+    fprintf(tw, "\n");
+    chk = FALSE;
+    chk2 = FALSE;
+    chk3 = FALSE;
+    ami_radiobuttonsiz(tw, "Station 1", &x, &y);
+    ami_radiobutton(tw, 10, 7, 10+x-1, 7+y-1, "Station 1", 1);
+    ami_radiobuttonsiz(tw, "Station 2", &x, &y);
+    ami_radiobutton(tw, 10, 10, 10+x-1, 10+y-1, "Station 2", 2);
+    ami_radiobuttonsiz(tw, "Station 3", &x, &y);
+    ami_radiobutton(tw, 10, 13, 10+x-1, 13+y-1, "Station 3", 3);
+    fprintf(tw, "Hit the radio button, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etradbut) {
+
+            if (er.radbid == 1) {
+
+                fprintf(tw, "You selected the top checkbox\n");
+                chk = !chk;
+                ami_selectwidget(tw, 1, chk);
+
+            } else if (er.radbid == 2) {
+
+                fprintf(tw, "You selected the middle checkbox\n");
+                chk2 = !chk2;
+                ami_selectwidget(tw, 2, chk2);
+
+            } else if (er.radbid == 3) {
+
+                fprintf(tw, "You selected the bottom checkbox\n");
+                chk3 = !chk3;
+                ami_selectwidget(tw, 3, chk3);
+
+            } else fprintf(tw, "!!! No button with id: %ld !!!", er.butid);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_enablewidget(tw, 2, FALSE);
+    fprintf(tw, "Now the middle radio button is disabled, and should not be able\n");
+    fprintf(tw, "to be pressed.\n");
+    fprintf(tw, "Hit the radio button, or return to continue\n");
+    fprintf(tw, "\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etradbut) {
+
+            if (er.radbid == 1) {
+
+                fprintf(tw, "You selected the top checkbox\n");
+                chk = !chk;
+                ami_selectwidget(tw, 1, chk);
+
+            } else if (er.radbid == 2) {
+
+                fprintf(tw, "You selected the middle checkbox\n");
+                chk2 = !chk2;
+                ami_selectwidget(tw, 2, chk2);
+
+            } else if (er.radbid == 3) {
+
+                fprintf(tw, "You selected the bottom checkbox\n");
+                chk3 = !chk3;
+                ami_selectwidget(tw, 3, chk3);
+
+            } else fprintf(tw, "!!! No button with id: %ld !!!\n", er.butid);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+
+    /* *********************** Character Group box test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character group box test\n");
+    fprintf(tw, "\n");
+    ami_groupsiz(tw, "Hello there", 0, 0, &x, &y, &ox, &oy);
+    ami_group(tw, 10, 10, 10+x, 10+y, "Hello there", 1);
+    fprintf(tw, "This is a group box with a null client area\n");
+    fprintf(tw, "Hit return to continue\n");
+    waitnext();
+    ami_killwidget(tw, 1);
+    ami_groupsiz(tw, "Hello there", 20, 10, &x, &y, &ox, &oy);
+    ami_group(tw, 10, 10, 10+x, 10+y, "Hello there", 1);
+    fprintf(tw, "This is a group box with a 20,10 client area\n");
+    fprintf(tw, "Hit return to continue\n");
+    waitnext();
+    ami_killwidget(tw, 1);
+    ami_groupsiz(tw, "Hello there", 20, 10, &x, &y, &ox, &oy);
+    ami_group(tw, 10, 10, 10+x, 10+y, "Hello there", 1);
+    ami_button(tw, 10+ox, 10+oy, 10+ox+20-1, 10+oy+10-1, "Bark, bark!", 2);
+    fprintf(tw, "This is a group box with a 20,10 layered button\n");
+    fprintf(tw, "Hit return to continue\n");
+    waitnext();
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+
+    /* *********************** Character background test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character background test\n");
+    fprintf(tw, "\n");
+    ami_background(tw, 10, 10, 40, 20, 1);
+    fprintf(tw, "Hit return to continue\n");
+    waitnext();
+    ami_button(tw, 11, 11, 39, 19, "Bark, bark!", 2);
+    fprintf(tw, "This is a background with a layered button\n");
+    fprintf(tw, "Hit return to continue\n");
+    waitnext();
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+
+    /* *********************** Character scroll bar test *********************** */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character scroll bar test\n");
+    fprintf(tw, "\n");
+    ami_scrollvertsiz(tw, &x, &y);
+    ami_scrollvert(tw, 10, 10, 10+x-1, 20, 1);
+    ami_scrollhorizsiz(tw, &x, &y);
+    ami_scrollhoriz(tw, 15, 10, 35, 10+y-1, 2);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etsclull)
+            fprintf(tw, "Scrollbar: %ld up/left line\n", er.sclulid);
+        if (er.etype == ami_etscldrl)
+            fprintf(tw, "Scrollbar: %ld down/right line\n", er.scldrid);
+        if (er.etype == ami_etsclulp)
+            fprintf(tw, "Scrollbar: %ld up/left page\n", er.sclupid);
+        if (er.etype == ami_etscldrp)
+            fprintf(tw, "Scrollbar: %ld down/right page\n", er.scldpid);
+        if (er.etype == ami_etsclpos) {
+
+            ami_scrollpos(tw, er.sclpid, er.sclpos); /* set new position for scrollbar */
+            fprintf(tw, "Scrollbar: %ld position set: %ld\n", er.sclpid, er.sclpos);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+
+    /* ******************* Character scroll bar sizing test ******************** */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character scroll bar sizing test\n");
+    fprintf(tw, "\n");
+    ami_scrollvert(tw, 10, 10, 12, 20, 1);
+    ami_scrollsiz(tw, 1, (LONG_MAX / 4)*3);
+    ami_scrollvert(tw, 10+5, 10, 12+5, 20, 2);
+    ami_scrollsiz(tw, 2, LONG_MAX / 2);
+    ami_scrollvert(tw, 10+10, 10, 12+10, 20, 3);
+    ami_scrollsiz(tw, 3, LONG_MAX / 4);
+    ami_scrollvert(tw, 10+15, 10, 12+15, 20, 4);
+    ami_scrollsiz(tw, 4, LONG_MAX / 8);
+    fprintf(tw, "Now should be four scrollbars, decending in size to the right.\n");
+    fprintf(tw, "All of the scrollbars can be manipulated.\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etsclull)
+            fprintf(tw, "Scrollbar: %ld up/left line\n", er.sclulid);
+        if (er.etype == ami_etscldrl)
+            fprintf(tw, "Scrollbar: %ld down/right line\n", er.scldrid);
+        if (er.etype == ami_etsclulp)
+            fprintf(tw, "Scrollbar: %ld up/left page\n", er.sclupid);
+        if (er.etype == ami_etscldrp)
+            fprintf(tw, "Scrollbar: %ld down/right page\n", er.scldpid);
+        if (er.etype == ami_etsclpos) {
+
+            ami_scrollpos(tw, er.sclpid, er.sclpos); /* set new position for scrollbar */
+            fprintf(tw, "Scrollbar: %ld position set: %ld\n", er.sclpid, er.sclpos);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+    ami_killwidget(tw, 4);
+
+    /* ****************** Character scroll bar minimums test ******************* */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character scroll bar minimums test\n");
+    fprintf(tw, "\n");
+    ami_scrollvertsiz(tw, &x, &y);
+    ami_scrollvert(tw, 10, 10, 10+x-1, 10+y-1, 1);
+    ami_scrollhorizsiz(tw, &x, &y);
+    ami_scrollhoriz(tw, 15, 10, 15+x-1, 10+y-1, 2);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etsclull)
+            fprintf(tw, "Scrollbar: %ld up/left line\n", er.sclulid);
+        if (er.etype == ami_etscldrl)
+            fprintf(tw, "Scrollbar: %ld down/right line\n", er.scldrid);
+        if (er.etype == ami_etsclulp)
+            fprintf(tw, "Scrollbar: %ld up/left page\n", er.sclupid);
+        if (er.etype == ami_etscldrp)
+            fprintf(tw, "Scrollbar: %ld down/right page\n", er.scldpid);
+        if (er.etype == ami_etsclpos) {
+
+            ami_scrollpos(tw, er.sclpid, er.sclpos); /* set new position for scrollbar */
+            fprintf(tw, "Scrollbar: %ld position set: %ld\n", er.sclpid, er.sclpos);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+
+    /* ************ Character scroll bar fat and skinny bars test ************** */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character scroll bar fat and skinny bars test\n");
+    fprintf(tw, "\n");
+    ami_scrollvertsiz(tw, &x, &y);
+    ami_scrollvert(tw, 10, 10, 10, 10+10, 1);
+    ami_scrollvert(tw, 12, 10, 20, 10+10, 3);
+    ami_scrollhorizsiz(tw, &x, &y);
+    ami_scrollhoriz(tw, 30, 10, 30+20, 10, 2);
+    ami_scrollhoriz(tw, 30, 12, 30+20, 20, 4);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etsclull)
+            fprintf(tw, "Scrollbar: %ld up/left line\n", er.sclulid);
+        if (er.etype == ami_etscldrl)
+            fprintf(tw, "Scrollbar: %ld down/right line\n", er.scldrid);
+        if (er.etype == ami_etsclulp)
+            fprintf(tw, "Scrollbar: %ld up/left page\n", er.sclupid);
+        if (er.etype == ami_etscldrp)
+            fprintf(tw, "Scrollbar: %ld down/right page\n", er.scldpid);
+        if (er.etype == ami_etsclpos) {
+
+            ami_scrollpos(tw, er.sclpid, er.sclpos); /* set new position for scrollbar */
+            fprintf(tw, "Scrollbar: %ld position set: %ld\n", er.sclpid, er.sclpos);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+    ami_killwidget(tw, 4);
+
+    /* ******************** Character number select box test ******************* */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character number select box test\n");
+    fprintf(tw, "\n");
+    ami_numselboxsiz(tw, 1, 10, &x, &y);
+    ami_numselbox(tw, 10, 10, 10+x-1, 10+y-1, 1, 10, 1);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etnumbox) fprintf(tw, "You selected: %ld\n", er.numbsl);
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* ************************* Character edit box test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character edit box test\n");
+    fprintf(tw, "\n");
+    ami_editboxsiz(tw, "Hi there, george", &x, &y);
+    ami_editbox(tw, 10, 10, 10+x-1, 10+y-1, 1);
+    ami_putwidgettext(tw, 1, "Hi there, george");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etedtbox) {
+
+            ami_getwidgettext(tw, 1, s, 100);
+            fprintf(tw, "You entered: %s\n", s);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* *********************** Character progress bar test ********************* */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character progress bar test\n");
+    fprintf(tw, "\n");
+    ami_progbarsiz(tw, &x, &y);
+    ami_progbar(tw, 10, 10, 10+x-1, 10+y-1, 1);
+    ami_timer(tw, 1, SECOND, TRUE);
+    prog = 1;
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_ettim) {
+
+            if (prog < 20) {
+
+                ami_progbarpos(tw, 1, LONG_MAX-((20-prog)*(LONG_MAX / 20)));
+                prog = prog+1; /* next progress value */
+
+            } else if (prog == 20) {
+
+                ami_progbarpos(tw, 1, LONG_MAX);
+                fprintf(tw, "Done !\n");
+                prog = 11;
+                ami_killtimer(tw, 1);
+
+            }
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* ************************* Character list box test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character list box test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "Note that it is normal for this box to not fill to exact\n");
+    fprintf(tw, "character cells.\n");
+    fprintf(tw, "\n");
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Blue");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Red");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Green");
+    sp->next = lp;
+    lp = sp;
+    ami_listboxsiz(tw, lp, &x, &y);
+    ami_listbox(tw, 10, 10, 10+x-1, 10+y-1, lp, 1);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etlstbox) {
+
+            switch (er.lstbsl) {
+
+                case 1: fprintf(tw, "You selected pa_green\n"); break;
+                case 2: fprintf(tw, "You selected pa_red\n"); break;
+                case 3: fprintf(tw, "You selected pa_blue\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n");
+
+            }
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* ************************* Character dropdown box test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character dropdown box test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "Note that it is normal for this box to not fill to exact\n");
+    fprintf(tw, "character cells.\n");
+    fprintf(tw, "\n");
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("dog");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("cat");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("bird");
+    sp->next = lp;
+    lp = sp;
+    ami_dropboxsiz(tw, lp, &cx, &cy, &ox, &oy);
+    ami_dropbox(tw, 10, 10, 10+ox-1, 10+oy-1, lp, 1);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etdrpbox) {
+
+            switch (er.drpbsl) {
+
+                case 1: fprintf(tw, "You selected Bird\n"); break;
+                case 2: fprintf(tw, "You selected Cat\n"); break;
+                case 3: fprintf(tw, "You selected Dog\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n");
+
+            }
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* ******************* Character dropdown edit box test ******************** */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character dropdown edit box test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "Note that it is normal for this box to not fill to exact\n");
+    fprintf(tw, "character cells.\n");
+    fprintf(tw, "\n");
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("corn");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("flower");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Tortillas");
+    sp->next = lp;
+    lp = sp;
+    ami_dropeditboxsiz(tw, lp, &cx, &cy, &ox, &oy);
+    ami_dropeditbox(tw, 10, 10, 10+ox-1, 10+oy-1, lp, 1);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etdrebox) {
+
+            ami_getwidgettext(tw, 1, s, 100);
+            fprintf(tw, "You selected: %s\n", s);
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+
+    /* ************************* Character slider test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character slider test\n");
+    ami_slidehorizsiz(tw, &x, &y);
+    x = 20;
+    ami_slidehoriz(tw, 10, 10, 10+x-1, 10+y-1, 10, 1);
+    ami_slidehoriz(tw, 10, 20, 10+x-1, 20+y-1, 0, 2);
+    ami_slidevertsiz(tw, &x, &y);
+    y = 10;
+    ami_slidevert(tw, 40, 10, 40+x-1, 10+y-1, 10, 3);
+    ami_slidevert(tw, 50, 10, 50+x-1, 10+y-1, 0, 4);
+    fprintf(tw, "Bottom and right sliders should not have tick marks\n");
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etsldpos)
+            fprintf(tw, "Slider id: %ld position: %ld\n", er.sldpid, er.sldpos);
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+    ami_killwidget(tw, 4);
+
+    /* ************************* Character tab bar test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character tab bar test\n");
+    fprintf(tw, "\n");
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Right");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Left");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_totop, 20, 2, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 15, 3, 15+x-1, 3+y-1, lp, ami_totop, 1);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Bottom");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Top");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_toright, 4, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 37, 7, 37+x-1, 7+y-1, lp, ami_toright, 2);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Right");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Left");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_tobottom, 20, 2, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 15, 19, 15+x-1, 19+y-1, lp, ami_tobottom, 3);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Bottom");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Top");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_toleft, 4, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 5, 7, 5+x-1, 7+y-1, lp, ami_toleft, 4);
+
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_ettabbar) {
+
+            if (er.tabid == 1) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Top bar: You selected Left\n"); break;
+                case 2: fprintf(tw, "Top bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Top bar: You selected Right\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 2) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Right bar: You selected Top\n"); break;
+                case 2: fprintf(tw, "Right bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Right bar: You selected Bottom\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 3) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Bottom bar: You selected Left\n"); break;
+                case 2: fprintf(tw, "Bottom bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Bottom bar: You selected right\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 4) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Left bar: You selected Top\n"); break;
+                case 2: fprintf(tw, "Left bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Left bar: You selected Bottom\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else fprintf(tw, "!!! Bad tab id !!!\n");
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+    ami_killwidget(tw, 4);
+
+    /* ************************* Character overlaid tab bar test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Character overlaid tab bar test\n");
+    fprintf(tw, "\n");
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Right");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Left");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_totop, 30, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 20-ox, 7-oy, 20+x-ox-1, 7+y-oy-1, lp, ami_totop, 1);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Bottom");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Top");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_toright, 30, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 20-ox, 7-oy, 20+x-ox-1, 7+y-oy-1, lp, ami_toright, 2);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Right");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Left");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_tobottom, 30, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 20-ox, 7-oy, 20+x-ox-1, 7+y-oy-1, lp, ami_tobottom, 3);
+
+    lp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    lp->str = str("Bottom");
+    lp->next = NULL;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Center");
+    sp->next = lp;
+    lp = sp;
+    sp = (ami_strptr)imalloc(sizeof(ami_strrec));
+    sp->str = str("Top");
+    sp->next = lp;
+    lp = sp;
+    ami_tabbarsiz(tw, ami_toleft, 30, 12, &x, &y, &ox, &oy);
+    ami_tabbar(tw, 20-ox, 7-oy, 20+x-ox-1, 7+y-oy-1, lp, ami_toleft, 4);
+
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_ettabbar) {
+
+            if (er.tabid == 1) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Top bar: You selected Left\n"); break;
+                case 2: fprintf(tw, "Top bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Top bar: You selected Right\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 2) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Right bar: You selected Top\n"); break;
+                case 2: fprintf(tw, "Right bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Right bar: You selected Bottom\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 3) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Bottom bar: You selected Left\n"); break;
+                case 2: fprintf(tw, "Bottom bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Bottom bar: You selected right\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else if (er.tabid == 4) switch (er.tabsel) {
+
+                case 1: fprintf(tw, "Left bar: You selected Top\n"); break;
+                case 2: fprintf(tw, "Left bar: You selected Center\n"); break;
+                case 3: fprintf(tw, "Left bar: You selected Bottom\n"); break;
+                default: fprintf(tw, "!!! Bad select number !!!\n"); break;
+
+            } else fprintf(tw, "!!! Bad tab id !!!\n");
+
+        }
+        if (er.etype == ami_etterm) longjmp(terminate_buf, 1);
+
+    } while (er.etype != ami_etenter);
+    ami_killwidget(tw, 1);
+    ami_killwidget(tw, 2);
+    ami_killwidget(tw, 3);
+    ami_killwidget(tw, 4);
+
+    /* ************************* Alert test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Alert test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be an pa_alert dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    ami_alert("This is an important message", "There has been an event !\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "Alert dialog should have completed now\n");
+    waitnext();
+
+    /* ************************* Color query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Color query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be an color query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    fprintf(tw, "The color pa_white should be the default selection\n");
+    r = LONG_MAX;
+    g = LONG_MAX;
+    b = LONG_MAX;
+    ami_querycolor(&r, &g, &b);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Colors are: red: %ld green: %ld blue: %ld\n", r, g, b);
+    waitnext();
+
+    /* ************************* Open file query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Open file query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be an open file query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    fprintf(tw, "The dialog should have \"myfile.txt\" as the default filename\n");
+    strcpy(s, "myfile.txt");
+    ami_queryopen(s, 100);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Filename is: %s\n", s);
+    waitnext();
+
+    /* ************************* Save file query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Save file query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be an save file query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    fprintf(tw, "The dialog should have \"myfile.txt\" as the default filename\n");
+    strcpy(s, "myfile.txt");
+    ami_querysave(s, 100);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Filename is: %s\n", s);
+    waitnext();
+
+    /* ************************* Find query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Find query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be a find query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    fprintf(tw, "The dialog should have \"mystuff\" as the default search string\n");
+    strcpy(s, "mystuff");
+    optf = 0;
+    ami_queryfind(s, 100, &optf);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Search string is: \"%s\"\n", s);
+    if (BIT(ami_qfncase)&optf) fprintf(tw, "Case sensitive is on\n");
+    else fprintf(tw, "Case sensitive is off\n");
+    if (BIT(ami_qfnup)&optf) fprintf(tw, "Search up\n");
+    else fprintf(tw, "Search down\n");
+    if (BIT(ami_qfnre)&optf) fprintf(tw, "Use regular expression\n");
+    else fprintf(tw, "Use literal expression\n");
+    waitnext();
+
+    /* ************************* Find/replace query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Find/replace query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be a find/replace query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    fprintf(tw, "The dialog should have \"bark\" as the default search string\n");
+    fprintf(tw, "and should have \"sniff\" as the default replacement string\n");
+    strcpy(ss, "bark");
+    strcpy(rs, "sniff");
+    optfr = 0;
+    ami_queryfindrep (ss, 100, rs, 100, &optfr);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Search string is: \"%s\"\n", ss);
+    fprintf(tw, "Replace string is: \"%s\"\n", rs);
+    if (BIT(ami_qfrcase)&optfr) fprintf(tw, "Case sensitive is on\n");
+    else fprintf(tw, "Case sensitive is off\n");
+    if (BIT(ami_qfrup)&optfr) fprintf(tw, "Search/replace up\n");
+    else fprintf(tw, "Search/replace down\n");
+    if (BIT(ami_qfrre)&optfr) fprintf(tw, "Regular expressions are on\n");
+    else fprintf(tw, "Regular expressions are off\n");
+    if (BIT(ami_qfrfind)&optfr) fprintf(tw, "Mode is find\n");
+    else fprintf(tw, "Mode is find/replace\n");
+    if (BIT(ami_qfrallfil)&optfr) fprintf(tw, "Mode is find/replace all in file\n");
+    else fprintf(tw, "Mode is find/replace first in file\n");
+    if (BIT(ami_qfralllin)&optfr) fprintf(tw, "Mode is find/replace all on line(s)\n");
+    else fprintf(tw, "Mode is find/replace first on line(s)\n");
+    waitnext();
+
+    /* ************************* Font query test ************************ */
+
+    setframe();
+
+    fprintf(tw, "\f");
+    fprintf(tw, "Font query test\n");
+    fprintf(tw, "\n");
+    fprintf(tw, "There should be a font query dialog\n");
+    fprintf(tw, "Both the dialog and this window should be fully reactive\n");
+    /* A character terminal has one font at one size, so the dialog offers
+       the colors and the effects it can present; the font and size come
+       back as they went in. */
+    fc = 1;
+    fs = 1;
+    fr = 0; /* set foreground to black */
+    fg = 0;
+    fb = 0;
+    br = LONG_MAX; /* set background to white */
+    bg = LONG_MAX;
+    bb = LONG_MAX;
+    fe = 0;
+    ami_queryfont(tw, &fc, &fs, &fr, &fg, &fb, &br, &bg, &bb, &fe);
+    fprintf(tw, "\n");
+    fprintf(tw, "Dialog should have completed now\n");
+    fprintf(tw, "Font code: %ld\n", fc);
+    fprintf(tw, "Font size: %ld\n", fs);
+    fprintf(tw, "Foreground color: Red: %ld Green: %ld Blue: %ld\n", fr, fg, fb);
+    fprintf(tw, "Background color: Red: %ld Green: %ld Blue: %ld\n", br, bg, bb);
+    if (BIT(ami_qfteblink)&fe) fprintf(tw, "Blink\n");
+    if (BIT(ami_qftereverse)&fe) fprintf(tw, "Reverse\n");
+    if (BIT(ami_qfteunderline)&fe) fprintf(tw, "Underline\n");
+    if (BIT(ami_qftesuperscript)&fe) fprintf(tw, "Superscript\n");
+    if (BIT(ami_qftesubscript)&fe) fprintf(tw, "Subscript\n");
+    if (BIT(ami_qfteitalic)&fe) fprintf(tw, "Italic\n");
+    if (BIT(ami_qftebold)&fe) fprintf(tw, "Bold\n");
+    if (BIT(ami_qftestrikeout)&fe) fprintf(tw, "Strikeout\n");
+    if (BIT(ami_qftestandout)&fe) fprintf(tw, "Standout\n");
+    if (BIT(ami_qftecondensed)&fe) fprintf(tw, "Condensed\n");
+    if (BIT(ami_qfteextended)&fe) fprintf(tw, "Extended\n");
+    if (BIT(ami_qftexlight)&fe) fprintf(tw, "Xlight\n");
+    if (BIT(ami_qftelight)&fe) fprintf(tw, "Light\n");
+    if (BIT(ami_qftexbold)&fe) fprintf(tw, "Xbold\n");
+    if (BIT(ami_qftehollow)&fe) fprintf(tw, "Hollow\n");
+    if (BIT(ami_qfteraised)&fe) fprintf(tw, "Raised\n");
+    waitnext();
+
+    terminate:;
+
+    fputc('\f', tw);
+    fprintf(tw, "Test complete\n");
+
+}


### PR DESCRIPTION
## Summary

Two arcs in one branch. First, `widget_testc`: the widget test applied to the character mode window manager (managerc over an unmodified terminal), the way `management_testc` does for the management test — the root window is the desktop, all testing applies to an 80x25 child window, the eighteen graphical sections dropped and the twenty six character sections kept. Second, everything the test turned up, which grew into a full overhaul of the widgets' feedback and the dialogs.

## The test

Same plan as `management_testc`: root as desktop, an 80x25 child test window, the first screen giving the user a chance to arrange things. Covers buttons, checkboxes, radio buttons, group boxes, backgrounds, the four scroll bar tests, number select, edit box, progress bar, list box, dropdown, dropdown edit, slider, tab bar and overlaid tab bar, plus all six dialogs. Graphical-only pieces with no character meaning are dropped: the widget background color constant, background invisible, and the ruled character grid.

## Widget behavior

- Disabled widgets show grey, through the same cell attribute as disabled menu items.
- Hover highlight extends from the frame to widgets, per part: scroll bar arrows, thumb and paging runs; number select's - and + cells; list, popup, menu and tab entries; the drop edit box's arrow versus edit area. Dead parts and disabled widgets take no highlight.
- The number select box takes typed digits, with over-range entry starting a new number, backspace, minus, and clamping on enter.
- Sliders draw their tick marks from the mark count.
- List boxes scroll: offset under the draw, click and arrows, with the arrows keeping the selection shown.
- Widget faces never show the hardware cursor (it rode the scroll bar thumb), and face text clips at the face edge.
- A drop box opens on the first click: the focusing click's fronting was burying the fresh popup, and popups float over everything.

## Dialogs

A dialog is a mini-program: `dlgloop` gained a layout callback, an event hook, self-answering checkboxes, and window-id discipline throughout so dialogs nest on the one shared event queue.

- Complete framed windows that ignore sizing: bars draw, drags and maximize do nothing, hover skips the dead parts. No dialog shows a cursor.
- **Choose color** holds a full 24 bit color: marked-off centered header, preset list, bordered exact swatch, R/G/B sliders with readouts, and a luminosity slider running black to white holding the hue. Starts on the color passed in; returns full scale components.
- **Open/save file** is a browser: path across the top, directories pane with dot-dot, files pane, a scroll bar each, name field at the bottom. Browsing elsewhere returns the full path; picking where it opened returns the bare name.
- **Find / find-replace** option boxes check and uncheck, and the bits read back from what was set.
- **Font** shows its choices as themselves: color names in their colors (white grounded on black), effect names in their effects, an exact swatch per color row, and an `rgb` button opening the color query over it for a 24 bit pick.

## Under the hood

- The cell model carries full color: a cell is a primary code or a flag-marked encoded 24 bit rgb value. The full color calls store exactly (primaries collapse to their codes, keeping run batching and the common paths identical); the display side decodes through the full color vector; the grey blend takes both.
- Widget faces can carry per-entry colors and a persistent attribute set — internal fields, no new API.
- A new window starts with no attributes: creation was copying the root emission cache (whatever attribute the terminal was last left on) into the window, latent until the effect faces made it visible as blinking buttons and a black reversed dialog.

## Verification

Every feature and fix was driven blind through a pty/pyte harness — per-cell colors, attributes, truecolor swatches, scroll positions, nested dialog flows, and returned values checked exactly — and both full test walks (`widget_testc`, `management_testc`) pass end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to
