### PR TITLE
stdio: static configuration overrides with hidden visibility; no special headers for users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,15 +325,34 @@ ifeq ($(STDIO_SOURCE),stdio)
     # In local link, we need to get stdio.h from local directory
     #
     CFLAGS +=-Ilibc
-    ifneq ($(OSTYPE),Windows_NT)
-    ifneq ($(OSTYPE),Darwin)
-        # Linux and FreeBSD use X11/libXau which accesses FILE* internals
-        # directly (backdoor access). STDIO_BYPASS prevents petit_ami from
-        # exporting fopen/fclose etc. as global symbols, so libXau always
-        # uses the real system fopen and a proper FILE*. Mac OS X is exempt
-        # because it uses Cocoa/CoreGraphics and does not involve libXau.
+    ifeq ($(OSTYPE),FreeBSD)
+        # FreeBSD keeps the coined-namespace bypass: its libc is not
+        # glibc, and the override scheme below is built on glibc facts.
         CFLAGS += -DSTDIO_BYPASS
-    endif
+    else ifeq ($(OSTYPE),Windows_NT)
+        # Windows overrides at link time, as always
+    else ifeq ($(OSTYPE),Darwin)
+        # Mac OS X overrides at link time, as always
+    else ifeq ($(LINK_TYPE),dynamic)
+        # The dynamic configuration keeps the STDIO_BYPASS coined
+        # namespace: petit ami's stdio lives beside glibc's under
+        # stdio_ names, paired with programs through the local header.
+        CFLAGS += -DSTDIO_BYPASS
+    else
+        # The static configuration runs stdio in override mode with
+        # hidden dynamic visibility (see the linux/stdio.o rule). The
+        # program and the petit ami archives resolve the real stdio
+        # names to petit ami's stdio at static link -- a program needs
+        # no special headers, printf lands in the window -- while the
+        # symbols stay out of the dynamic table, so every shared
+        # library (X, ALSA, and glibc's own NSS lookups, whose FILEs
+        # glibc processes internally) binds glibc's stdio and runs
+        # wholly on glibc FILEs. The two stdio worlds split at the
+        # dynamic boundary, which no FILE crosses.
+        # tools/stdioaudit lists a binary's stdio surface if a new
+        # system needs checking. Switching LINK_TYPE requires a clean
+        # build: the modes compile stdio call sites differently.
+        STDIOVIS = -fvisibility=hidden
     endif
 endif
 
@@ -687,7 +706,7 @@ endif
 # Linux library components
 #
 linux/stdio.o: libc/stdio.c libc/stdio.h Makefile
-	$(CC) $(CFLAGS) -c libc/stdio.c -o linux/stdio.o
+	$(CC) $(CFLAGS) $(STDIOVIS) -c libc/stdio.c -o linux/stdio.o
 
 linux/services.o: linux/services.c include/services.h Makefile
 	$(CC) $(CFLAGS) -c linux/services.c -o linux/services.o

--- a/curses/Makefile
+++ b/curses/Makefile
@@ -20,9 +20,11 @@ ROOT     = ..
 BINDIR   = $(ROOT)/bin
 CC       = gcc
 
-# flags for building the curses adapter (needs Ami stdio interception)
+# flags for building the curses adapter (needs Ami stdio interception).
+# Matches the main build: Linux runs stdio in override mode, no
+# STDIO_BYPASS coined namespace.
 AMIFLAGS = -g3 -I$(ROOT)/apis -I$(ROOT)/include -I$(ROOT)/libc \
-           -I/usr/include/freetype2 -I/usr/include/libpng16 -DSTDIO_BYPASS
+           -I/usr/include/freetype2 -I/usr/include/libpng16
 
 # flags for building program source (standard libc, no Ami stdio override)
 CFLAGS   = -g3 -I$(ROOT)/apis -D'__COPYRIGHT(x)=' -D'__RCSID(x)='

--- a/libc/stdio.c
+++ b/libc/stdio.c
@@ -4967,3 +4967,340 @@ static void deinit_stdio()
     fflush((FILE *)NULL); /* flush all buffered output streams */
 
 }
+
+/*******************************************************************************
+
+Override-mode compatibility surface (Linux)
+
+In override mode (no STDIO_BYPASS) this module's definitions preempt
+glibc's for every caller in the process, foreign libraries included. Any
+stdio entry point a foreign library imports that this module does not
+define falls through to glibc, which then receives a petit ami FILE and
+aborts on its vtable validation. This section closes the audited gaps
+(tools/stdioaudit lists a binary's imports against what is provided):
+
+- the fortified variants (__fprintf_chk and kin) that FILE-touching
+  callers compiled with _FORTIFY_SOURCE import, forwarded to the plain
+  implementations;
+- the large-file aliases (fopen64 and kin), identities on a 64 bit
+  system;
+- the _unlocked family, aliases here since this stdio does not lock;
+- the old glibc internal entry points (_IO_getc and kin) that binaries
+  compiled against older glibc headers call;
+- getline/getdelim and popen/pclose (libasound imports popen),
+  implemented;
+- loud failures for the FILE-creating entries that are not implemented
+  (fmemopen and kin), so a gap diagnoses itself in one line instead of
+  a crash inside glibc.
+
+*******************************************************************************/
+
+#if !defined(STDIO_BYPASS) && defined(__linux__)
+
+#include <sys/wait.h>
+
+/* wint_t/wchar_t without wchar.h, which would drag glibc's FILE in */
+typedef unsigned int wint_t_;
+typedef int wchar_t_;
+#define wint_t wint_t_
+#define wchar_t wchar_t_
+
+/* minimal fopencookie type, matching glibc's shape for the stub */
+typedef struct {
+
+    void* read;
+    void* write;
+    void* seek;
+    void* close;
+
+} cookie_io_functions_t;
+
+/* fortified print family: the checking is glibc's affair; the calls
+   forward to the plain implementations */
+int __fprintf_chk(FILE* f, int flag, const char* fmt, ...)
+
+{
+
+    va_list ap;
+    int r;
+
+    va_start(ap, fmt);
+    r = vfprintf(f, fmt, ap);
+    va_end(ap);
+
+    return (r);
+
+}
+
+int __vfprintf_chk(FILE* f, int flag, const char* fmt, va_list ap)
+
+{
+
+    return (vfprintf(f, fmt, ap));
+
+}
+
+int __printf_chk(int flag, const char* fmt, ...)
+
+{
+
+    va_list ap;
+    int r;
+
+    va_start(ap, fmt);
+    r = vfprintf(stdout, fmt, ap);
+    va_end(ap);
+
+    return (r);
+
+}
+
+int __vprintf_chk(int flag, const char* fmt, va_list ap)
+
+{
+
+    return (vfprintf(stdout, fmt, ap));
+
+}
+
+char *__fgets_chk(char* s, size_t size, int n, FILE* f)
+
+{
+
+    if (size != (size_t)-1 && (size_t)n > size) n = size;
+
+    return (fgets(s, n, f));
+
+}
+
+size_t __fread_chk(void* p, size_t plen, size_t size, size_t n, FILE* f)
+
+{
+
+    return (fread(p, size, n, f));
+
+}
+
+size_t __fread_unlocked_chk(void* p, size_t plen, size_t size, size_t n,
+                            FILE* f)
+
+{
+
+    return (fread(p, size, n, f));
+
+}
+
+/* large file aliases: off_t is 64 bits on a 64 bit system, so these are
+   the plain calls under the names LFS-compiled callers import */
+FILE *fopen64(const char* fn, const char* mode) { return (fopen(fn, mode)); }
+FILE *freopen64(const char* fn, const char* mode, FILE* f)
+    { return (freopen(fn, mode, f)); }
+FILE *tmpfile64(void) { return (tmpfile()); }
+int fseeko(FILE* f, long off, int whence) { return (fseek(f, off, whence)); }
+long ftello(FILE* f) { return (ftell(f)); }
+int fseeko64(FILE* f, long off, int whence) { return (fseek(f, off, whence)); }
+long ftello64(FILE* f) { return (ftell(f)); }
+
+/* the unlocked family: this stdio does not lock, so they are the plain
+   calls */
+int getc_unlocked(FILE* f) { return (fgetc(f)); }
+int fgetc_unlocked(FILE* f) { return (fgetc(f)); }
+int putc_unlocked(int c, FILE* f) { return (fputc(c, f)); }
+int fputc_unlocked(int c, FILE* f) { return (fputc(c, f)); }
+char *fgets_unlocked(char* s, int n, FILE* f) { return (fgets(s, n, f)); }
+int fputs_unlocked(const char* s, FILE* f) { return (fputs(s, f)); }
+size_t fread_unlocked(void* p, size_t size, size_t n, FILE* f)
+    { return (fread(p, size, n, f)); }
+size_t fwrite_unlocked(const void* p, size_t size, size_t n, FILE* f)
+    { return (fwrite(p, size, n, f)); }
+int feof_unlocked(FILE* f) { return (feof(f)); }
+int ferror_unlocked(FILE* f) { return (ferror(f)); }
+void clearerr_unlocked(FILE* f) { clearerr(f); }
+int fileno_unlocked(FILE* f) { return (fileno(f)); }
+int fflush_unlocked(FILE* f) { return (fflush(f)); }
+
+/* old glibc internal entry points, from binaries compiled against older
+   glibc headers where getc and putc were macros over these */
+int _IO_getc(FILE* f) { return (fgetc(f)); }
+int _IO_putc(int c, FILE* f) { return (fputc(c, f)); }
+int __uflow(FILE* f) { return (fgetc(f)); }
+int __overflow(FILE* f, int c)
+    { return (c == EOF? fflush(f): fputc(c, f)); }
+
+/* line input */
+ssize_t getdelim(char** lineptr, size_t* n, int delim, FILE* f)
+
+{
+
+    size_t len = 0;
+    int c;
+
+    if (!lineptr || !n || !f) return (-1);
+    if (!*lineptr || !*n) {
+
+        *n = 128;
+        *lineptr = realloc(*lineptr, *n);
+        if (!*lineptr) return (-1);
+
+    }
+    for (;;) {
+
+        c = fgetc(f);
+        if (c == EOF) break;
+        if (len+2 > *n) {
+
+            *n *= 2;
+            *lineptr = realloc(*lineptr, *n);
+            if (!*lineptr) return (-1);
+
+        }
+        (*lineptr)[len++] = c;
+        if (c == delim) break;
+
+    }
+    (*lineptr)[len] = 0;
+
+    return (len? (ssize_t)len: -1);
+
+}
+
+ssize_t getline(char** lineptr, size_t* n, FILE* f)
+
+{
+
+    return (getdelim(lineptr, n, '\n', f));
+
+}
+
+/* piped commands over this stdio's own files (libasound imports popen) */
+static int popen_pids[FOPEN_MAX];
+
+FILE *popen(const char* command, const char* mode)
+
+{
+
+    int   fds[2];
+    int   pid;
+    int   rd = mode && mode[0] == 'r';
+    FILE* f;
+
+    if (pipe(fds) < 0) return (NULL);
+    pid = fork();
+    if (pid < 0) {
+
+        close(fds[0]);
+        close(fds[1]);
+
+        return (NULL);
+
+    }
+    if (!pid) { /* child: wire the pipe to the shell */
+
+        if (rd) dup2(fds[1], 1); else dup2(fds[0], 0);
+        close(fds[0]);
+        close(fds[1]);
+        execl("/bin/sh", "sh", "-c", command, (char*)NULL);
+        _exit(127);
+
+    }
+    close(rd? fds[1]: fds[0]);
+    f = fdopen(rd? fds[0]: fds[1], rd? "r": "w");
+    if (!f) close(rd? fds[0]: fds[1]);
+    else if (fileno(f) >= 0 && fileno(f) < FOPEN_MAX)
+        popen_pids[fileno(f)] = pid;
+
+    return (f);
+
+}
+
+int pclose(FILE* f)
+
+{
+
+    int fd = fileno(f);
+    int pid = fd >= 0 && fd < FOPEN_MAX? popen_pids[fd]: 0;
+    int status = -1;
+
+    if (fd >= 0 && fd < FOPEN_MAX) popen_pids[fd] = 0;
+    fclose(f);
+    if (pid > 0) while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
+
+    return (status);
+
+}
+
+/* the C99 scanf aliases, what modern compiles bind fscanf and scanf to */
+int __isoc99_fscanf(FILE* f, const char* fmt, ...)
+
+{
+
+    va_list ap;
+    int r;
+
+    va_start(ap, fmt);
+    r = vfscanf(f, fmt, ap);
+    va_end(ap);
+
+    return (r);
+
+}
+
+int __isoc99_vfscanf(FILE* f, const char* fmt, va_list ap)
+
+{
+
+    return (vfscanf(f, fmt, ap));
+
+}
+
+int __isoc99_scanf(const char* fmt, ...)
+
+{
+
+    va_list ap;
+    int r;
+
+    va_start(ap, fmt);
+    r = vfscanf(stdin, fmt, ap);
+    va_end(ap);
+
+    return (r);
+
+}
+
+int __isoc99_vscanf(const char* fmt, va_list ap)
+
+{
+
+    return (vfscanf(stdin, fmt, ap));
+
+}
+
+/* The FILE-creating entries not implemented fail in one loud line
+   rather than handing glibc a petit ami FILE (or the reverse) to crash
+   on. Implement them here if a library ever wants one. */
+static void stdio_noimp(const char* who)
+
+{
+
+    write(2, "petit_ami stdio: ", 17);
+    write(2, who, strlen(who));
+    write(2, " is not implemented\n", 20);
+    abort();
+
+}
+
+FILE *fmemopen(void* buf, size_t size, const char* mode)
+    { stdio_noimp("fmemopen"); return (NULL); }
+FILE *open_memstream(char** ptr, size_t* sizeloc)
+    { stdio_noimp("open_memstream"); return (NULL); }
+FILE *fopencookie(void* cookie, const char* mode, cookie_io_functions_t io)
+    { stdio_noimp("fopencookie"); return (NULL); }
+int fwide(FILE* f, int mode)
+    { stdio_noimp("fwide (wide character streams)"); return (0); }
+wint_t fgetwc(FILE* f)
+    { stdio_noimp("fgetwc (wide character streams)"); return (0); }
+wint_t fputwc(wchar_t c, FILE* f)
+    { stdio_noimp("fputwc (wide character streams)"); return (0); }
+
+#endif /* !STDIO_BYPASS && __linux__ */

--- a/tests/stdio_test.c
+++ b/tests/stdio_test.c
@@ -319,8 +319,12 @@ int main(void)
     if (strcmp(s, "42-hi") || n != 5) fails++;
 
     /* snprintf: output truncated to the size, always terminated, returns the
-       length that would have been written */
+       length that would have been written. The truncation is the test, so
+       the compiler's truncation warning does not apply. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     n = snprintf(s, 4, "%d-%s", 42, "hi");
+#pragma GCC diagnostic pop
     printf("test 164: \"%s\" n=%d s/b \"42-\" 5\n", s, n);
     if (strcmp(s, "42-") || n != 5) fails++;
 

--- a/tests/terminal_test.c
+++ b/tests/terminal_test.c
@@ -1212,7 +1212,7 @@ int main(int argc, char *argv[])
     for (y = 1; y <= ami_maxy(stdout); y++) {
 
         for (i = 1; i <= y-1; i++) printf("\t");
-        printf(">Tab %3d\n", y-1);
+        printf(">Tab %3ld\n", y-1);
 
     }
     prtcen(ami_maxy(stdout), "Tabbing test");

--- a/tools/stdioaudit
+++ b/tools/stdioaudit
@@ -1,0 +1,81 @@
+#!/bin/bash
+################################################################################
+#
+# Audit a binary's stdio surface against petit ami's stdio (override mode).
+#
+# In override mode (Linux default, no STDIO_BYPASS) petit ami's stdio
+# exports the real stdio names and the executable's symbols preempt
+# glibc's for every shared library in the process. That works exactly as
+# far as coverage does: a FILE-touching stdio function some library
+# imports that petit ami does not define falls through to glibc, which
+# then receives a petit ami FILE and aborts.
+#
+# This script lists, for a binary and every shared library it loads, the
+# imported stdio entry points that touch or create FILEs, and reports any
+# that petit ami's stdio does not provide. Silence is a pass.
+#
+# Execution:
+#
+#     tools/stdioaudit <binary> [<binary>...]
+#
+# Returns the number of binaries with gaps, so 0 means a pass.
+#
+# String-only entry points (sprintf, sscanf, the string _chk variants)
+# are glibc's to keep: they take no FILE and interpose harmlessly either
+# way, so they are not audited.
+#
+################################################################################
+
+# the FILE-touching and FILE-creating stdio surface worth auditing
+WATCH='fopen|fopen64|freopen|freopen64|fdopen|fclose|fcloseall|fflush|fflush_unlocked
+fread|fread_unlocked|fwrite|fwrite_unlocked|fgetc|fgetc_unlocked|fgets|fgets_unlocked
+fputc|fputc_unlocked|fputs|fputs_unlocked|getc|getc_unlocked|putc|putc_unlocked
+getchar|putchar|gets|puts|ungetc|getline|getdelim|getw|putw
+fseek|fseeko|fseeko64|ftell|ftello|ftello64|rewind|fgetpos|fgetpos64|fsetpos|fsetpos64
+feof|feof_unlocked|ferror|ferror_unlocked|clearerr|clearerr_unlocked|fileno|fileno_unlocked
+fprintf|printf|vfprintf|vprintf|fscanf|scanf|vfscanf|vscanf
+__fprintf_chk|__vfprintf_chk|__printf_chk|__vprintf_chk|__fgets_chk|__fgets_unlocked_chk
+__fread_chk|__fread_unlocked_chk|__isoc99_fscanf|__isoc99_scanf|__isoc99_vfscanf
+setvbuf|setbuf|setbuffer|setlinebuf|perror|tmpfile|tmpfile64|popen|pclose
+fmemopen|open_memstream|fopencookie|fwide|fgetwc|fputwc|fwprintf
+_IO_getc|_IO_putc|__uflow|__overflow|freadahead|fseterr'
+WATCH=$(echo "$WATCH" | tr '\n' '|' | sed 's/|$//')
+
+# what petit ami's stdio provides, from the object itself
+STDIOOBJ=$(dirname "$0")/../linux/stdio.o
+if [ ! -f "$STDIOOBJ" ]; then
+    echo "stdioaudit: $STDIOOBJ not built" >&2
+    exit 1
+fi
+PROVIDED=$(nm -g --defined-only "$STDIOOBJ" | awk '{print $3}' | sort -u)
+
+fails=0
+for BIN in "$@"; do
+
+    if [ ! -f "$BIN" ]; then
+        echo "$BIN: no such file" >&2
+        fails=$((fails+1))
+        continue
+    fi
+    # the binary and everything it loads
+    FILES="$BIN $(ldd "$BIN" 2>/dev/null | awk '/=>/ { print $3 }')"
+    GAPS=""
+    for F in $FILES; do
+        [ -f "$F" ] || continue
+        # imported stdio surface of this object
+        IMP=$(nm -D -u "$F" 2>/dev/null | awk '{print $NF}' | grep -xE "$WATCH" | sort -u)
+        [ -n "$IMP" ] || continue
+        # anything not provided by petit ami's stdio is a gap
+        MISSING=$(comm -23 <(echo "$IMP") <(echo "$PROVIDED"))
+        if [ -n "$MISSING" ]; then
+            GAPS="$GAPS$(basename $F): $(echo $MISSING | tr '\n' ' ')\n"
+        fi
+    done
+    if [ -n "$GAPS" ]; then
+        echo "$BIN: stdio coverage gaps:"
+        echo -e "$GAPS" | sed 's/^/    /'
+        fails=$((fails+1))
+    fi
+
+done
+exit $fails


### PR DESCRIPTION
## Summary

The static configuration runs stdio in **override mode with hidden dynamic visibility**, ending the requirement that programs pair with Petit-Ami through the local header. An external user writes:

```c
#include <stdio.h>            /* system header, nothing special */
int main(void) { printf("hello\n"); return 0; }
```

links `libami_term.a`, and printf lands in the window. Verified exactly so.

## The design

Petit-Ami's stdio compiles with `-fvisibility=hidden` in the static configuration and exports the **real names**. The program and the archives resolve those names at static link -- interposition where it is sound, inside the executable -- while the symbols stay out of the dynamic table, so **every shared library binds glibc's stdio** and runs wholly on glibc FILEs. The two stdio worlds split at the dynamic boundary, which no FILE crosses.

## Why the boundary matters

Full process-wide interposition was tried first, on the strength of an audit showing the era that motivated STDIO_BYPASS has passed: no current library imports `_IO_*` entries or `*_unlocked` variants, none touches FILE internals -- libXau's famous "backdoor" is gone from modern binaries -- and X, fontconfig and the widget stack all ran correctly on Petit-Ami FILEs. It died on glibc itself: **NSS lookups** (`getaddrinfo`, `getgrnam_r`) open `/etc/hosts` and `/etc/group` through the public, interposable `fopen` -- receiving Petit-Ami FILEs -- and then parse them with glibc-internal helpers (`__libc_readline_unlocked`) that no interposition reaches. Network name lookup and ALSA's dmix both segfaulted. Hidden visibility keeps foreign and internal glibc code entirely in glibc's world.

## The widened surface

What an executable's own code may bind is now covered: the fortified FILE variants (`__fprintf_chk` and kin, which anything compiled with `_FORTIFY_SOURCE` imports), the C99 scanf aliases (`__isoc99_fscanf`...), the large-file aliases (`fopen64`...), the `_unlocked` family, the old glibc-internal entries (`_IO_getc`...), `getline`/`getdelim` and `popen`/`pclose` implemented, and loud one-line failures for the FILE-creating entries not implemented (`fmemopen` and kin) so a gap diagnoses itself instead of crashing inside glibc. **`tools/stdioaudit`** lists any binary's imported stdio surface against what is provided; it found the `__isoc99_*` and fortify gaps during development.

## Unchanged

The dynamic configuration keeps the STDIO_BYPASS coined namespace exactly as it was; FreeBSD keeps it too (the scheme is built on glibc facts). Switching LINK_TYPE now requires a clean build, since the modes compile stdio call sites differently.

## Verification

Both character walks, regress 3/3 (network_test exercising the once-crashing getaddrinfo path), playwave through ALSA dmix (the once-crashing getgrnam path), test_demo clicking and kicking under Xvfb, the plain-stdio external-user program running through the terminal handler, `objdump -T` confirming zero exported stdio symbols, stdioaudit clean over the test suite, and the dynamic configuration rebuilt from clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to
