### PR TITLE
A spreadsheet on the graphics API, and the widget work it found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1670,7 +1670,7 @@ ball6: $(GLIBSD) graph_programs/ball6.c
 # Spreadsheet: grid, formulas, menus, file dialogs
 #
 spreadsheet: $(GLIBSD) graph_programs/spreadsheet.c
-	$(CC) $(CFLAGS) graph_programs/spreadsheet.c $(GLIBS) -o bin/spreadsheet
+	$(CC) $(CFLAGS) graph_programs/spreadsheet.c $(GLIBS) -lz -o bin/spreadsheet
 	
 #
 # Moving lines dazzlers

--- a/Makefile
+++ b/Makefile
@@ -1665,6 +1665,12 @@ ball5: $(GLIBSD) graph_programs/ball5.c
 	
 ball6: $(GLIBSD) graph_programs/ball6.c
 	$(CC) $(CFLAGS) graph_programs/ball6.c $(GLIBS) -o bin/ball6
+
+#
+# Spreadsheet: grid, formulas, menus, file dialogs
+#
+spreadsheet: $(GLIBSD) graph_programs/spreadsheet.c
+	$(CC) $(CFLAGS) graph_programs/spreadsheet.c $(GLIBS) -o bin/spreadsheet
 	
 #
 # Moving lines dazzlers

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -585,9 +585,24 @@ sheet reflows on a resize or a column width change.
 
 *******************************************************************************/
 
+/* A fraction as a ratio of LONG_MAX, which is the full scale the bars
+   work in. In integers: LONG_MAX is not representable as a double, so
+   the obvious double form rounds up to one past it, and the cast back
+   overflows to a negative -- which the scroll bar rejects as an invalid
+   position, exactly at the end of the sheet, where num reaches den. */
+static long fullscale(long num, long den)
+
+{
+
+    if (den < 1 || num <= 0) return (0);
+    if (num >= den) return (LONG_MAX);
+
+    return (LONG_MAX/den*num); /* num < den, so this cannot overflow */
+
+}
+
 /* Set a scroll bar from the view: the thumb is the visible share of the
-   sheet, at the scrolled position. The bars work in ratios of LONG_MAX,
-   as the rest of the API does. */
+   sheet, at the scrolled position. */
 static void setbar(long id, long org, long vis, long total)
 
 {
@@ -595,9 +610,8 @@ static void setbar(long id, long org, long vis, long total)
     long max = total-vis;
 
     if (max < 1) max = 1;
-    if (vis > total) vis = total;
-    ami_scrollsiz(stdout, id, (long)((double)LONG_MAX*vis/total));
-    ami_scrollpos(stdout, id, (long)((double)LONG_MAX*org/max));
+    ami_scrollsiz(stdout, id, fullscale(vis, total));
+    ami_scrollpos(stdout, id, fullscale(org, max));
 
 }
 
@@ -606,9 +620,10 @@ static long barcell(long pos, long travel)
 
 {
 
-    if (travel < 1) return (0);
+    if (travel < 1 || pos <= 0) return (0);
+    if (pos >= LONG_MAX) return (travel);
 
-    return ((long)((double)travel*pos/LONG_MAX+0.5));
+    return ((long)((double)travel*((double)pos/LONG_MAX)+0.5));
 
 }
 

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -933,10 +933,20 @@ int main(int argc, char* argv[])
         ami_event(stdin, &er);
         switch (er.etype) {
 
-            case ami_etredraw:
             case ami_etresize:
+                /* The window is buffered, so its measurements are the
+                   buffer's: without this the sheet kept the size it
+                   started at while the window grew around it. The
+                   buffer follows the window, and everything after is
+                   derived from the new measurements. */
+                ami_sizbufg(stdout, er.rszxg, er.rszyg);
                 layout();
-                follow();
+                clamporg();
+                drawall();
+                break;
+
+            case ami_etredraw:
+                layout();
                 drawall();
                 break;
 

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -1944,8 +1944,12 @@ int main(int argc, char* argv[])
 
                     case AMI_SMOPEN:
                         fn[0] = 0;
+                        if (diag) fprintf(stderr, "queryopen: calling\n");
                         ami_queryopen(fn, sizeof(fn));
+                        if (diag) fprintf(stderr, "queryopen: returned [%s]\n",
+                                          fn);
                         if (*fn) { loadsheet(fn); layout(); drawall(); }
+                        if (diag) fprintf(stderr, "queryopen: loaded\n");
                         break;
 
                     case AMI_SMSAVE:

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -14,6 +14,8 @@
 * Using it:                                                                    *
 *                                                                              *
 * Click a cell, or move with the arrow keys, page up and down, home and end.   *
+* The scroll bars at the right and the bottom move the view over the whole      *
+* sheet, which is 78 columns (A through BZ) by 1000 rows.                       *
 * Type to enter: digits and text go in as typed, and a leading = makes a       *
 * formula. Enter commits and steps down, tab commits and steps right, escape   *
 * abandons the entry. Delete or backspace on a settled cell clears it.         *
@@ -67,6 +69,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <limits.h>
 
 #include <localdefs.h>
 #include <graphics.h>
@@ -74,12 +77,18 @@
 #define OFF 0
 #define ON  1
 
-#define COLS     26   /* columns, A through Z */
-#define ROWS     200  /* rows */
+#define COLS     78   /* columns, A through Z, AA through BZ */
+/* the sheet is fixed at these bounds; the window shows what fits and the
+   scroll bars move the view over the rest */
+#define ROWS     1000 /* rows */
 #define CELLEN   80   /* longest cell contents */
 #define COLDIG   9    /* column width in digits of the display font */
 #define HDRDIG   4    /* row header width in digits */
 #define MAXNEST  32   /* deepest formula evaluation, catches cycles */
+
+/* the scroll bars */
+#define SBVERT   1 /* vertical scroll bar widget id */
+#define SBHORIZ  2 /* horizontal scroll bar widget id */
 
 /* menu ids of our own, after the standard ones */
 #define MENUWIDER  (AMI_SMMAX+1) /* wider columns */
@@ -103,7 +112,10 @@ static long   curx, cury;      /* the current cell, 0 based */
 static long   orgx, orgy;      /* top left cell shown, 0 based */
 static long   colw, rowh;      /* cell size in pixels */
 static long   hdrw, hdrh;      /* header sizes in pixels */
-static long   cellx, celly;    /* cells that fit in the client area */
+static long   cellx, celly;    /* whole cells that fit in the grid area */
+static long   gridx0, gridy0;  /* the grid area, in pixels */
+static long   gridx1, gridy1;
+static long   sbw, sbh;        /* scroll bar thickness */
 static long   coldig = COLDIG; /* column width in digits */
 static char   entry[CELLEN];   /* the entry under construction */
 static int    entering;        /* an entry is being typed */
@@ -126,12 +138,25 @@ Cell naming
 
 *******************************************************************************/
 
+/* the name of a column, as A or AB */
+static void colnam(long x, char* s)
+
+{
+
+    if (x < 26) sprintf(s, "%c", (int)('A'+x));
+    else sprintf(s, "%c%c", (int)('A'+x/26-1), (int)('A'+x%26));
+
+}
+
 /* the name of a cell, as A1 */
 static void cellnam(long x, long y, char* s)
 
 {
 
-    sprintf(s, "%c%ld", (int)('A'+x), y+1);
+    char c[4];
+
+    colnam(x, c);
+    sprintf(s, "%s%ld", c, y+1);
 
 }
 
@@ -147,6 +172,12 @@ static int cellref(long* x, long* y)
     if (!isalpha((unsigned char)*pp)) return (FALSE);
     *x = toupper((unsigned char)*pp)-'A';
     pp++;
+    if (isalpha((unsigned char)*pp)) { /* a two letter column */
+
+        *x = (*x+1)*26+(toupper((unsigned char)*pp)-'A');
+        pp++;
+
+    }
     if (!isdigit((unsigned char)*pp)) { pp = sp; return (FALSE); }
     while (isdigit((unsigned char)*pp)) r = r*10+(*pp++-'0');
     *y = r-1;
@@ -550,7 +581,22 @@ sheet reflows on a resize or a column width change.
 
 *******************************************************************************/
 
-/* recompute the geometry from the window and the font */
+/* set a scroll bar from the view: the thumb is the visible share of the
+   sheet, at the scrolled position */
+static void setbar(long id, long org, long vis, long total)
+
+{
+
+    long max = total-vis;
+
+    if (max < 1) max = 1;
+    ami_scrollsiz(stdout, id, (long)((double)INT_MAX*vis/total));
+    ami_scrollpos(stdout, id, (long)((double)INT_MAX*org/max));
+
+}
+
+/* recompute the geometry from the window and the font, place the scroll
+   bars, and set them from the view */
 static void layout(void)
 
 {
@@ -559,11 +605,27 @@ static void layout(void)
     rowh = ami_chrsizy(stdout)+4;
     hdrw = ami_strsiz(stdout, "0")*HDRDIG;
     hdrh = rowh; /* the column header row */
-    /* the entry line sits above the grid, one row tall with a margin */
-    cellx = (ami_maxxg(stdout)-hdrw)/colw;
-    celly = (ami_maxyg(stdout)-hdrh-rowh*2)/rowh;
+    /* the grid area: below the entry line and the column headers, and
+       inside the scroll bars */
+    gridx0 = hdrw;
+    gridy0 = rowh*2+hdrh;
+    gridx1 = ami_maxxg(stdout)-sbw;
+    gridy1 = ami_maxyg(stdout)-sbh;
+    if (gridx1 < gridx0+colw) gridx1 = gridx0+colw;
+    if (gridy1 < gridy0+rowh) gridy1 = gridy0+rowh;
+    /* whole cells that fit, which is what a page moves by */
+    cellx = (gridx1-gridx0)/colw;
+    celly = (gridy1-gridy0)/rowh;
     if (cellx < 1) cellx = 1;
     if (celly < 1) celly = 1;
+    /* the bars line the grid area: vertical at the right of it,
+       horizontal under it, each spanning the grid */
+    ami_poswidgetg(stdout, SBVERT, gridx1+1, gridy0);
+    ami_sizwidgetg(stdout, SBVERT, sbw, gridy1-gridy0);
+    ami_poswidgetg(stdout, SBHORIZ, gridx0, gridy1+1);
+    ami_sizwidgetg(stdout, SBHORIZ, gridx1-gridx0, sbh);
+    setbar(SBVERT, orgy, celly, ROWS);
+    setbar(SBHORIZ, orgx, cellx, COLS);
 
 }
 
@@ -586,8 +648,9 @@ static void drawcell(long x, long y)
     char s[CELLEN];
     long tw;
 
-    if (x < orgx || x >= orgx+cellx || y < orgy || y >= orgy+celly) return;
+    if (x < orgx || y < orgy) return;
     cellpos(x, y, &px, &py);
+    if (px > gridx1 || py > gridy1) return;
     /* the cell face: the current cell is marked */
     if (x == curx && y == cury) ami_fcolor(stdout, ami_cyan);
     else ami_fcolor(stdout, ami_white);
@@ -627,6 +690,9 @@ static void drawall(void)
     char s[CELLEN+40];
     char nam[16];
 
+    long nx = (gridx1-gridx0+colw-1)/colw+1; /* cells to cover the area */
+    long ny = (gridy1-gridy0+rowh-1)/rowh+1;
+
     ami_fcolor(stdout, ami_white);
     ami_frect(stdout, 1, 1, ami_maxxg(stdout), ami_maxyg(stdout));
     /* the entry line: the current cell and what it holds */
@@ -638,49 +704,65 @@ static void drawall(void)
     ami_cursorg(stdout, 2, 2);
     fprintf(stdout, "%s", s);
     ami_line(stdout, 1, rowh*2-2, ami_maxxg(stdout), rowh*2-2);
-    /* the column headers */
+    /* the header bands */
     ami_fcolor(stdout, ami_yellow);
-    ami_frect(stdout, 1, rowh*2, ami_maxxg(stdout), rowh*2+hdrh-1);
-    ami_frect(stdout, 1, rowh*2, hdrw-1, ami_maxyg(stdout));
+    ami_frect(stdout, 1, rowh*2, gridx1, rowh*2+hdrh-1);
+    ami_frect(stdout, 1, rowh*2, hdrw-1, gridy1);
     ami_fcolor(stdout, ami_black);
-    for (x = orgx; x < orgx+cellx && x < COLS; x++) {
+    /* the column headers */
+    for (x = orgx; x < orgx+nx && x < COLS; x++) {
 
         cellpos(x, orgy, &px, &py);
-        sprintf(s, "%c", (int)('A'+x));
+        if (px > gridx1) break;
+        colnam(x, s);
         ami_cursorg(stdout, px+colw/2-ami_strsiz(stdout, s)/2, rowh*2+2);
         fprintf(stdout, "%s", s);
 
     }
     /* the row headers */
-    for (y = orgy; y < orgy+celly && y < ROWS; y++) {
+    for (y = orgy; y < orgy+ny && y < ROWS; y++) {
 
         cellpos(orgx, y, &px, &py);
+        if (py > gridy1) break;
         sprintf(s, "%ld", y+1);
         ami_cursorg(stdout, hdrw-2-ami_strsiz(stdout, s), py+2);
         fprintf(stdout, "%s", s);
 
     }
     /* the cells */
-    for (y = orgy; y < orgy+celly && y < ROWS; y++)
-        for (x = orgx; x < orgx+cellx && x < COLS; x++) drawcell(x, y);
-    /* the grid lines */
+    for (y = orgy; y < orgy+ny && y < ROWS; y++)
+        for (x = orgx; x < orgx+nx && x < COLS; x++) drawcell(x, y);
+    /* the grid lines, stopped at the grid area */
     ami_fcolor(stdout, ami_black);
-    for (x = orgx; x <= orgx+cellx && x <= COLS; x++) {
+    for (x = orgx; x <= orgx+nx && x <= COLS; x++) {
 
         cellpos(x, orgy, &px, &py);
-        ami_line(stdout, px-1, rowh*2, px-1, ami_maxyg(stdout));
+        if (px-1 > gridx1) break;
+        ami_line(stdout, px-1, rowh*2, px-1, gridy1);
 
     }
-    for (y = orgy; y <= orgy+celly && y <= ROWS; y++) {
+    for (y = orgy; y <= orgy+ny && y <= ROWS; y++) {
 
         cellpos(orgx, y, &px, &py);
-        ami_line(stdout, 1, py-1, ami_maxxg(stdout), py-1);
+        if (py-1 > gridy1) break;
+        ami_line(stdout, 1, py-1, gridx1, py-1);
 
     }
 
 }
 
 /* bring the current cell into view, and redraw if the view moved */
+static void clamporg(void)
+
+{
+
+    if (orgx > COLS-cellx) orgx = COLS-cellx;
+    if (orgy > ROWS-celly) orgy = ROWS-celly;
+    if (orgx < 0) orgx = 0;
+    if (orgy < 0) orgy = 0;
+
+}
+
 static void follow(void)
 
 {
@@ -691,9 +773,34 @@ static void follow(void)
     if (curx >= orgx+cellx) orgx = curx-cellx+1;
     if (cury < orgy) orgy = cury;
     if (cury >= orgy+celly) orgy = cury-celly+1;
-    if (orgx < 0) orgx = 0;
-    if (orgy < 0) orgy = 0;
-    if (ox != orgx || oy != orgy) drawall();
+    clamporg();
+    if (ox != orgx || oy != orgy) {
+
+        setbar(SBVERT, orgy, celly, ROWS);
+        setbar(SBHORIZ, orgx, cellx, COLS);
+        drawall();
+
+    }
+
+}
+
+/* scroll the view without moving the current cell, as the bars do */
+static void scrollto(long nx, long ny)
+
+{
+
+    long ox = orgx, oy = orgy;
+
+    orgx = nx;
+    orgy = ny;
+    clamporg();
+    if (ox != orgx || oy != orgy) {
+
+        setbar(SBVERT, orgy, celly, ROWS);
+        setbar(SBHORIZ, orgx, cellx, COLS);
+        drawall();
+
+    }
 
 }
 
@@ -814,6 +921,11 @@ int main(int argc, char* argv[])
     setupmenu();
     clearsheet();
     if (argc > 1) loadsheet(argv[1]);
+    /* the scroll bars, at their standard thickness */
+    ami_scrollvertsizg(stdout, &sbw, &y);
+    ami_scrollhorizsizg(stdout, &x, &sbh);
+    ami_scrollvertg(stdout, 1, 1, sbw, 100, SBVERT);
+    ami_scrollhorizg(stdout, 1, 1, 100, sbh, SBHORIZ);
     layout();
     drawall();
     do {
@@ -835,9 +947,10 @@ int main(int argc, char* argv[])
 
             case ami_etmouba: /* a click picks a cell */
                 if (er.amoubn != 1) break;
-                if (mpx < hdrw || mpy < rowh*2+hdrh) break;
-                x = (mpx-hdrw)/colw+orgx;
-                y = (mpy-rowh*2-hdrh)/rowh+orgy;
+                if (mpx < gridx0 || mpy < gridy0 ||
+                    mpx > gridx1 || mpy > gridy1) break;
+                x = (mpx-gridx0)/colw+orgx;
+                y = (mpy-gridy0)/rowh+orgy;
                 if (x < 0 || x >= COLS || y < 0 || y >= ROWS) break;
                 commit();
                 curx = x;
@@ -962,6 +1075,35 @@ int main(int argc, char* argv[])
                 curx = x;
                 follow();
                 drawall();
+                break;
+
+            case ami_etsclull: /* a line back */
+                if (er.sclulid == SBVERT) scrollto(orgx, orgy-1);
+                else scrollto(orgx-1, orgy);
+                break;
+
+            case ami_etscldrl: /* a line on */
+                if (er.scldrid == SBVERT) scrollto(orgx, orgy+1);
+                else scrollto(orgx+1, orgy);
+                break;
+
+            case ami_etsclulp: /* a page back */
+                if (er.sclupid == SBVERT) scrollto(orgx, orgy-celly);
+                else scrollto(orgx-cellx, orgy);
+                break;
+
+            case ami_etscldrp: /* a page on */
+                if (er.scldpid == SBVERT) scrollto(orgx, orgy+celly);
+                else scrollto(orgx+cellx, orgy);
+                break;
+
+            case ami_etsclpos: /* dragged to a position */
+                if (er.sclpid == SBVERT)
+                    scrollto(orgx, (long)((double)(ROWS-celly)*
+                                          er.sclpos/INT_MAX));
+                else
+                    scrollto((long)((double)(COLS-cellx)*
+                                    er.sclpos/INT_MAX), orgy);
                 break;
 
             case ami_etmenus: /* the menu */

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -29,6 +29,11 @@
 *     =SUM(A1:A10)      SUM, AVG, MIN, MAX, COUNT over a range                 *
 *     =2*(SUM(B1:B9)+1) they nest                                              *
 *                                                                              *
+* Text that does not fit its column runs on into the empty cells to its       *
+* right, so a title need not fit the column it starts in; it stops at the      *
+* first cell holding anything. A number that does not fit shows as # marks     *
+* rather than a truncated number, which would read as a different number.      *
+*                                                                              *
 * A cell shows its value; the entry line at the top shows what the current     *
 * cell holds, which for a formula is the formula. Formulas recalculate         *
 * whenever anything changes, and a formula that cannot be evaluated shows      *
@@ -677,7 +682,64 @@ static void cellpos(long x, long y, long* px, long* py)
 
 }
 
-/* draw one cell, headers included in the caller's frame */
+/* A text cell prints past its own cell, into the empty cells to its
+   right, so a title need not fit the column it starts in. The run ends
+   at the first cell holding anything, or at the edge of the grid.
+   Numbers do not run on: a number that does not fit is not a number the
+   reader can trust, so it shows as # marks instead. */
+static long spillwid(long x, long y)
+
+{
+
+    long w = colw;
+    long i, px, py;
+
+    for (i = x+1; i < COLS; i++) {
+
+        cellpos(i, y, &px, &py);
+        if (px > gridx1) break; /* the edge of the grid */
+        if (cells[y][i].text) break; /* the next cell holds something */
+        w += colw;
+
+    }
+    cellpos(x, y, &px, &py);
+    if (px+w-2 > gridx1) w = gridx1-px+2; /* clipped to the grid */
+
+    return (w);
+
+}
+
+/* clip a string to a pixel width, in place */
+static void clipstr(char* s, long w)
+
+{
+
+    long i = strlen(s);
+
+    while (i && ami_strsiz(stdout, s) > w) s[--i] = 0;
+
+}
+
+/* The face of one cell. The faces of a row go down before any of its
+   contents, so that text running past its own cell is not painted over
+   by the cells it runs into. */
+static void drawface(long x, long y)
+
+{
+
+    long px, py;
+
+    if (x < orgx || y < orgy) return;
+    cellpos(x, y, &px, &py);
+    if (px > gridx1 || py > gridy1) return;
+    /* the current cell is marked */
+    if (x == curx && y == cury) ami_fcolor(stdout, ami_cyan);
+    else ami_fcolor(stdout, ami_white);
+    ami_frect(stdout, px, py, px+colw-2, py+rowh-2);
+
+}
+
+/* the contents of one cell */
 static void drawcell(long x, long y)
 
 {
@@ -685,37 +747,51 @@ static void drawcell(long x, long y)
     long px, py;
     char s[CELLEN];
     long tw;
+    int  val; /* the cell shows a value, not text */
 
     if (x < orgx || y < orgy) return;
     cellpos(x, y, &px, &py);
     if (px > gridx1 || py > gridy1) return;
-    /* the cell face: the current cell is marked */
-    if (x == curx && y == cury) ami_fcolor(stdout, ami_cyan);
-    else ami_fcolor(stdout, ami_white);
-    ami_frect(stdout, px, py, px+colw-2, py+rowh-2);
-    ami_fcolor(stdout, ami_black);
     if (entering && x == curx && y == cury) strcpy(s, entry);
     else celldsp(x, y, s, sizeof(s));
-    if (*s) {
+    if (!*s) return;
+    /* a value keeps to its own cell, text runs on into empty cells */
+    val = !entering && cells[y][x].text &&
+          (cells[y][x].isnum || cells[y][x].text[0] == '=' ||
+           cells[y][x].err);
+    if (val) { /* numbers to the right, in their own cell */
 
-        /* numbers to the right, text to the left, as a sheet does */
-        tw = ami_strsiz(stdout, s);
-        if (tw > colw-4) tw = colw-4;
-        if (!entering && cells[y][x].text &&
-            (cells[y][x].isnum || cells[y][x].text[0] == '=' ||
-             cells[y][x].err))
-            ami_cursorg(stdout, px+colw-3-tw, py+2);
-        else ami_cursorg(stdout, px+2, py+2);
-        /* clipped to the cell by the window's own edge; keep it short */
-        if (ami_strsiz(stdout, s) > colw-4) {
+        ami_fcolor(stdout, ami_black);
+        if (ami_strsiz(stdout, s) > colw-4) { /* it does not fit */
 
-            long i = strlen(s);
-            while (i && ami_strsiz(stdout, s) > colw-4) s[--i] = 0;
+            long i;
+
+            for (i = 0; i < (long)sizeof(s)-1; i++) s[i] = '#';
+            s[i] = 0;
+            clipstr(s, colw-4);
 
         }
-        fprintf(stdout, "%s", s);
+        tw = ami_strsiz(stdout, s);
+        ami_cursorg(stdout, px+colw-3-tw, py+2);
+
+    } else { /* text to the left, running on if it must */
+
+        long w = spillwid(x, y);
+
+        if (ami_strsiz(stdout, s) > colw-4 && w > colw) {
+
+            /* clear the run, which takes the grid lines under it, as a
+               sheet does where text crosses a cell edge */
+            ami_fcolor(stdout, ami_white);
+            ami_frect(stdout, px+colw-1, py-1, px+w-2, py+rowh-2);
+
+        }
+        ami_fcolor(stdout, ami_black);
+        clipstr(s, w-4);
+        ami_cursorg(stdout, px+2, py+2);
 
     }
+    fprintf(stdout, "%s", s);
 
 }
 
@@ -767,10 +843,9 @@ static void drawall(void)
         fprintf(stdout, "%s", s);
 
     }
-    /* the cells */
-    for (y = orgy; y < orgy+ny && y < ROWS; y++)
-        for (x = orgx; x < orgx+nx && x < COLS; x++) drawcell(x, y);
-    /* the grid lines, stopped at the grid area */
+    /* The grid lines, stopped at the grid area. They go down before the
+       cells, so text that runs past its own cell can take the lines it
+       crosses with it. */
     ami_fcolor(stdout, ami_black);
     for (x = orgx; x <= orgx+nx && x <= COLS; x++) {
 
@@ -784,6 +859,13 @@ static void drawall(void)
         cellpos(orgx, y, &px, &py);
         if (py-1 > gridy1) break;
         ami_line(stdout, 1, py-1, gridx1, py-1);
+
+    }
+    /* the cells, faces first so a run is not painted over */
+    for (y = orgy; y < orgy+ny && y < ROWS; y++) {
+
+        for (x = orgx; x < orgx+nx && x < COLS; x++) drawface(x, y);
+        for (x = orgx; x < orgx+nx && x < COLS; x++) drawcell(x, y);
 
     }
 

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -9,7 +9,10 @@
 * Build and run:                                                               *
 *                                                                              *
 *     make spreadsheet                                                         *
-*     bin/spreadsheet [<file>]                                                 *
+*     bin/spreadsheet [-d] [<file>]                                            *
+*                                                                              *
+* -d reports the layout and the events to stderr, for when the window          *
+* behaves unexpectedly.                                                        *
 *                                                                              *
 * Using it:                                                                    *
 *                                                                              *
@@ -123,6 +126,7 @@ static char   filename[500];   /* the file this sheet came from */
 static int    modified;        /* the sheet has unsaved changes */
 static int    evalnest;        /* formula evaluation depth */
 static long   mpx, mpy;        /* the mouse, tracked in pixels */
+static int    diag;            /* report to stderr, from -d */
 
 /* the parser's position in a formula, and its error flag */
 static const char* pp;
@@ -581,8 +585,9 @@ sheet reflows on a resize or a column width change.
 
 *******************************************************************************/
 
-/* set a scroll bar from the view: the thumb is the visible share of the
-   sheet, at the scrolled position */
+/* Set a scroll bar from the view: the thumb is the visible share of the
+   sheet, at the scrolled position. The bars work in ratios of LONG_MAX,
+   as the rest of the API does. */
 static void setbar(long id, long org, long vis, long total)
 
 {
@@ -590,8 +595,20 @@ static void setbar(long id, long org, long vis, long total)
     long max = total-vis;
 
     if (max < 1) max = 1;
-    ami_scrollsiz(stdout, id, (long)((double)INT_MAX*vis/total));
-    ami_scrollpos(stdout, id, (long)((double)INT_MAX*org/max));
+    if (vis > total) vis = total;
+    ami_scrollsiz(stdout, id, (long)((double)LONG_MAX*vis/total));
+    ami_scrollpos(stdout, id, (long)((double)LONG_MAX*org/max));
+
+}
+
+/* a cell offset from a bar position, over the given travel */
+static long barcell(long pos, long travel)
+
+{
+
+    if (travel < 1) return (0);
+
+    return ((long)((double)travel*pos/LONG_MAX+0.5));
 
 }
 
@@ -626,6 +643,12 @@ static void layout(void)
     ami_sizwidgetg(stdout, SBHORIZ, gridx1-gridx0, sbh);
     setbar(SBVERT, orgy, celly, ROWS);
     setbar(SBHORIZ, orgx, cellx, COLS);
+    if (diag) fprintf(stderr,
+        "layout: window %ldx%ld grid %ld,%ld-%ld,%ld cells %ldx%ld "
+        "bars: vert at %ld,%ld %ldx%ld horiz at %ld,%ld %ldx%ld\n",
+        ami_maxxg(stdout), ami_maxyg(stdout), gridx0, gridy0, gridx1, gridy1,
+        cellx, celly, gridx1+1, gridy0, sbw, gridy1-gridy0,
+        gridx0, gridy1+1, gridx1-gridx0, sbh);
 
 }
 
@@ -910,6 +933,13 @@ int main(int argc, char* argv[])
     char  fn[500];
     long  x, y;
 
+    if (argc > 1 && !strcmp(argv[1], "-d")) { /* report what happens */
+
+        diag = TRUE;
+        argc--;
+        argv++;
+
+    }
     ami_title(stdout, "Spreadsheet");
     ami_curvis(stdout, FALSE);
     ami_auto(stdout, FALSE);
@@ -931,6 +961,28 @@ int main(int argc, char* argv[])
     do {
 
         ami_event(stdin, &er);
+        if (diag) switch (er.etype) { /* the events the bars send */
+
+            case ami_etmouba:
+                fprintf(stderr, "click button %ld at %ld,%ld\n",
+                        er.amoubn, mpx, mpy);
+                break;
+            case ami_etsclull: fprintf(stderr, "scroll line back, bar %ld\n",
+                                       er.sclulid); break;
+            case ami_etscldrl: fprintf(stderr, "scroll line on, bar %ld\n",
+                                       er.scldrid); break;
+            case ami_etsclulp: fprintf(stderr, "scroll page back, bar %ld\n",
+                                       er.sclupid); break;
+            case ami_etscldrp: fprintf(stderr, "scroll page on, bar %ld\n",
+                                       er.scldpid); break;
+            case ami_etsclpos: fprintf(stderr, "scroll to %ld, bar %ld\n",
+                                       er.sclpos, er.sclpid); break;
+            case ami_etresize: fprintf(stderr, "resize to %ldx%ld\n",
+                                       er.rszxg, er.rszyg); break;
+            case ami_etredraw: fprintf(stderr, "redraw\n"); break;
+            default: break;
+
+        }
         switch (er.etype) {
 
             case ami_etresize:
@@ -1109,11 +1161,9 @@ int main(int argc, char* argv[])
 
             case ami_etsclpos: /* dragged to a position */
                 if (er.sclpid == SBVERT)
-                    scrollto(orgx, (long)((double)(ROWS-celly)*
-                                          er.sclpos/INT_MAX));
+                    scrollto(orgx, barcell(er.sclpos, ROWS-celly));
                 else
-                    scrollto((long)((double)(COLS-cellx)*
-                                    er.sclpos/INT_MAX), orgy);
+                    scrollto(barcell(er.sclpos, COLS-cellx), orgy);
                 break;
 
             case ami_etmenus: /* the menu */

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -40,8 +40,9 @@
 * ERR -- a bad reference, a division by zero, or a reference cycle, which      *
 * ends at the nesting bound rather than hanging.                               *
 *                                                                              *
-* The file format is one line per non-empty cell, "A1: contents", which is     *
-* both what it writes and what it reads.                                       *
+* The file is an OpenDocument spreadsheet, .ods, the ISO/IEC 26300 format      *
+* that LibreOffice and the rest read and write, so a sheet written here        *
+* opens there and one written there opens here, formulas and all.              *
 *                                                                              *
 *                          BSD LICENSE INFORMATION                             *
 *                                                                              *
@@ -79,6 +80,8 @@
 #include <math.h>
 #include <limits.h>
 
+#include <zlib.h> /* the .ods container is a zip, deflated */
+
 #include <localdefs.h>
 #include <graphics.h>
 
@@ -98,11 +101,14 @@
 #define SBVERT   1 /* vertical scroll bar widget id */
 #define SBHORIZ  2 /* horizontal scroll bar widget id */
 
-/* menu ids of our own, after the standard ones */
-#define MENUWIDER  (AMI_SMMAX+1) /* wider columns */
-#define MENUNARROW (AMI_SMMAX+2) /* narrower columns */
-#define MENUCLEAR  (AMI_SMMAX+3) /* clear the sheet */
-#define MENURECALC (AMI_SMMAX+4) /* recalculate */
+/* Menu ids of our own, after the standard ones. They hang under one
+   Sheet entry of our own, which the standard menu places between its
+   Edit and Window menus. */
+#define MENUSHEET  (AMI_SMMAX+1) /* the sheet menu itself */
+#define MENUWIDER  (AMI_SMMAX+2) /* wider columns */
+#define MENUNARROW (AMI_SMMAX+3) /* narrower columns */
+#define MENUCLEAR  (AMI_SMMAX+4) /* clear the sheet */
+#define MENURECALC (AMI_SMMAX+5) /* recalculate */
 
 /* a cell holds what the user typed; the value is derived */
 typedef struct {
@@ -132,6 +138,11 @@ static int    modified;        /* the sheet has unsaved changes */
 static int    evalnest;        /* formula evaluation depth */
 static long   mpx, mpy;        /* the mouse, tracked in pixels */
 static int    diag;            /* report to stderr, from -d */
+static char*  undtxt;          /* the contents a cell had before the last
+                                  change, for undo */
+static long   undx, undy;      /* the cell that change was in */
+static int    undval;          /* there is something to undo */
+static char*  clip;            /* the cut cell, for paste */
 
 /* the parser's position in a formula, and its error flag */
 static const char* pp;
@@ -459,6 +470,18 @@ static void setcell(long x, long y, const char* s)
 
     cellrec* c = &cells[y][x];
 
+    /* what the cell held is kept for undo */
+    if (undtxt) free(undtxt);
+    undtxt = NULL;
+    if (c->text) {
+
+        undtxt = malloc(strlen(c->text)+1);
+        if (undtxt) strcpy(undtxt, c->text);
+
+    }
+    undx = x;
+    undy = y;
+    undval = TRUE;
     if (c->text) free(c->text);
     c->text = NULL;
     if (s && *s) {
@@ -518,42 +541,341 @@ static void celldsp(long x, long y, char* s, long sl)
 
 Files
 
+The sheet is kept as an OpenDocument spreadsheet (.ods, ISO/IEC 26300):
+a zip container holding the mimetype, a manifest, and content.xml, which
+carries the cells. That is what LibreOffice and the rest read and write,
+so a sheet written here opens there and a sheet written there opens
+here.
+
+Only what this program has is written: values, text, and formulas. A
+formula crosses over in the ODF form, which brackets its references --
+=SUM(A1:A3) is stored as of:=SUM([.A1:.A3]) -- so the translation is at
+the brackets, both ways.
+
+Reading takes the zip apart far enough to find content.xml, inflating
+it when the writer compressed it (they all do), and scans the XML for
+rows and cells. It is not a general XML parser: it looks for the
+handful of elements a spreadsheet body is made of, which is enough for
+the files LibreOffice writes and all the files this program writes.
+
 *******************************************************************************/
 
-static void loadsheet(const char* fn)
+/* a growing byte buffer, for building the zip and for the inflated xml */
+typedef struct {
+
+    char*  p;   /* the bytes */
+    size_t len; /* how many */
+    size_t max; /* room */
+
+} buffer;
+
+static void bufput(buffer* b, const void* d, size_t n)
 
 {
 
-    FILE* f;
-    char  line[CELLEN+40];
-    char* p;
-    long  x, y;
+    if (b->len+n > b->max) {
 
-    f = fopen(fn, "r");
-    if (!f) { ami_alert("spreadsheet", "Cannot open file"); return; }
-    clearsheet();
-    while (fgets(line, sizeof(line), f)) {
-
-        p = strchr(line, '\n');
-        if (p) *p = 0;
-        p = strchr(line, ':');
-        if (!p) continue; /* not a cell line */
-        *p++ = 0;
-        while (*p == ' ') p++;
-        pp = line;
-        perr = FALSE;
-        if (!cellref(&x, &y) || perr || *pp) continue; /* bad name */
-        if (cells[y][x].text) free(cells[y][x].text);
-        cells[y][x].text = malloc(strlen(p)+1);
-        if (!cells[y][x].text) { ami_alert("spreadsheet", "Out of memory");
-                                 exit(1); }
-        strcpy(cells[y][x].text, p);
+        while (b->len+n > b->max) b->max = b->max? b->max*2: 4096;
+        b->p = realloc(b->p, b->max);
+        if (!b->p) { ami_alert("spreadsheet", "Out of memory"); exit(1); }
 
     }
-    fclose(f);
-    recalc();
-    modified = FALSE;
-    strncpy(filename, fn, sizeof(filename)-1);
+    memcpy(b->p+b->len, d, n);
+    b->len += n;
+
+}
+
+static void bufstr(buffer* b, const char* s) { bufput(b, s, strlen(s)); }
+
+static void buf16(buffer* b, unsigned v)
+
+{
+
+    char c[2];
+
+    c[0] = v&0xff; c[1] = v >> 8&0xff;
+    bufput(b, c, 2);
+
+}
+
+static void buf32(buffer* b, unsigned long v)
+
+{
+
+    char c[4];
+
+    c[0] = v&0xff; c[1] = v >> 8&0xff; c[2] = v >> 16&0xff; c[3] = v >> 24&0xff;
+    bufput(b, c, 4);
+
+}
+
+/* xml text with the five characters that cannot appear as themselves */
+static void bufxml(buffer* b, const char* s)
+
+{
+
+    while (*s) {
+
+        switch (*s) {
+
+            case '&':  bufstr(b, "&amp;"); break;
+            case '<':  bufstr(b, "&lt;"); break;
+            case '>':  bufstr(b, "&gt;"); break;
+            case '"':  bufstr(b, "&quot;"); break;
+            case '\'': bufstr(b, "&apos;"); break;
+            default:   bufput(b, s, 1); break;
+
+        }
+        s++;
+
+    }
+
+}
+
+/* one stored (uncompressed) zip member, appended to the archive and
+   noted for the central directory */
+typedef struct {
+
+    const char* name;
+    unsigned long crc;
+    size_t len;
+    size_t off;
+
+} zipent;
+
+static void zipadd(buffer* z, zipent* e, const char* name, const char* data,
+                   size_t len)
+
+{
+
+    e->name = name;
+    e->crc = crc32(0, (const Bytef*)data, len);
+    e->len = len;
+    e->off = z->len;
+    buf32(z, 0x04034b50); /* local file header */
+    buf16(z, 20);         /* version needed */
+    buf16(z, 0);          /* flags */
+    buf16(z, 0);          /* stored */
+    buf16(z, 0);          /* time */
+    buf16(z, 0x21);       /* date, 1980-01-01 */
+    buf32(z, e->crc);
+    buf32(z, len);        /* compressed size */
+    buf32(z, len);        /* uncompressed size */
+    buf16(z, strlen(name));
+    buf16(z, 0);          /* no extra */
+    bufstr(z, name);
+    bufput(z, data, len);
+
+}
+
+static void zipend(buffer* z, zipent* ents, long n)
+
+{
+
+    size_t dir = z->len;
+    size_t dirlen;
+    long   i;
+
+    for (i = 0; i < n; i++) {
+
+        buf32(z, 0x02014b50); /* central directory header */
+        buf16(z, 20);         /* version made by */
+        buf16(z, 20);         /* version needed */
+        buf16(z, 0);          /* flags */
+        buf16(z, 0);          /* stored */
+        buf16(z, 0);          /* time */
+        buf16(z, 0x21);       /* date */
+        buf32(z, ents[i].crc);
+        buf32(z, ents[i].len);
+        buf32(z, ents[i].len);
+        buf16(z, strlen(ents[i].name));
+        buf16(z, 0);          /* extra */
+        buf16(z, 0);          /* comment */
+        buf16(z, 0);          /* disk */
+        buf16(z, 0);          /* internal attributes */
+        buf32(z, 0);          /* external attributes */
+        buf32(z, ents[i].off);
+        bufstr(z, ents[i].name);
+
+    }
+    dirlen = z->len-dir; /* taken before the record below adds to it */
+    buf32(z, 0x06054b50); /* end of central directory */
+    buf16(z, 0);          /* disk */
+    buf16(z, 0);          /* disk with directory */
+    buf16(z, n);
+    buf16(z, n);
+    buf32(z, dirlen);
+    buf32(z, dir);
+    buf16(z, 0);          /* no comment */
+
+}
+
+/* a formula in the ODF form: the references are bracketed and dotted,
+   =SUM(A1:A3) becoming of:=SUM([.A1:.A3]) */
+static void odfformula(buffer* b, const char* f)
+
+{
+
+    const char* p = f+1; /* past the = */
+    long x, y;
+
+    bufstr(b, "of:=");
+    while (*p) {
+
+        if (isalpha((unsigned char)*p)) { /* a name, or a reference */
+
+            const char* sp = p;
+
+            pp = p;
+            perr = FALSE;
+            if (cellref(&x, &y) && !perr) { /* a reference, maybe a range */
+
+                const char* re = pp;
+
+                if (*pp == ':') { /* a range: both ends bracketed */
+
+                    const char* mid = pp;
+
+                    pp++;
+                    if (cellref(&x, &y) && !perr) {
+
+                        bufstr(b, "[.");
+                        bufput(b, sp, mid-sp);
+                        bufstr(b, ":.");
+                        bufput(b, mid+1, pp-mid-1);
+                        bufstr(b, "]");
+                        p = pp;
+                        continue;
+
+                    }
+                    pp = re; /* not a range after all */
+
+                }
+                bufstr(b, "[.");
+                bufput(b, sp, re-sp);
+                bufstr(b, "]");
+                p = re;
+
+                continue;
+
+            }
+            /* a function name, which carries over as it stands */
+            while (isalpha((unsigned char)*p)) { bufput(b, p, 1); p++; }
+
+            continue;
+
+        }
+        bufxml(b, (char[2]){*p, 0});
+        p++;
+
+    }
+
+}
+
+/* The same in reverse: of:=SUM([.A1:.A3]) becomes =SUM(A1:A3). The
+   result carries its own leading =, whatever the source had. */
+static void plainformula(char* d, const char* s, long dl)
+
+{
+
+    long i = 0;
+    const char* b;
+
+    if (!strncmp(s, "of:", 3)) s += 3;
+    if (*s != '=' && i < dl-1) d[i++] = '='; /* it must lead with one */
+    b = s;
+    while (*s && i < dl-1) {
+
+        /* the brackets and the sheet marks come off; a dot only where it
+           marks a reference, never one inside a number */
+        if (*s == '[' || *s == ']' || *s == '$') s++;
+        else if (*s == '.' && (s == b || !isdigit((unsigned char)s[-1]))) s++;
+        else d[i++] = *s++;
+
+    }
+    d[i] = 0;
+
+}
+
+/* the content.xml of the sheet as it stands */
+static void odscontent(buffer* b)
+
+{
+
+    long x, y, lastx, lasty, gap;
+    char s[CELLEN];
+    cellrec* c;
+
+    bufstr(b, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    bufstr(b, "<office:document-content "
+        "xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        "xmlns:of=\"urn:oasis:names:tc:opendocument:xmlns:of:1.2\" "
+        "office:version=\"1.2\">"
+        "<office:body><office:spreadsheet>"
+        "<table:table table:name=\"Sheet1\">");
+    /* the last row and column that hold anything bound the writing */
+    lastx = lasty = -1;
+    for (y = 0; y < ROWS; y++) for (x = 0; x < COLS; x++)
+        if (cells[y][x].text) { if (y > lasty) lasty = y;
+                                if (x > lastx) lastx = x; }
+    bufstr(b, "<table:table-column table:number-columns-repeated=\"");
+    sprintf(s, "%ld", lastx+1 > 0? lastx+1: 1);
+    bufstr(b, s);
+    bufstr(b, "\"/>");
+    for (y = 0; y <= lasty; y++) {
+
+        bufstr(b, "<table:table-row>");
+        gap = 0;
+        for (x = 0; x <= lastx; x++) {
+
+            c = &cells[y][x];
+            if (!c->text) { gap++; continue; } /* empty cells go as a run */
+            if (gap) {
+
+                bufstr(b, "<table:table-cell table:number-columns-repeated=\"");
+                sprintf(s, "%ld", gap);
+                bufstr(b, s);
+                bufstr(b, "\"/>");
+                gap = 0;
+
+            }
+            bufstr(b, "<table:table-cell");
+            if (c->text[0] == '=') { /* a formula, with its last value */
+
+                bufstr(b, " table:formula=\"");
+                odfformula(b, c->text);
+                bufstr(b, "\"");
+
+            }
+            if (c->text[0] == '=' || c->isnum) { /* a value */
+
+                bufstr(b, " office:value-type=\"float\" office:value=\"");
+                sprintf(s, "%.15g", c->val);
+                bufstr(b, s);
+                bufstr(b, "\">");
+                celldsp(x, y, s, sizeof(s));
+                bufstr(b, "<text:p>");
+                bufxml(b, s);
+                bufstr(b, "</text:p>");
+
+            } else { /* text */
+
+                bufstr(b, " office:value-type=\"string\">");
+                bufstr(b, "<text:p>");
+                bufxml(b, c->text);
+                bufstr(b, "</text:p>");
+
+            }
+            bufstr(b, "</table:table-cell>");
+
+        }
+        bufstr(b, "</table:table-row>");
+
+    }
+    bufstr(b, "</table:table></office:spreadsheet></office:body>"
+              "</office:document-content>");
 
 }
 
@@ -561,20 +883,296 @@ static void savesheet(const char* fn)
 
 {
 
-    FILE* f;
-    long  x, y;
-    char  nam[16];
+    buffer z = { NULL, 0, 0 };
+    buffer c = { NULL, 0, 0 };
+    zipent ents[3];
+    FILE*  f;
+    static const char* manifest =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<manifest:manifest "
+        "xmlns:manifest=\"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0\" "
+        "manifest:version=\"1.2\">"
+        "<manifest:file-entry manifest:full-path=\"/\" "
+        "manifest:media-type=\"application/vnd.oasis.opendocument.spreadsheet\"/>"
+        "<manifest:file-entry manifest:full-path=\"content.xml\" "
+        "manifest:media-type=\"text/xml\"/>"
+        "</manifest:manifest>";
+    static const char* mime =
+        "application/vnd.oasis.opendocument.spreadsheet";
 
-    f = fopen(fn, "w");
-    if (!f) { ami_alert("spreadsheet", "Cannot write file"); return; }
-    for (y = 0; y < ROWS; y++) for (x = 0; x < COLS; x++)
-        if (cells[y][x].text) {
+    odscontent(&c);
+    /* the mimetype goes first and stored, which is how the format is
+       recognized without unpacking it */
+    zipadd(&z, &ents[0], "mimetype", mime, strlen(mime));
+    zipadd(&z, &ents[1], "META-INF/manifest.xml", manifest, strlen(manifest));
+    zipadd(&z, &ents[2], "content.xml", c.p, c.len);
+    zipend(&z, ents, 3);
+    f = fopen(fn, "wb");
+    if (!f) { ami_alert("spreadsheet", "Cannot write file"); }
+    else {
 
-            cellnam(x, y, nam);
-            fprintf(f, "%s: %s\n", nam, cells[y][x].text);
+        fwrite(z.p, 1, z.len, f);
+        fclose(f);
+        modified = FALSE;
+        strncpy(filename, fn, sizeof(filename)-1);
+
+    }
+    free(z.p);
+    free(c.p);
+
+}
+
+/* Find content.xml in the zip and give it back inflated.
+   The read goes by the central directory, not by walking the local
+   headers: a writer may stream a member, leaving the sizes zero in its
+   local header and putting them in a descriptor after the data, which
+   is what LibreOffice does, and a walk of local headers then loses its
+   place. The central directory always carries the sizes and the offset
+   of each member. */
+static char* odsread(const char* fn)
+
+{
+
+    FILE*  f;
+    buffer raw = { NULL, 0, 0 };
+    char   buf[4096];
+    size_t n;
+    long   i, cd, cnt, ent;
+    char*  out = NULL;
+    unsigned char* d;
+
+    f = fopen(fn, "rb");
+    if (!f) return (NULL);
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) bufput(&raw, buf, n);
+    fclose(f);
+    d = (unsigned char*)raw.p;
+    /* the end of central directory record, last in the file */
+    cd = -1;
+    for (i = (long)raw.len-22; i >= 0; i--)
+        if (d[i] == 0x50 && d[i+1] == 0x4b && d[i+2] == 0x05 &&
+            d[i+3] == 0x06) { cd = i; break; }
+    if (cd < 0) { free(raw.p); return (NULL); } /* not a zip */
+    cnt = d[cd+10]|d[cd+11] << 8;
+    ent = d[cd+16]|d[cd+17] << 8|(long)d[cd+18] << 16|(long)d[cd+19] << 24;
+    /* the directory entries, looking for content.xml */
+    for (i = 0; i < cnt && ent+46 <= (long)raw.len; i++) {
+
+        unsigned char* p = d+ent;
+        long method, nlen, elen, clen, csize, usize, loc;
+
+        if (!(p[0] == 0x50 && p[1] == 0x4b && p[2] == 0x01 && p[3] == 0x02))
+            break;
+        method = p[10]|p[11] << 8;
+        csize = p[20]|p[21] << 8|(long)p[22] << 16|(long)p[23] << 24;
+        usize = p[24]|p[25] << 8|(long)p[26] << 16|(long)p[27] << 24;
+        nlen = p[28]|p[29] << 8;
+        elen = p[30]|p[31] << 8;
+        clen = p[32]|p[33] << 8;
+        loc = p[42]|p[43] << 8|(long)p[44] << 16|(long)p[45] << 24;
+        if (nlen == 11 && !memcmp(p+46, "content.xml", 11)) {
+
+            unsigned char* lp = d+loc;
+            char* data;
+
+            if (loc < 0 || loc+30 > (long)raw.len) break;
+            /* the local header carries its own name and extra lengths */
+            data = (char*)lp+30+(lp[26]|lp[27] << 8)+(lp[28]|lp[29] << 8);
+            if (method == 0) { /* stored */
+
+                out = malloc(csize+1);
+                if (out) { memcpy(out, data, csize); out[csize] = 0; }
+
+            } else if (method == 8) { /* deflated */
+
+                z_stream zs;
+
+                out = malloc(usize+1);
+                if (out) {
+
+                    memset(&zs, 0, sizeof(zs));
+                    zs.next_in = (Bytef*)data;
+                    zs.avail_in = csize;
+                    zs.next_out = (Bytef*)out;
+                    zs.avail_out = usize;
+                    if (inflateInit2(&zs, -MAX_WBITS) != Z_OK ||
+                        inflate(&zs, Z_FINISH) < 0) { free(out); out = NULL; }
+                    else out[zs.total_out] = 0;
+                    inflateEnd(&zs);
+
+                }
+
+            }
+            break;
 
         }
-    fclose(f);
+        ent += 46+nlen+elen+clen;
+
+    }
+    free(raw.p);
+
+    return (out);
+
+}
+
+/* the text of an xml attribute, or NULL: the tag is one element */
+static int xmlatt(const char* tag, const char* name, char* d, long dl)
+
+{
+
+    const char* p = tag;
+    long n = strlen(name);
+    long i = 0;
+
+    while ((p = strstr(p, name))) {
+
+        if ((p == tag || p[-1] == ' ') && p[n] == '=' && p[n+1] == '"') {
+
+            p += n+2;
+            while (*p && *p != '"' && i < dl-1) {
+
+                if (!strncmp(p, "&amp;", 5)) { d[i++] = '&'; p += 5; }
+                else if (!strncmp(p, "&lt;", 4)) { d[i++] = '<'; p += 4; }
+                else if (!strncmp(p, "&gt;", 4)) { d[i++] = '>'; p += 4; }
+                else if (!strncmp(p, "&quot;", 6)) { d[i++] = '"'; p += 6; }
+                else if (!strncmp(p, "&apos;", 6)) { d[i++] = '\''; p += 6; }
+                else d[i++] = *p++;
+
+            }
+            d[i] = 0;
+
+            return (TRUE);
+
+        }
+        p += n;
+
+    }
+
+    return (FALSE);
+
+}
+
+/* the text of the <text:p> runs inside a cell element */
+static void xmltext(const char* cell, const char* end, char* d, long dl)
+
+{
+
+    const char* p = cell;
+    long i = 0;
+
+    while ((p = strstr(p, "<text:p")) && p < end) {
+
+        p = strchr(p, '>');
+        if (!p) break;
+        p++;
+        while (*p && *p != '<' && i < dl-1) {
+
+            if (!strncmp(p, "&amp;", 5)) { d[i++] = '&'; p += 5; }
+            else if (!strncmp(p, "&lt;", 4)) { d[i++] = '<'; p += 4; }
+            else if (!strncmp(p, "&gt;", 4)) { d[i++] = '>'; p += 4; }
+            else if (!strncmp(p, "&quot;", 6)) { d[i++] = '"'; p += 6; }
+            else if (!strncmp(p, "&apos;", 6)) { d[i++] = '\''; p += 6; }
+            else d[i++] = *p++;
+
+        }
+
+    }
+    d[i] = 0;
+
+}
+
+static void loadsheet(const char* fn)
+
+{
+
+    char* xml;
+    char* p;
+    long  x = 0, y = -1;
+    char  att[CELLEN], txt[CELLEN];
+    FILE* t;
+
+    /* a name that is not there yet is a new sheet to be written there,
+       which is how a sheet is started from the command line */
+    t = fopen(fn, "rb");
+    if (!t) {
+
+        clearsheet();
+        strncpy(filename, fn, sizeof(filename)-1);
+
+        return;
+
+    }
+    fclose(t);
+    xml = odsread(fn);
+    if (!xml) { ami_alert("spreadsheet", "Not a spreadsheet file"); return; }
+    clearsheet();
+    p = xml;
+    while ((p = strpbrk(p, "<"))) {
+
+        if (!strncmp(p, "<table:table-row", 16)) { /* a row, maybe repeated */
+
+            char* e = strchr(p, '>');
+
+            y++;
+            x = 0;
+            p = e? e: p+16;
+
+        } else if (!strncmp(p, "<table:table-cell", 17)) {
+
+            char* e = strchr(p, '>');
+            char* close;
+            long  rep = 1;
+            long  empty = TRUE;
+
+            if (!e) break;
+            *e = 0; /* the element alone, for the attribute search */
+            if (xmlatt(p, "table:number-columns-repeated", att, sizeof(att)))
+                rep = atol(att);
+            if (xmlatt(p, "table:formula", att, sizeof(att))) {
+
+                char f[CELLEN];
+
+                plainformula(f, att, sizeof(f));
+                if (y >= 0 && y < ROWS && x < COLS) {
+
+                    cells[y][x].text = malloc(strlen(f)+1);
+                    if (cells[y][x].text) strcpy(cells[y][x].text, f);
+
+                }
+                empty = FALSE;
+
+            } else if (xmlatt(p, "office:value", att, sizeof(att))) {
+
+                if (y >= 0 && y < ROWS && x < COLS) {
+
+                    cells[y][x].text = malloc(strlen(att)+1);
+                    if (cells[y][x].text) strcpy(cells[y][x].text, att);
+
+                }
+                empty = FALSE;
+
+            }
+            *e = '>';
+            if (empty) { /* text, if it holds any */
+
+                close = strstr(e, "</table:table-cell>");
+                if (!close) close = e+1;
+                xmltext(e, close, txt, sizeof(txt));
+                if (*txt && y >= 0 && y < ROWS && x < COLS) {
+
+                    cells[y][x].text = malloc(strlen(txt)+1);
+                    if (cells[y][x].text) strcpy(cells[y][x].text, txt);
+
+                }
+
+            }
+            x += rep;
+            p = e+1;
+
+        } else p++;
+
+    }
+    free(xml);
+    recalc();
     modified = FALSE;
     strncpy(filename, fn, sizeof(filename)-1);
 
@@ -967,27 +1565,91 @@ static void newmenu(ami_menuptr* mp, int onoff, int oneof, int bar,
 
 }
 
-/* the standard file and edit menus, with a sheet menu of our own after */
+/* The standard menu, with a Sheet menu of our own. The standard menu
+   builds File and Edit, places the program's own entries after them,
+   and finishes with Window and Help; only the standard entries this
+   program actually implements are asked for. */
 static void setupmenu(void)
 
 {
 
     ami_menuptr ml = NULL; /* our own entries */
+    ami_menuptr sh;        /* the sheet menu */
     ami_menuptr mp;
     ami_menuptr sm = NULL; /* the completed menu */
 
-    newmenu(&mp, FALSE, FALSE, OFF, MENUWIDER, "Wider columns");
-    appendmenu(&ml, mp);
-    newmenu(&mp, FALSE, FALSE, OFF, MENUNARROW, "Narrower columns");
-    appendmenu(&ml, mp);
-    newmenu(&mp, FALSE, FALSE, OFF, MENURECALC, "Recalculate");
-    appendmenu(&ml, mp);
-    newmenu(&mp, FALSE, FALSE, OFF, MENUCLEAR, "Clear sheet");
-    appendmenu(&ml, mp);
-    ami_stdmenu(BIT(AMI_SMNEW) | BIT(AMI_SMOPEN) | BIT(AMI_SMSAVE) |
-                BIT(AMI_SMSAVEAS) | BIT(AMI_SMEXIT) | BIT(AMI_SMABOUT),
+    newmenu(&sh, FALSE, FALSE, OFF, MENUSHEET, "Sheet");
+    appendmenu(&ml, sh);
+    ami_stdmenu(BIT(AMI_SMNEW) | BIT(AMI_SMOPEN) | BIT(AMI_SMCLOSE) |
+                BIT(AMI_SMSAVE) | BIT(AMI_SMSAVEAS) | BIT(AMI_SMEXIT) |
+                BIT(AMI_SMUNDO) | BIT(AMI_SMCUT) | BIT(AMI_SMPASTE) |
+                BIT(AMI_SMDELETE) | BIT(AMI_SMFIND) | BIT(AMI_SMGOTO) |
+                BIT(AMI_SMHELPTOPIC) | BIT(AMI_SMABOUT),
                 &sm, ml);
+    /* The sheet menu's entries hang on after the standard menu is
+       built: the splice inside it appends the program's entries with a
+       routine that clears the branch link, so a submenu built before
+       the call does not survive it. */
+    newmenu(&mp, FALSE, FALSE, OFF, MENUWIDER, "Wider Columns");
+    appendmenu(&sh->branch, mp);
+    newmenu(&mp, FALSE, FALSE, ON, MENUNARROW, "Narrower Columns");
+    appendmenu(&sh->branch, mp);
+    newmenu(&mp, FALSE, FALSE, ON, MENURECALC, "Recalculate");
+    appendmenu(&sh->branch, mp);
+    newmenu(&mp, FALSE, FALSE, OFF, MENUCLEAR, "Clear Sheet");
+    appendmenu(&sh->branch, mp);
     ami_menu(stdout, sm);
+
+}
+
+/* find the next cell holding the given text, from the one after the
+   current, and go to it */
+static void findcell(const char* what)
+
+{
+
+    long i, n = (long)ROWS*COLS;
+    long x = curx, y = cury;
+
+    for (i = 0; i < n; i++) { /* every cell once, from the next */
+
+        if (++x >= COLS) { x = 0; if (++y >= ROWS) y = 0; }
+        if (cells[y][x].text && strstr(cells[y][x].text, what)) {
+
+            curx = x;
+            cury = y;
+            follow();
+            drawall();
+
+            return;
+
+        }
+
+    }
+    ami_alert("Find", "No cell holds that");
+
+}
+
+/* go to a cell by name, as A1 or BZ100 */
+static void gotocell(const char* name)
+
+{
+
+    long x, y;
+
+    pp = name;
+    perr = FALSE;
+    if (!cellref(&x, &y) || perr || *pp) {
+
+        ami_alert("Go to", "Not a cell name");
+
+        return;
+
+    }
+    curx = x;
+    cury = y;
+    follow();
+    drawall();
 
 }
 
@@ -1305,6 +1967,82 @@ int main(int argc, char* argv[])
 
                     case AMI_SMEXIT:
                         goto done;
+
+                    case AMI_SMCLOSE: /* put the sheet away */
+                        clearsheet();
+                        filename[0] = 0;
+                        layout();
+                        drawall();
+                        break;
+
+                    case AMI_SMUNDO: /* the last cell change back */
+                        if (undval) {
+
+                            char* t = undtxt;
+
+                            undtxt = NULL; /* setcell takes the current */
+                            curx = undx;
+                            cury = undy;
+                            setcell(undx, undy, t);
+                            if (t) free(t);
+                            undval = FALSE; /* one change deep */
+                            follow();
+                            drawall();
+
+                        }
+                        break;
+
+                    case AMI_SMCUT: /* the cell to the clipboard */
+                        if (clip) free(clip);
+                        clip = NULL;
+                        if (cells[cury][curx].text) {
+
+                            clip = malloc(strlen(cells[cury][curx].text)+1);
+                            if (clip) strcpy(clip, cells[cury][curx].text);
+
+                        }
+                        setcell(curx, cury, NULL);
+                        drawall();
+                        break;
+
+                    case AMI_SMPASTE: /* the clipboard to the cell */
+                        if (clip) { setcell(curx, cury, clip); drawall(); }
+                        break;
+
+                    case AMI_SMDELETE: /* empty the cell */
+                        setcell(curx, cury, NULL);
+                        drawall();
+                        break;
+
+                    case AMI_SMFIND: { /* the next cell holding text */
+
+                        ami_qfnopts opt = 0;
+
+                        fn[0] = 0;
+                        ami_queryfind(fn, sizeof(fn), &opt);
+                        if (*fn) findcell(fn);
+                        break;
+
+                    }
+
+                    case AMI_SMGOTO: { /* to a cell by name */
+
+                        ami_qfnopts opt = 0;
+
+                        fn[0] = 0;
+                        ami_queryfind(fn, sizeof(fn), &opt);
+                        if (*fn) gotocell(fn);
+                        break;
+
+                    }
+
+                    case AMI_SMHELPTOPIC:
+                        ami_alert("Spreadsheet",
+                            "Type to enter, = starts a formula. Enter goes "
+                            "down, tab goes right, escape abandons. Formulas "
+                            "take + - * / ( ) and SUM AVG MIN MAX COUNT over "
+                            "a range, as =SUM(A1:A10).");
+                        break;
 
                     case AMI_SMABOUT:
                         ami_alert("Spreadsheet",

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -1,0 +1,1041 @@
+/*******************************************************************************
+*                                                                              *
+*                              SPREADSHEET                                     *
+*                                                                              *
+* A working spreadsheet on Petit-Ami graphics: a scrolling grid of cells       *
+* holding numbers, text and formulas, with the standard menu, the standard     *
+* file dialogs, and a window that reflows when it is resized.                  *
+*                                                                              *
+* Build and run:                                                               *
+*                                                                              *
+*     make spreadsheet                                                         *
+*     bin/spreadsheet [<file>]                                                 *
+*                                                                              *
+* Using it:                                                                    *
+*                                                                              *
+* Click a cell, or move with the arrow keys, page up and down, home and end.   *
+* Type to enter: digits and text go in as typed, and a leading = makes a       *
+* formula. Enter commits and steps down, tab commits and steps right, escape   *
+* abandons the entry. Delete or backspace on a settled cell clears it.         *
+*                                                                              *
+* Formulas:                                                                    *
+*                                                                              *
+*     =A1+B2*2          the four operators, parentheses, unary minus           *
+*     =SUM(A1:A10)      SUM, AVG, MIN, MAX, COUNT over a range                 *
+*     =2*(SUM(B1:B9)+1) they nest                                              *
+*                                                                              *
+* A cell shows its value; the entry line at the top shows what the current     *
+* cell holds, which for a formula is the formula. Formulas recalculate         *
+* whenever anything changes, and a formula that cannot be evaluated shows      *
+* ERR -- a bad reference, a division by zero, or a reference cycle, which      *
+* ends at the nesting bound rather than hanging.                               *
+*                                                                              *
+* The file format is one line per non-empty cell, "A1: contents", which is     *
+* both what it writes and what it reads.                                       *
+*                                                                              *
+*                          BSD LICENSE INFORMATION                             *
+*                                                                              *
+* Copyright (C) 2026 - Scott A. Franco                                         *
+*                                                                              *
+* All rights reserved.                                                         *
+*                                                                              *
+* Redistribution and use in source and binary forms, with or without           *
+* modification, are permitted provided that the following conditions are met:  *
+*                                                                              *
+* 1. Redistributions of source code must retain the above copyright notice,    *
+*    this list of conditions and the following disclaimer.                     *
+* 2. Redistributions in binary form must reproduce the above copyright notice, *
+*    this list of conditions and the following disclaimer in the               *
+*    documentation and/or other materials provided with the distribution.      *
+* 3. Neither the name of the project nor the names of its contributors may be  *
+*    used to endorse or promote products derived from this software without    *
+*    specific prior written permission.                                        *
+*                                                                              *
+* THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND ANY  *
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE       *
+* DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY *
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES   *
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT   *
+* LIABILITY, OR TORT ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  *
+* IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                *
+*                                                                              *
+*******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+
+#include <localdefs.h>
+#include <graphics.h>
+
+#define OFF 0
+#define ON  1
+
+#define COLS     26   /* columns, A through Z */
+#define ROWS     200  /* rows */
+#define CELLEN   80   /* longest cell contents */
+#define COLDIG   9    /* column width in digits of the display font */
+#define HDRDIG   4    /* row header width in digits */
+#define MAXNEST  32   /* deepest formula evaluation, catches cycles */
+
+/* menu ids of our own, after the standard ones */
+#define MENUWIDER  (AMI_SMMAX+1) /* wider columns */
+#define MENUNARROW (AMI_SMMAX+2) /* narrower columns */
+#define MENUCLEAR  (AMI_SMMAX+3) /* clear the sheet */
+#define MENURECALC (AMI_SMMAX+4) /* recalculate */
+
+/* a cell holds what the user typed; the value is derived */
+typedef struct {
+
+    char* text;  /* contents as entered, NULL if empty */
+    double val;  /* last computed value */
+    int    isnum; /* the value is a number, not text */
+    int    err;  /* evaluation failed */
+
+} cellrec;
+
+static cellrec cells[ROWS][COLS];
+
+static long   curx, cury;      /* the current cell, 0 based */
+static long   orgx, orgy;      /* top left cell shown, 0 based */
+static long   colw, rowh;      /* cell size in pixels */
+static long   hdrw, hdrh;      /* header sizes in pixels */
+static long   cellx, celly;    /* cells that fit in the client area */
+static long   coldig = COLDIG; /* column width in digits */
+static char   entry[CELLEN];   /* the entry under construction */
+static int    entering;        /* an entry is being typed */
+static char   filename[500];   /* the file this sheet came from */
+static int    modified;        /* the sheet has unsaved changes */
+static int    evalnest;        /* formula evaluation depth */
+static long   mpx, mpy;        /* the mouse, tracked in pixels */
+
+/* the parser's position in a formula, and its error flag */
+static const char* pp;
+static int    perr;
+
+static double expr(void); /* forward */
+static void   layout(void); /* forward */
+static void   drawall(void); /* forward */
+
+/*******************************************************************************
+
+Cell naming
+
+*******************************************************************************/
+
+/* the name of a cell, as A1 */
+static void cellnam(long x, long y, char* s)
+
+{
+
+    sprintf(s, "%c%ld", (int)('A'+x), y+1);
+
+}
+
+/* parse a cell reference at the parse position; returns TRUE and the
+   coordinates if one is there */
+static int cellref(long* x, long* y)
+
+{
+
+    const char* sp = pp;
+    long r = 0;
+
+    if (!isalpha((unsigned char)*pp)) return (FALSE);
+    *x = toupper((unsigned char)*pp)-'A';
+    pp++;
+    if (!isdigit((unsigned char)*pp)) { pp = sp; return (FALSE); }
+    while (isdigit((unsigned char)*pp)) r = r*10+(*pp++-'0');
+    *y = r-1;
+    if (*x < 0 || *x >= COLS || *y < 0 || *y >= ROWS) { perr = TRUE; }
+
+    return (TRUE);
+
+}
+
+/*******************************************************************************
+
+Formula evaluation
+
+A recursive descent parser over the formula text, with the value of a
+referenced cell taken by evaluating that cell in turn. The nesting counter
+bounds the recursion, so a reference cycle ends as an error instead of a
+stack overflow.
+
+*******************************************************************************/
+
+static double cellval(long x, long y); /* forward */
+
+static void skipsp(void) { while (*pp == ' ') pp++; }
+
+/* SUM(A1:B9) and friends: the function name has been consumed */
+static double range(int fn)
+
+{
+
+    long x1, y1, x2, y2, x, y;
+    double acc = 0, v;
+    long   n = 0;
+    int    first = TRUE;
+
+    skipsp();
+    if (*pp != '(') { perr = TRUE; return (0); }
+    pp++;
+    skipsp();
+    if (!cellref(&x1, &y1)) { perr = TRUE; return (0); }
+    skipsp();
+    if (*pp != ':') { perr = TRUE; return (0); }
+    pp++;
+    skipsp();
+    if (!cellref(&x2, &y2)) { perr = TRUE; return (0); }
+    skipsp();
+    if (*pp != ')') { perr = TRUE; return (0); }
+    pp++;
+    if (perr) return (0);
+    if (x1 > x2) { x = x1; x1 = x2; x2 = x; }
+    if (y1 > y2) { y = y1; y1 = y2; y2 = y; }
+    for (y = y1; y <= y2; y++) for (x = x1; x <= x2; x++) {
+
+        if (!cells[y][x].text) continue; /* empty cells do not count */
+        v = cellval(x, y);
+        n++;
+        switch (fn) {
+
+            case 0: acc += v; break; /* SUM */
+            case 1: acc += v; break; /* AVG, divided below */
+            case 2: if (first || v < acc) acc = v; break; /* MIN */
+            case 3: if (first || v > acc) acc = v; break; /* MAX */
+            case 4: acc = n; break; /* COUNT */
+
+        }
+        first = FALSE;
+
+    }
+    if (fn == 1) acc = n? acc/n: 0;
+    if (fn == 4) acc = n;
+
+    return (acc);
+
+}
+
+/* a number, a cell reference, a function, a parenthesized expression, or
+   a unary minus before any of them */
+static double factor(void)
+
+{
+
+    double v;
+    long   x, y;
+    char   name[16];
+    int    i;
+
+    skipsp();
+    if (*pp == '-') { pp++; return (-factor()); }
+    if (*pp == '+') { pp++; return (factor()); }
+    if (*pp == '(') {
+
+        pp++;
+        v = expr();
+        skipsp();
+        if (*pp == ')') pp++; else perr = TRUE;
+
+        return (v);
+
+    }
+    if (isdigit((unsigned char)*pp) || *pp == '.')
+        return (strtod(pp, (char**)&pp));
+    if (isalpha((unsigned char)*pp)) {
+
+        /* a function name, or a cell reference */
+        i = 0;
+        while (isalpha((unsigned char)pp[i]) && i < (int)sizeof(name)-1) i++;
+        memcpy(name, pp, i);
+        name[i] = 0;
+        for (x = 0; x < i; x++) name[x] = toupper((unsigned char)name[x]);
+        if (i > 1 && (!strcmp(name, "SUM") || !strcmp(name, "AVG") ||
+                      !strcmp(name, "MIN") || !strcmp(name, "MAX") ||
+                      !strcmp(name, "COUNT"))) {
+
+            pp += i;
+
+            return (range(!strcmp(name, "SUM")? 0:
+                          !strcmp(name, "AVG")? 1:
+                          !strcmp(name, "MIN")? 2:
+                          !strcmp(name, "MAX")? 3: 4));
+
+        }
+        if (cellref(&x, &y)) {
+
+            if (perr) return (0);
+
+            return (cellval(x, y));
+
+        }
+
+    }
+    perr = TRUE;
+
+    return (0);
+
+}
+
+static double term(void)
+
+{
+
+    double v = factor();
+    double d;
+
+    for (;;) {
+
+        skipsp();
+        if (*pp == '*') { pp++; v *= factor(); }
+        else if (*pp == '/') {
+
+            pp++;
+            d = factor();
+            if (d == 0) { perr = TRUE; return (0); }
+            v /= d;
+
+        } else return (v);
+
+    }
+
+}
+
+static double expr(void)
+
+{
+
+    double v = term();
+
+    for (;;) {
+
+        skipsp();
+        if (*pp == '+') { pp++; v += term(); }
+        else if (*pp == '-') { pp++; v -= term(); }
+        else return (v);
+
+    }
+
+}
+
+/* the value of a cell: a number as itself, a formula evaluated, text as
+   zero */
+static double cellval(long x, long y)
+
+{
+
+    cellrec*    c;
+    const char* savepp;
+    int         saveerr;
+    double      v;
+    char*       ep;
+
+    if (x < 0 || x >= COLS || y < 0 || y >= ROWS) return (0);
+    c = &cells[y][x];
+    if (!c->text) return (0);
+    if (c->text[0] != '=') { /* a number, or text */
+
+        v = strtod(c->text, &ep);
+        while (*ep == ' ') ep++;
+
+        return (*ep? 0: v);
+
+    }
+    if (evalnest >= MAXNEST) { perr = TRUE; return (0); } /* a cycle */
+    evalnest++;
+    savepp = pp; /* the parse of the referring formula is suspended */
+    saveerr = perr;
+    pp = c->text+1;
+    perr = FALSE;
+    v = expr();
+    skipsp();
+    if (*pp) perr = TRUE; /* trailing junk */
+    c->err = perr;
+    c->val = v;
+    c->isnum = TRUE;
+    pp = savepp;
+    if (perr) saveerr = TRUE; /* a bad reference poisons the referrer */
+    perr = saveerr;
+    evalnest--;
+
+    return (v);
+
+}
+
+/* recompute every cell that holds a formula */
+static void recalc(void)
+
+{
+
+    long x, y;
+    cellrec* c;
+    char* ep;
+
+    for (y = 0; y < ROWS; y++) for (x = 0; x < COLS; x++) {
+
+        c = &cells[y][x];
+        c->err = FALSE;
+        c->isnum = FALSE;
+        c->val = 0;
+        if (!c->text) continue;
+        if (c->text[0] == '=') { /* a formula */
+
+            evalnest = 0;
+            perr = FALSE;
+            pp = c->text+1;
+            c->val = expr();
+            skipsp();
+            if (*pp) perr = TRUE;
+            c->err = perr;
+            c->isnum = TRUE;
+
+        } else { /* a number, or text */
+
+            c->val = strtod(c->text, &ep);
+            while (*ep == ' ') ep++;
+            c->isnum = c->text[0] && !*ep;
+
+        }
+
+    }
+
+}
+
+/*******************************************************************************
+
+Sheet contents
+
+*******************************************************************************/
+
+/* place contents in a cell, or clear it with NULL */
+static void setcell(long x, long y, const char* s)
+
+{
+
+    cellrec* c = &cells[y][x];
+
+    if (c->text) free(c->text);
+    c->text = NULL;
+    if (s && *s) {
+
+        c->text = malloc(strlen(s)+1);
+        if (!c->text) { ami_alert("spreadsheet", "Out of memory"); exit(1); }
+        strcpy(c->text, s);
+
+    }
+    modified = TRUE;
+    recalc();
+
+}
+
+/* empty the sheet */
+static void clearsheet(void)
+
+{
+
+    long x, y;
+
+    for (y = 0; y < ROWS; y++) for (x = 0; x < COLS; x++)
+        if (cells[y][x].text) {
+
+            free(cells[y][x].text);
+            cells[y][x].text = NULL;
+
+        }
+    memset(cells, 0, sizeof(cells));
+    curx = cury = 0;
+    orgx = orgy = 0;
+    modified = FALSE;
+
+}
+
+/* what a cell displays: its value, or its text, or an error */
+static void celldsp(long x, long y, char* s, long sl)
+
+{
+
+    cellrec* c = &cells[y][x];
+    double   v;
+
+    if (!c->text) { *s = 0; return; }
+    if (c->err) { snprintf(s, sl, "%s", "ERR"); return; }
+    if (c->text[0] == '=' || c->isnum) { /* a value */
+
+        v = c->val;
+        if (v == floor(v) && fabs(v) < 1e15) snprintf(s, sl, "%.0f", v);
+        else snprintf(s, sl, "%.4g", v);
+
+    } else snprintf(s, sl, "%s", c->text); /* text */
+
+}
+
+/*******************************************************************************
+
+Files
+
+*******************************************************************************/
+
+static void loadsheet(const char* fn)
+
+{
+
+    FILE* f;
+    char  line[CELLEN+40];
+    char* p;
+    long  x, y;
+
+    f = fopen(fn, "r");
+    if (!f) { ami_alert("spreadsheet", "Cannot open file"); return; }
+    clearsheet();
+    while (fgets(line, sizeof(line), f)) {
+
+        p = strchr(line, '\n');
+        if (p) *p = 0;
+        p = strchr(line, ':');
+        if (!p) continue; /* not a cell line */
+        *p++ = 0;
+        while (*p == ' ') p++;
+        pp = line;
+        perr = FALSE;
+        if (!cellref(&x, &y) || perr || *pp) continue; /* bad name */
+        if (cells[y][x].text) free(cells[y][x].text);
+        cells[y][x].text = malloc(strlen(p)+1);
+        if (!cells[y][x].text) { ami_alert("spreadsheet", "Out of memory");
+                                 exit(1); }
+        strcpy(cells[y][x].text, p);
+
+    }
+    fclose(f);
+    recalc();
+    modified = FALSE;
+    strncpy(filename, fn, sizeof(filename)-1);
+
+}
+
+static void savesheet(const char* fn)
+
+{
+
+    FILE* f;
+    long  x, y;
+    char  nam[16];
+
+    f = fopen(fn, "w");
+    if (!f) { ami_alert("spreadsheet", "Cannot write file"); return; }
+    for (y = 0; y < ROWS; y++) for (x = 0; x < COLS; x++)
+        if (cells[y][x].text) {
+
+            cellnam(x, y, nam);
+            fprintf(f, "%s: %s\n", nam, cells[y][x].text);
+
+        }
+    fclose(f);
+    modified = FALSE;
+    strncpy(filename, fn, sizeof(filename)-1);
+
+}
+
+/*******************************************************************************
+
+Display
+
+The grid is drawn from the top left cell shown, filling whatever client
+area the window has. Everything is derived from the font metrics, so the
+sheet reflows on a resize or a column width change.
+
+*******************************************************************************/
+
+/* recompute the geometry from the window and the font */
+static void layout(void)
+
+{
+
+    colw = ami_strsiz(stdout, "0")*coldig;
+    rowh = ami_chrsizy(stdout)+4;
+    hdrw = ami_strsiz(stdout, "0")*HDRDIG;
+    hdrh = rowh; /* the column header row */
+    /* the entry line sits above the grid, one row tall with a margin */
+    cellx = (ami_maxxg(stdout)-hdrw)/colw;
+    celly = (ami_maxyg(stdout)-hdrh-rowh*2)/rowh;
+    if (cellx < 1) cellx = 1;
+    if (celly < 1) celly = 1;
+
+}
+
+/* the pixel origin of a displayed cell */
+static void cellpos(long x, long y, long* px, long* py)
+
+{
+
+    *px = hdrw+(x-orgx)*colw+1;
+    *py = rowh*2+hdrh+(y-orgy)*rowh+1;
+
+}
+
+/* draw one cell, headers included in the caller's frame */
+static void drawcell(long x, long y)
+
+{
+
+    long px, py;
+    char s[CELLEN];
+    long tw;
+
+    if (x < orgx || x >= orgx+cellx || y < orgy || y >= orgy+celly) return;
+    cellpos(x, y, &px, &py);
+    /* the cell face: the current cell is marked */
+    if (x == curx && y == cury) ami_fcolor(stdout, ami_cyan);
+    else ami_fcolor(stdout, ami_white);
+    ami_frect(stdout, px, py, px+colw-2, py+rowh-2);
+    ami_fcolor(stdout, ami_black);
+    if (entering && x == curx && y == cury) strcpy(s, entry);
+    else celldsp(x, y, s, sizeof(s));
+    if (*s) {
+
+        /* numbers to the right, text to the left, as a sheet does */
+        tw = ami_strsiz(stdout, s);
+        if (tw > colw-4) tw = colw-4;
+        if (!entering && cells[y][x].text &&
+            (cells[y][x].isnum || cells[y][x].text[0] == '=' ||
+             cells[y][x].err))
+            ami_cursorg(stdout, px+colw-3-tw, py+2);
+        else ami_cursorg(stdout, px+2, py+2);
+        /* clipped to the cell by the window's own edge; keep it short */
+        if (ami_strsiz(stdout, s) > colw-4) {
+
+            long i = strlen(s);
+            while (i && ami_strsiz(stdout, s) > colw-4) s[--i] = 0;
+
+        }
+        fprintf(stdout, "%s", s);
+
+    }
+
+}
+
+/* the whole window: entry line, headers, cells, grid */
+static void drawall(void)
+
+{
+
+    long x, y, px, py;
+    char s[CELLEN+40];
+    char nam[16];
+
+    ami_fcolor(stdout, ami_white);
+    ami_frect(stdout, 1, 1, ami_maxxg(stdout), ami_maxyg(stdout));
+    /* the entry line: the current cell and what it holds */
+    cellnam(curx, cury, nam);
+    if (entering) snprintf(s, sizeof(s), "%s  %s_", nam, entry);
+    else snprintf(s, sizeof(s), "%s  %s", nam,
+                  cells[cury][curx].text? cells[cury][curx].text: "");
+    ami_fcolor(stdout, ami_black);
+    ami_cursorg(stdout, 2, 2);
+    fprintf(stdout, "%s", s);
+    ami_line(stdout, 1, rowh*2-2, ami_maxxg(stdout), rowh*2-2);
+    /* the column headers */
+    ami_fcolor(stdout, ami_yellow);
+    ami_frect(stdout, 1, rowh*2, ami_maxxg(stdout), rowh*2+hdrh-1);
+    ami_frect(stdout, 1, rowh*2, hdrw-1, ami_maxyg(stdout));
+    ami_fcolor(stdout, ami_black);
+    for (x = orgx; x < orgx+cellx && x < COLS; x++) {
+
+        cellpos(x, orgy, &px, &py);
+        sprintf(s, "%c", (int)('A'+x));
+        ami_cursorg(stdout, px+colw/2-ami_strsiz(stdout, s)/2, rowh*2+2);
+        fprintf(stdout, "%s", s);
+
+    }
+    /* the row headers */
+    for (y = orgy; y < orgy+celly && y < ROWS; y++) {
+
+        cellpos(orgx, y, &px, &py);
+        sprintf(s, "%ld", y+1);
+        ami_cursorg(stdout, hdrw-2-ami_strsiz(stdout, s), py+2);
+        fprintf(stdout, "%s", s);
+
+    }
+    /* the cells */
+    for (y = orgy; y < orgy+celly && y < ROWS; y++)
+        for (x = orgx; x < orgx+cellx && x < COLS; x++) drawcell(x, y);
+    /* the grid lines */
+    ami_fcolor(stdout, ami_black);
+    for (x = orgx; x <= orgx+cellx && x <= COLS; x++) {
+
+        cellpos(x, orgy, &px, &py);
+        ami_line(stdout, px-1, rowh*2, px-1, ami_maxyg(stdout));
+
+    }
+    for (y = orgy; y <= orgy+celly && y <= ROWS; y++) {
+
+        cellpos(orgx, y, &px, &py);
+        ami_line(stdout, 1, py-1, ami_maxxg(stdout), py-1);
+
+    }
+
+}
+
+/* bring the current cell into view, and redraw if the view moved */
+static void follow(void)
+
+{
+
+    long ox = orgx, oy = orgy;
+
+    if (curx < orgx) orgx = curx;
+    if (curx >= orgx+cellx) orgx = curx-cellx+1;
+    if (cury < orgy) orgy = cury;
+    if (cury >= orgy+celly) orgy = cury-celly+1;
+    if (orgx < 0) orgx = 0;
+    if (orgy < 0) orgy = 0;
+    if (ox != orgx || oy != orgy) drawall();
+
+}
+
+/*******************************************************************************
+
+Menu
+
+*******************************************************************************/
+
+static void appendmenu(ami_menuptr* list, ami_menuptr m)
+
+{
+
+    ami_menuptr lp;
+
+    m->next = NULL;
+    m->branch = NULL;
+    if (!*list) *list = m;
+    else { lp = *list; while (lp->next) lp = lp->next; lp->next = m; }
+
+}
+
+static void newmenu(ami_menuptr* mp, int onoff, int oneof, int bar,
+                    int id, const char* face)
+
+{
+
+    *mp = malloc(sizeof(ami_menurec));
+    if (!*mp) { ami_alert("spreadsheet", "Out of memory"); exit(1); }
+    (*mp)->onoff = onoff;
+    (*mp)->oneof = oneof;
+    (*mp)->bar = bar;
+    (*mp)->id = id;
+    (*mp)->face = malloc(strlen(face)+1);
+    if (!(*mp)->face) { ami_alert("spreadsheet", "Out of memory"); exit(1); }
+    strcpy((*mp)->face, face);
+    (*mp)->next = NULL;
+    (*mp)->branch = NULL;
+
+}
+
+/* the standard file and edit menus, with a sheet menu of our own after */
+static void setupmenu(void)
+
+{
+
+    ami_menuptr ml = NULL; /* our own entries */
+    ami_menuptr mp;
+    ami_menuptr sm = NULL; /* the completed menu */
+
+    newmenu(&mp, FALSE, FALSE, OFF, MENUWIDER, "Wider columns");
+    appendmenu(&ml, mp);
+    newmenu(&mp, FALSE, FALSE, OFF, MENUNARROW, "Narrower columns");
+    appendmenu(&ml, mp);
+    newmenu(&mp, FALSE, FALSE, OFF, MENURECALC, "Recalculate");
+    appendmenu(&ml, mp);
+    newmenu(&mp, FALSE, FALSE, OFF, MENUCLEAR, "Clear sheet");
+    appendmenu(&ml, mp);
+    ami_stdmenu(BIT(AMI_SMNEW) | BIT(AMI_SMOPEN) | BIT(AMI_SMSAVE) |
+                BIT(AMI_SMSAVEAS) | BIT(AMI_SMEXIT) | BIT(AMI_SMABOUT),
+                &sm, ml);
+    ami_menu(stdout, sm);
+
+}
+
+/*******************************************************************************
+
+Entry
+
+*******************************************************************************/
+
+/* start typing into the current cell */
+static void startentry(char first)
+
+{
+
+    entering = TRUE;
+    entry[0] = first;
+    entry[1] = 0;
+    drawall();
+
+}
+
+/* commit what was typed */
+static void commit(void)
+
+{
+
+    if (!entering) return;
+    entering = FALSE;
+    setcell(curx, cury, entry);
+    entry[0] = 0;
+
+}
+
+/*******************************************************************************
+
+Main
+
+*******************************************************************************/
+
+int main(int argc, char* argv[])
+
+{
+
+    ami_evtrec er;
+    char  fn[500];
+    long  x, y;
+
+    ami_title(stdout, "Spreadsheet");
+    ami_curvis(stdout, FALSE);
+    ami_auto(stdout, FALSE);
+    ami_font(stdout, AMI_FONT_TERM); /* a fixed pitch font suits a grid */
+    ami_fontsiz(stdout, 20);
+    ami_binvis(stdout);
+    setupmenu();
+    clearsheet();
+    if (argc > 1) loadsheet(argv[1]);
+    layout();
+    drawall();
+    do {
+
+        ami_event(stdin, &er);
+        switch (er.etype) {
+
+            case ami_etredraw:
+            case ami_etresize:
+                layout();
+                follow();
+                drawall();
+                break;
+
+            case ami_etmoumovg: /* the mouse, for the next click */
+                mpx = er.moupxg;
+                mpy = er.moupyg;
+                break;
+
+            case ami_etmouba: /* a click picks a cell */
+                if (er.amoubn != 1) break;
+                if (mpx < hdrw || mpy < rowh*2+hdrh) break;
+                x = (mpx-hdrw)/colw+orgx;
+                y = (mpy-rowh*2-hdrh)/rowh+orgy;
+                if (x < 0 || x >= COLS || y < 0 || y >= ROWS) break;
+                commit();
+                curx = x;
+                cury = y;
+                drawall();
+                break;
+
+            case ami_etchar: /* typing enters */
+                if (er.echar >= ' ' && er.echar != 0x7f) {
+
+                    if (!entering) startentry(er.echar);
+                    else if (strlen(entry) < CELLEN-1) {
+
+                        entry[strlen(entry)+1] = 0;
+                        entry[strlen(entry)] = er.echar;
+                        drawall();
+
+                    }
+
+                }
+                break;
+
+            case ami_etenter: /* commit and step down */
+                commit();
+                if (cury < ROWS-1) cury++;
+                follow();
+                drawall();
+                break;
+
+            case ami_ettab: /* commit and step right */
+                commit();
+                if (curx < COLS-1) curx++;
+                follow();
+                drawall();
+                break;
+
+            case ami_etcan: /* abandon the entry */
+                entering = FALSE;
+                entry[0] = 0;
+                drawall();
+                break;
+
+            case ami_etdelcb: /* backspace: in an entry, or clear the cell */
+                if (entering) {
+
+                    if (*entry) entry[strlen(entry)-1] = 0;
+                    if (!*entry) entering = FALSE;
+
+                } else setcell(curx, cury, NULL);
+                drawall();
+                break;
+
+            case ami_etdelcf: /* delete clears the cell */
+                if (!entering) setcell(curx, cury, NULL);
+                drawall();
+                break;
+
+            case ami_etup:
+                commit();
+                if (cury) cury--;
+                follow();
+                drawall();
+                break;
+
+            case ami_etdown:
+                commit();
+                if (cury < ROWS-1) cury++;
+                follow();
+                drawall();
+                break;
+
+            case ami_etleft:
+                commit();
+                if (curx) curx--;
+                follow();
+                drawall();
+                break;
+
+            case ami_etright:
+                commit();
+                if (curx < COLS-1) curx++;
+                follow();
+                drawall();
+                break;
+
+            case ami_etpagu:
+                commit();
+                cury -= celly;
+                if (cury < 0) cury = 0;
+                follow();
+                drawall();
+                break;
+
+            case ami_etpagd:
+                commit();
+                cury += celly;
+                if (cury >= ROWS) cury = ROWS-1;
+                follow();
+                drawall();
+                break;
+
+            case ami_ethome:
+            case ami_ethomes:
+                commit();
+                curx = 0;
+                cury = 0;
+                follow();
+                drawall();
+                break;
+
+            case ami_ethomel:
+                commit();
+                curx = 0;
+                follow();
+                drawall();
+                break;
+
+            case ami_etendl:
+                commit();
+                /* the last occupied cell in the row, or the first */
+                for (x = COLS-1; x > 0 && !cells[cury][x].text; x--);
+                curx = x;
+                follow();
+                drawall();
+                break;
+
+            case ami_etmenus: /* the menu */
+                switch (er.menuid) {
+
+                    case AMI_SMNEW:
+                        clearsheet();
+                        filename[0] = 0;
+                        drawall();
+                        break;
+
+                    case AMI_SMOPEN:
+                        fn[0] = 0;
+                        ami_queryopen(fn, sizeof(fn));
+                        if (*fn) { loadsheet(fn); layout(); drawall(); }
+                        break;
+
+                    case AMI_SMSAVE:
+                        if (*filename) savesheet(filename);
+                        else {
+
+                            fn[0] = 0;
+                            ami_querysave(fn, sizeof(fn));
+                            if (*fn) savesheet(fn);
+
+                        }
+                        break;
+
+                    case AMI_SMSAVEAS:
+                        strcpy(fn, filename);
+                        ami_querysave(fn, sizeof(fn));
+                        if (*fn) savesheet(fn);
+                        break;
+
+                    case AMI_SMEXIT:
+                        goto done;
+
+                    case AMI_SMABOUT:
+                        ami_alert("Spreadsheet",
+                                  "A spreadsheet on Petit-Ami graphics");
+                        break;
+
+                    case MENUWIDER:
+                        if (coldig < 20) coldig++;
+                        layout();
+                        follow();
+                        drawall();
+                        break;
+
+                    case MENUNARROW:
+                        if (coldig > 5) coldig--;
+                        layout();
+                        follow();
+                        drawall();
+                        break;
+
+                    case MENURECALC:
+                        recalc();
+                        drawall();
+                        break;
+
+                    case MENUCLEAR:
+                        clearsheet();
+                        drawall();
+                        break;
+
+                }
+                break;
+
+            default: break;
+
+        }
+
+    } while (er.etype != ami_etterm);
+    done:
+
+    return (0);
+
+}

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -822,8 +822,13 @@ static void follow(void)
 
 }
 
-/* scroll the view without moving the current cell, as the bars do */
-static void scrollto(long nx, long ny)
+/* Scroll the view without moving the current cell, as the bars do. The
+   bar the scroll came from, if any, is left alone: it reported where the
+   user put its slider and has been set there, and setting it again from
+   the view would drag the slider back to the nearest whole cell -- which
+   on a bar with few cells of travel is most of the way back where it
+   started, so the bar appeared not to work. */
+static void scrollto(long nx, long ny, long frombar)
 
 {
 
@@ -834,8 +839,8 @@ static void scrollto(long nx, long ny)
     clamporg();
     if (ox != orgx || oy != orgy) {
 
-        setbar(SBVERT, orgy, celly, ROWS);
-        setbar(SBHORIZ, orgx, cellx, COLS);
+        if (frombar != SBVERT) setbar(SBVERT, orgy, celly, ROWS);
+        if (frombar != SBHORIZ) setbar(SBHORIZ, orgx, cellx, COLS);
         drawall();
 
     }
@@ -1155,30 +1160,33 @@ int main(int argc, char* argv[])
                 break;
 
             case ami_etsclull: /* a line back */
-                if (er.sclulid == SBVERT) scrollto(orgx, orgy-1);
-                else scrollto(orgx-1, orgy);
+                if (er.sclulid == SBVERT) scrollto(orgx, orgy-1, 0);
+                else scrollto(orgx-1, orgy, 0);
                 break;
 
             case ami_etscldrl: /* a line on */
-                if (er.scldrid == SBVERT) scrollto(orgx, orgy+1);
-                else scrollto(orgx+1, orgy);
+                if (er.scldrid == SBVERT) scrollto(orgx, orgy+1, 0);
+                else scrollto(orgx+1, orgy, 0);
                 break;
 
             case ami_etsclulp: /* a page back */
-                if (er.sclupid == SBVERT) scrollto(orgx, orgy-celly);
-                else scrollto(orgx-cellx, orgy);
+                if (er.sclupid == SBVERT) scrollto(orgx, orgy-celly, 0);
+                else scrollto(orgx-cellx, orgy, 0);
                 break;
 
             case ami_etscldrp: /* a page on */
-                if (er.scldpid == SBVERT) scrollto(orgx, orgy+celly);
-                else scrollto(orgx+cellx, orgy);
+                if (er.scldpid == SBVERT) scrollto(orgx, orgy+celly, 0);
+                else scrollto(orgx+cellx, orgy, 0);
                 break;
 
-            case ami_etsclpos: /* dragged to a position */
+            case ami_etsclpos: /* the slider was placed */
+                /* the slider goes where the user put it, then the view
+                   follows from there */
+                ami_scrollpos(stdout, er.sclpid, er.sclpos);
                 if (er.sclpid == SBVERT)
-                    scrollto(orgx, barcell(er.sclpos, ROWS-celly));
+                    scrollto(orgx, barcell(er.sclpos, ROWS-celly), SBVERT);
                 else
-                    scrollto(barcell(er.sclpos, COLS-cellx), orgy);
+                    scrollto(barcell(er.sclpos, COLS-cellx), orgy, SBHORIZ);
                 break;
 
             case ami_etmenus: /* the menu */

--- a/graph_programs/spreadsheet.c
+++ b/graph_programs/spreadsheet.c
@@ -807,7 +807,9 @@ int main(int argc, char* argv[])
     ami_curvis(stdout, FALSE);
     ami_auto(stdout, FALSE);
     ami_font(stdout, AMI_FONT_TERM); /* a fixed pitch font suits a grid */
-    ami_fontsiz(stdout, 20);
+    /* by point size, so the sheet is the same size on any display: a
+       pixel height would come out small on a high density screen */
+    ami_setpoints(stdout, 12.0);
     ami_binvis(stdout);
     setupmenu();
     clearsheet();

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -6406,6 +6406,14 @@ static void remmen(metptr mp)
         /* if window file is open, close it */
         if (mp->wf && !mp->prime) {
 
+            /* Clear the window to menu tracking entry with it. The entry
+               was left in place, so the next window to be given this id
+               -- ids return to use as windows close, and a menu opens
+               and closes them freely -- had its events dispatched to
+               this entry, whose file is now gone: the next dialog to
+               open drew through a null file and died with "File is
+               invalid". */
+            xltmnu[mp->wid+MAXFIL] = NULL;
             fclose(mp->wf); /* close */
             mp->wf = NULL; /* clear file link */
             mp->pressed = FALSE; /* remove any press status */

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -53,6 +53,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <time.h>
 
 /* linux definitions */
 #include <limits.h>
@@ -6599,6 +6600,22 @@ in the buffer.
 #define QFL_ID_PATH     3
 #define QFL_ID_LIST     4
 #define QFL_ID_NAME     5
+#define QFL_ID_PLACES   6 /* the places at the left */
+
+/* Rebuild the file list for the directory now current. The widget is
+   made anew rather than refilled, which is what the widget set gives;
+   killing it frees the old list, so the old pointer must not be touched
+   after. Kept in one place because the geometry must match the layout
+   below wherever the list is rebuilt. */
+#define QFL_RELIST() do { \
+    ami_killwidget(out, QFL_ID_LIST); \
+    listsp = build_qfl_list(curdir); \
+    wp = getwig(); \
+    wp->strlst = listsp; \
+    widget(out, chrw*16, titbot+chrsz*3.4, chrw*78, titbot+chrsz*19.0, \
+           "", QFL_ID_LIST, wtlistbox, &wp); \
+    ami_font(fndwig(out, QFL_ID_LIST)->wf, AMI_FONT_TERM); \
+} while (0)
 
 /*
  * Build a listbox string list for directory `dir`. Directories get a trailing
@@ -6606,18 +6623,145 @@ in the buffer.
  * Returns a list suitable to pass to widget(...wtlistbox...).
  * Caller must pass the returned list to free_qfl_list() when done.
  */
+/* The places: the directories a file is most often wanted from. The
+   home directory and the standard folders under it, each shown by its
+   own name and carrying its path. */
+static const char* qfl_places[] = {
+
+    "Home", "", "Desktop", "Desktop", "Documents", "Documents",
+    "Downloads", "Downloads", "Music", "Music", "Pictures", "Pictures",
+    "Videos", "Videos", NULL, NULL
+
+};
+
+static ami_strptr build_qfl_places(void)
+
+{
+
+    ami_strptr head = NULL, tail = NULL, e;
+    long i;
+
+    for (i = 0; qfl_places[i]; i += 2) {
+
+        e = malloc(sizeof(ami_strrec));
+        if (!e) break;
+        e->next = NULL;
+        e->str = strdup(qfl_places[i]);
+        if (!head) head = e; else tail->next = e;
+        tail = e;
+
+    }
+
+    return (head);
+
+}
+
+/* the path a place stands for */
+static void qfl_placepath(long n, char* d, long dl)
+
+{
+
+    const char* home = getenv("HOME");
+
+    if (!home) home = "/";
+    if (n < 1) { strncpy(d, home, dl-1); d[dl-1] = 0; return; }
+    if (!qfl_places[(n-1)*2]) { strncpy(d, home, dl-1); d[dl-1] = 0; return; }
+    snprintf(d, dl, "%s%s%s", home, qfl_places[(n-1)*2+1][0]? "/": "",
+             qfl_places[(n-1)*2+1]);
+
+}
+
+/* An entry as the list shows it: the name, then its size and the date it
+   was last changed, in columns. The list is set in the fixed pitch font,
+   so the columns line up under their headings. */
+#define QFL_NAMEW 32 /* the name column, in characters */
+
+static void qfl_entry(char* d, long dl, const char* name, int isdir,
+                      long long size, long modify)
+
+{
+
+    char   szs[32];
+    char   dts[32];
+    char   tms[32];
+    long   i;
+
+    /* the name, cut with an ellipsis if it will not fit its column */
+    for (i = 0; i < QFL_NAMEW && name[i]; i++) d[i] = name[i];
+    if (name[i]) { d[QFL_NAMEW-3] = '.'; d[QFL_NAMEW-2] = '.';
+                   d[QFL_NAMEW-1] = '.'; i = QFL_NAMEW; }
+    if (isdir && i < QFL_NAMEW) d[i++] = '/';
+    while (i < QFL_NAMEW+1) d[i++] = ' ';
+    /* the size, in the units it reads best in; a directory has none */
+    if (isdir) strcpy(szs, "");
+    else if (size < 1000LL) sprintf(szs, "%lld B", size);
+    else if (size < 1000000LL) sprintf(szs, "%.1f kB", size/1000.0);
+    else if (size < 1000000000LL) sprintf(szs, "%.1f MB", size/1000000.0);
+    else sprintf(szs, "%.1f GB", size/1000000000.0);
+    for (i = 0; i < 10-(long)strlen(szs); i++) d[QFL_NAMEW+1+i] = ' ';
+    strcpy(d+QFL_NAMEW+1+i, szs); /* right aligned, as sizes read */
+    i = strlen(d);
+    d[i++] = ' ';
+    d[i++] = ' ';
+    /* The date and time last changed, through the services module's own
+       formatters: the time in a file record is its own, not the C
+       library's, and reading it as the C library's put every file in
+       another century. */
+    if (modify) {
+
+        ami_dates(dts, sizeof(dts), ami_local(modify));
+        ami_times(tms, sizeof(tms), ami_local(modify));
+        snprintf(d+i, dl-i, "%s %s", dts, tms);
+
+    } else d[i] = 0; /* nothing to say, as for .. */
+
+}
+
+/* The name out of a list entry, which carries its columns: the name
+   fills the first field, padded, and a directory ends with a slash.
+   Returns whether the entry is a directory. */
+static int qfl_name(const char* e, char* d, long dl)
+
+{
+
+    long i = 0, isdir;
+
+    while (i < QFL_NAMEW && e[i] && e[i] != ' ' && i < dl-1) { d[i] = e[i];
+                                                              i++; }
+    d[i] = 0;
+    isdir = i > 0 && d[i-1] == '/';
+    if (isdir) d[i-1] = 0; /* the slash marks it, it is not in the name */
+
+    return (isdir);
+
+}
+
+/* directories before files, and each in name order, which is how a file
+   list is expected to arrive */
+static int qfl_before(const char* an, int ad, const char* bn, int bd)
+
+{
+
+    if (ad != bd) return (ad); /* a directory leads a file */
+
+    return (strcasecmp(an, bn) < 0);
+
+}
+
 static ami_strptr build_qfl_list(const char* dir) {
 
     ami_filrec *files = NULL;
     ami_strptr  head = NULL;
     ami_strptr  tail = NULL;
     char        pat[4096];
+    char        line[256];
     long        dl;
 
     /* always include ".." for navigation */
     head = malloc(sizeof(ami_strrec));
     head->next = NULL;
-    head->str  = strdup("../");
+    qfl_entry(line, sizeof(line), "..", TRUE, 0, 0);
+    head->str  = strdup(line);
     tail = head;
 
     /* ami_list() treats its argument as dir + wildcard-filename. To list
@@ -6630,21 +6774,28 @@ static ami_strptr build_qfl_list(const char* dir) {
     ami_list(pat, &files);
     for (ami_filrec *fp = files; fp; fp = fp->next) {
         long is_dir;
-        size_t nl;
-        ami_strptr e;
+        ami_strptr e, lp;
         if (!fp->name) continue;
-        if (fp->name[0] == '.' && fp->name[1] == 0) continue; /* skip "." */
-        if (fp->name[0] == '.' && fp->name[1] == '.' && fp->name[2] == 0)
-            continue; /* already added */
+        /* the hidden entries stay hidden, as a file dialog shows them
+           only when asked; .. is already in the list */
+        if (fp->name[0] == '.') continue;
         is_dir = !!(fp->attr & (1L << ami_atdir));
-        nl = strlen(fp->name);
+        qfl_entry(line, sizeof(line), fp->name, is_dir, fp->size, fp->modify);
         e = malloc(sizeof(ami_strrec));
         e->next = NULL;
-        e->str  = malloc(nl + 2);
-        strcpy(e->str, fp->name);
-        if (is_dir) strcat(e->str, "/");
-        tail->next = e;
-        tail = e;
+        e->str  = strdup(line);
+        /* in place, after the entries that come before it. The first
+           entry is always .., which nothing displaces */
+        lp = head;
+        while (lp->next &&
+               !qfl_before(e->str, is_dir, lp->next->str,
+                           strchr(lp->next->str, '/') != NULL &&
+                           strchr(lp->next->str, '/') <
+                               lp->next->str+QFL_NAMEW+1))
+            lp = lp->next;
+        e->next = lp->next;
+        lp->next = e;
+        if (tail == lp) tail = e;
     }
 
     /* NOTE: ami_list's returned records are owned by services; we do not
@@ -6746,6 +6897,8 @@ static void qfl_dialog(char* s, long sl, const char* title) {
     char       curdir[4096];
     char       curfile[512];
     ami_strptr listsp;
+    ami_strptr plcsp;
+    long       chrw; /* character width, for the horizontal */
     char       tmpbuf[4096];
     long       i;
 
@@ -6791,8 +6944,13 @@ static void qfl_dialog(char* s, long sl, const char* title) {
 
     chrsz = ami_chrsizy(out);
     titbot = chrsz*1.6;
+    /* The horizontal is laid out in character widths and the vertical in
+       character heights. Both were the height before, so every width came
+       out twice what it read as: the dialog was half again wider than the
+       screen it had to fit. */
+    chrw = ami_strsiz(out, "0");
 
-    ami_setsizg(out, chrsz*50, titbot+chrsz*22);
+    ami_setsizg(out, chrw*79, titbot+chrsz*24);
 
     ami_scnceng(out, &sx, &sy);
     ami_getsizg(out, &x, &y);
@@ -6801,9 +6959,17 @@ static void qfl_dialog(char* s, long sl, const char* title) {
 
     /* path edit box: current directory */
     wp = getwig();
-    widget(out, chrsz*6, titbot+chrsz*0.6,
-                chrsz*49, titbot+chrsz*2.0, "", QFL_ID_PATH, wteditbox, &wp);
+    widget(out, chrw*6, titbot+chrsz*0.6,
+                chrw*78, titbot+chrsz*2.0, "", QFL_ID_PATH, wteditbox, &wp);
     ami_putwidgettext(out, QFL_ID_PATH, curdir);
+
+    /* The places at the left: the directories a file is most often
+       wanted from, which saves typing a path to reach them. */
+    plcsp = build_qfl_places();
+    wp = getwig();
+    wp->strlst = plcsp;
+    widget(out, chrw, titbot+chrsz*3.4,
+                chrw*15, titbot+chrsz*19.0, "", QFL_ID_PLACES, wtlistbox, &wp);
 
     /* file list box. Set wp->strlst BEFORE widget() so that any draws
        during construction see a populated list. The widget will free the
@@ -6811,27 +6977,30 @@ static void qfl_dialog(char* s, long sl, const char* title) {
     listsp = build_qfl_list(curdir);
     wp = getwig();
     wp->strlst = listsp;
-    widget(out, chrsz, titbot+chrsz*2.5,
-                chrsz*49, titbot+chrsz*18.0, "", QFL_ID_LIST, wtlistbox, &wp);
+    widget(out, chrw*16, titbot+chrsz*3.4,
+                chrw*78, titbot+chrsz*19.0, "", QFL_ID_LIST, wtlistbox, &wp);
+    /* the list is set in the fixed pitch font, so its columns line up
+       under the headings drawn above it */
+    ami_font(fndwig(out, QFL_ID_LIST)->wf, AMI_FONT_TERM);
 
     /* filename edit box */
     wp = getwig();
-    widget(out, chrsz*6, titbot+chrsz*18.8,
-                chrsz*35, titbot+chrsz*20.2, "", QFL_ID_NAME, wteditbox, &wp);
+    widget(out, chrw*6, titbot+chrsz*19.8,
+                chrw*60, titbot+chrsz*21.2, "", QFL_ID_NAME, wteditbox, &wp);
     if (curfile[0]) ami_putwidgettext(out, QFL_ID_NAME, curfile);
 
     /* OK button */
     wp = getwig();
     wp->cbc = &select_cbc;
-    widget(out, chrsz*37, titbot+chrsz*18.7,
-                chrsz*43, titbot+chrsz*20.3, "OK",
+    widget(out, chrw*62, titbot+chrsz*19.7,
+                chrw*69, titbot+chrsz*21.3, "Open",
                 QFL_ID_OK, wtcbutton, &wp);
 
     /* Cancel button */
     wp = getwig();
     wp->cbc = &cancel_cbc;
-    widget(out, chrsz*44, titbot+chrsz*18.7,
-                chrsz*49, titbot+chrsz*20.3, "Cancel",
+    widget(out, chrw*70, titbot+chrsz*19.7,
+                chrw*78, titbot+chrsz*21.3, "Cancel",
                 QFL_ID_CANCEL, wtcbutton, &wp);
 
     mpy = 0;
@@ -6857,46 +7026,53 @@ static void qfl_dialog(char* s, long sl, const char* title) {
                 fputs(title, out);
                 ami_bold(out, FALSE);
                 ami_fcolor(out, ami_black);
-                ami_cursorg(out, chrsz, titbot+chrsz*0.9);
+                ami_cursorg(out, chrw, titbot+chrsz*0.9);
                 fputs("Path:", out);
-                ami_cursorg(out, chrsz, titbot+chrsz*19.1);
+                ami_cursorg(out, chrw, titbot+chrsz*20.1);
                 fputs("Name:", out);
+                /* the headings over the two lists. The file headings are
+                   set in the fixed pitch font the list itself uses, so
+                   they stand over their columns. */
+                ami_bold(out, TRUE);
+                ami_cursorg(out, chrw, titbot+chrsz*2.4);
+                fputs("Places", out);
+                ami_font(out, AMI_FONT_TERM);
+                ami_cursorg(out, chrw*16, titbot+chrsz*2.4);
+                fputs("Name                             "
+                      "      Size  Modified", out);
+                ami_font(out, AMI_FONT_SIGN);
+                ami_bold(out, FALSE);
                 break;
 
             case ami_etlstbox:
-                if (er.lstbid == QFL_ID_LIST) {
+                if (er.lstbid == QFL_ID_PLACES) { /* to a place */
+
+                    qfl_placepath(er.lstbsl, tmpbuf, sizeof(tmpbuf));
+                    normalize_dir(curdir, sizeof(curdir), tmpbuf);
+                    QFL_RELIST();
+                    ami_putwidgettext(out, QFL_ID_PATH, curdir);
+
+                } else if (er.lstbid == QFL_ID_LIST) {
                     /* find the selected string */
                     ami_strptr sp = listsp;
                     long n = er.lstbsl;
                     for (i = 1; i < n && sp; i++) sp = sp->next;
                     if (sp && sp->str) {
-                        long l = (long)strlen(sp->str);
-                        long is_dir = (l > 0 && sp->str[l-1] == '/');
+                        char name[512];
+                        long is_dir = qfl_name(sp->str, name, sizeof(name));
                         if (is_dir) {
                             /* navigate into this directory */
-                            char trimmed[512];
-                            long tl = l - 1;
-                            if (tl >= (long)sizeof(trimmed))
-                                tl = sizeof(trimmed)-1;
-                            memcpy(trimmed, sp->str, tl);
-                            trimmed[tl] = 0;
-                            join_path(tmpbuf, sizeof(tmpbuf), curdir, trimmed);
+                            join_path(tmpbuf, sizeof(tmpbuf), curdir, name);
                             normalize_dir(curdir, sizeof(curdir), tmpbuf);
                             /* rebuild listbox. ami_killwidget frees the
                                previous strlst via putwig, so we must not
                                touch the old listsp pointer. */
-                            ami_killwidget(out, QFL_ID_LIST);
-                            listsp = build_qfl_list(curdir);
-                            wp = getwig();
-                            wp->strlst = listsp; /* set before widget() */
-                            widget(out, chrsz, titbot+chrsz*2.5,
-                                        chrsz*49, titbot+chrsz*18.0,
-                                        "", QFL_ID_LIST, wtlistbox, &wp);
+                            QFL_RELIST();
                             /* update path edit */
                             ami_putwidgettext(out, QFL_ID_PATH, curdir);
                         } else {
                             /* file selected: copy to name edit box */
-                            ami_putwidgettext(out, QFL_ID_NAME, sp->str);
+                            ami_putwidgettext(out, QFL_ID_NAME, name);
                         }
                     }
                 }
@@ -6907,13 +7083,7 @@ static void qfl_dialog(char* s, long sl, const char* title) {
                     /* user pressed enter in path: reload */
                     getwidgettextz(out, QFL_ID_PATH, curdir, sizeof(curdir));
                     if (curdir[0] == 0) { curdir[0]='.'; curdir[1]=0; }
-                    ami_killwidget(out, QFL_ID_LIST);
-                    listsp = build_qfl_list(curdir);
-                    wp = getwig();
-                    wp->strlst = listsp;
-                    widget(out, chrsz, titbot+chrsz*2.5,
-                                chrsz*49, titbot+chrsz*18.0,
-                                "", QFL_ID_LIST, wtlistbox, &wp);
+                    QFL_RELIST();
                 } else if (er.edtbid == QFL_ID_NAME) {
                     er.etype = ami_etterm; /* enter in name = OK */
                 }

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -6703,15 +6703,31 @@ static void qfl_entry(char* d, long dl, const char* name, int isdir,
     i = strlen(d);
     d[i++] = ' ';
     d[i++] = ' ';
-    /* The date and time last changed, through the services module's own
-       formatters: the time in a file record is its own, not the C
-       library's, and reading it as the C library's put every file in
+    /* When it was last changed, said the way a file list says it: the
+       time alone for today, Yesterday for the day before, the day and
+       month within the year, and the year as well for anything older.
+       The times here are the services module's own, not the C
+       library's, and read as the C library's every file landed in
        another century. */
     if (modify) {
 
-        ami_dates(dts, sizeof(dts), ami_local(modify));
-        ami_times(tms, sizeof(tms), ami_local(modify));
-        snprintf(d+i, dl-i, "%s %s", dts, tms);
+        long lt = ami_local(modify);
+        long now = ami_local(ami_time());
+        long day = 24L*60*60; /* a day: these times count in seconds */
+        char yr[32]; /* the formatter writes a whole date, not four
+                        characters: a short buffer is an error to it */
+
+        ami_dates(dts, sizeof(dts), lt);
+        ami_times(tms, sizeof(tms), lt);
+        if (strlen(tms) > 5) strcpy(tms+5, tms+8); /* drop the seconds */
+        ami_dates(yr, sizeof(yr), now);
+        yr[4] = 0; /* this year, to compare against */
+        if (now >= lt && now-lt < day) snprintf(d+i, dl-i, "%s", tms);
+        else if (now >= lt && now-lt < 2*day)
+            snprintf(d+i, dl-i, "Yesterday");
+        else if (!strncmp(dts, yr, 4)) /* this year: no need to say which */
+            snprintf(d+i, dl-i, "%s", dts+5);
+        else snprintf(d+i, dl-i, "%s", dts);
 
     } else d[i] = 0; /* nothing to say, as for .. */
 
@@ -6943,7 +6959,10 @@ static void qfl_dialog(char* s, long sl, const char* title) {
     ami_frame(out, FALSE);
 
     chrsz = ami_chrsizy(out);
-    titbot = chrsz*1.6;
+    /* The header bar carries the two buttons, one at each end,
+       with the title between them, which is where a desktop file
+       dialog puts them. It is deep enough for a button to sit in. */
+    titbot = chrsz*2.2;
     /* The horizontal is laid out in character widths and the vertical in
        character heights. Both were the height before, so every width came
        out twice what it read as: the dialog was half again wider than the
@@ -6986,21 +7005,20 @@ static void qfl_dialog(char* s, long sl, const char* title) {
     /* filename edit box */
     wp = getwig();
     widget(out, chrw*6, titbot+chrsz*19.8,
-                chrw*60, titbot+chrsz*21.2, "", QFL_ID_NAME, wteditbox, &wp);
+                chrw*78, titbot+chrsz*21.2, "", QFL_ID_NAME, wteditbox, &wp);
     if (curfile[0]) ami_putwidgettext(out, QFL_ID_NAME, curfile);
 
     /* OK button */
     wp = getwig();
     wp->cbc = &select_cbc;
-    widget(out, chrw*62, titbot+chrsz*19.7,
-                chrw*69, titbot+chrsz*21.3, "Open",
+    widget(out, chrw*70, chrsz*0.35, chrw*78, chrsz*1.85,
+                title[0] == 'S'? "Save": "Open",
                 QFL_ID_OK, wtcbutton, &wp);
 
     /* Cancel button */
     wp = getwig();
     wp->cbc = &cancel_cbc;
-    widget(out, chrw*70, titbot+chrsz*19.7,
-                chrw*78, titbot+chrsz*21.3, "Cancel",
+    widget(out, chrw, chrsz*0.35, chrw*9, chrsz*1.85, "Cancel",
                 QFL_ID_CANCEL, wtcbutton, &wp);
 
     mpy = 0;
@@ -7022,7 +7040,10 @@ static void qfl_dialog(char* s, long sl, const char* title) {
                 ami_frect(out, 1, 1, ami_maxxg(out), titbot);
                 ami_fcolor(out, ami_white);
                 ami_bold(out, TRUE);
-                ami_cursorg(out, chrsz, titbot*0.5 - chrsz*0.5);
+                /* centered between the buttons at the ends */
+                ami_cursorg(out, ami_maxxg(out)/2-
+                            ami_strsiz(out, title)/2,
+                            titbot*0.5 - chrsz*0.5);
                 fputs(title, out);
                 ami_bold(out, FALSE);
                 ami_fcolor(out, ami_black);

--- a/portable/gnome_widgets.c
+++ b/portable/gnome_widgets.c
@@ -358,6 +358,13 @@ typedef struct wigrec {
     /** string list */                        ami_strptr strlst;
     /** string selected, 0 if none */         long      ss;
     /** string hovered, 0 if none */          long      sh;
+    /** list box: first entry shown, 1 based */ long    top;
+    /** List box column stops, in pixels from the left of the box. An
+       entry is split at tabs and each field placed at its stop; a
+       negative stop right aligns the field to it, as a column of sizes
+       reads. None means the entry is one string, as it always was. */
+                                              long      tabs[4];
+    /** how many stops */                     long      ntabs;
     /** child window id */                    long      cid;
     /** mouse grabs scrollbar/slider */       long      grab;
     /** tick marks on slider */               long      ticks;
@@ -870,6 +877,8 @@ static void wiginit(void* vwg)
     wp->strlst = NULL; /* clear string list */
     wp->ss = 0; /* no string selected */
     wp->sh = 0; /* no string hovered */
+    wp->top = 1; /* the list starts at its first entry */
+    wp->ntabs = 0; /* no columns: the entry is one string */
     wp->cid = 0; /* clear child id */
     wp->grab = FALSE; /* set no scrollbar/slider grab */
     wp->ticks = 0; /* set no tick marks on slider */
@@ -2488,6 +2497,44 @@ Handles drawing list boxes.
    The fill is inset horizontally so the rounded outline is never overpainted --
    that lets the motion handler repaint just the line that gains or loses the
    hover highlight instead of redrawing (and re-rendering) the whole list. */
+/* the entries a list box has room for */
+static long listbox_vis(wigptr wg)
+
+{
+
+    long n = (ami_maxyg(wg->wf)-ami_chrsizy(wg->wf)*0.5)/ami_chrsizy(wg->wf);
+
+    return (n < 1? 1: n);
+
+}
+
+/* the entries it holds */
+static long listbox_cnt(wigptr wg)
+
+{
+
+    ami_strptr sp = wg->strlst;
+    long n = 0;
+
+    while (sp) { n++; sp = sp->next; }
+
+    return (n);
+
+}
+
+/* Hold the view inside the list: it starts at the first entry, and it
+   cannot start so late that the box would run past the end. */
+static void listbox_clamp(wigptr wg)
+
+{
+
+    long last = listbox_cnt(wg)-listbox_vis(wg)+1;
+
+    if (wg->top > last) wg->top = last;
+    if (wg->top < 1) wg->top = 1;
+
+}
+
 static void listbox_line(wigptr wg, ami_strptr sp, long idx, long y)
 
 {
@@ -2497,8 +2544,39 @@ static void listbox_line(wigptr wg, ami_strptr sp, long idx, long y)
     else ami_fcolor(wg->wf, ami_white); /* normal background */
     ami_frect(wg->wf, 4, y, ami_maxxg(wg->wf)-3, y+ami_chrsizy(wg->wf)-1);
     ami_fcolor(wg->wf, ami_black);
-    ami_cursorg(wg->wf, ami_chrsizy(wg->wf)*0.5, y);
-    fprintf(wg->wf, "%s", sp->str); /* place string */
+    if (wg->ntabs) { /* in columns, each field at its stop */
+
+        const char* p = sp->str;
+        long i = 0;
+
+        while (p && i <= wg->ntabs) {
+
+            const char* e = strchr(p, '\t');
+            char  fld[256];
+            long  l = e? (long)(e-p): (long)strlen(p);
+            long  x;
+
+            if (l > (long)sizeof(fld)-1) l = sizeof(fld)-1;
+            memcpy(fld, p, l);
+            fld[l] = 0;
+            if (!i) x = ami_chrsizy(wg->wf)*0.5; /* the name leads */
+            else if (wg->tabs[i-1] < 0) /* right aligned to its stop */
+                x = -wg->tabs[i-1]-ami_strsiz(wg->wf, fld);
+            else x = wg->tabs[i-1];
+            ami_cursorg(wg->wf, x, y);
+            fprintf(wg->wf, "%s", fld);
+            if (!e) break;
+            p = e+1;
+            i++;
+
+        }
+
+    } else {
+
+        ami_cursorg(wg->wf, ami_chrsizy(wg->wf)*0.5, y);
+        fprintf(wg->wf, "%s", sp->str); /* place string */
+
+    }
 
 }
 
@@ -2513,10 +2591,11 @@ static void listbox_line_idx(wigptr wg, long idx)
     long      y;
     long      sc;
 
-    if (idx < 1) return; /* nothing to paint */
+    if (idx < wg->top) return; /* above the view, nothing to paint */
     sp = wg->strlst; /* index top of stringlist */
-    y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
     sc = 1; /* set first string */
+    while (sp && sc < wg->top) { sp = sp->next; sc++; } /* to the view */
+    y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
     while (sp && sc < idx) { /* walk to the target line */
 
         y += ami_chrsizy(wg->wf); /* next line */
@@ -2524,7 +2603,9 @@ static void listbox_line_idx(wigptr wg, long idx)
         sc++; /* next select */
 
     }
-    if (sp) listbox_line(wg, sp, idx, y); /* in range: paint it */
+    /* in the view: paint it. Below it, there is nothing to paint */
+    if (sp && y+ami_chrsizy(wg->wf) <= ami_maxyg(wg->wf))
+        listbox_line(wg, sp, idx, y);
 
 }
 
@@ -2545,10 +2626,13 @@ static void listbox_draw(
     fcolort(wg->wf, th_outline1);
     ami_linewidth(wg->wf, 2);
     ami_rrect(wg->wf, 2, 2, ami_maxxg(wg->wf)-1, ami_maxyg(wg->wf)-1, 10, 10);
+    /* from the entry the view starts at, for as many as the box holds */
+    listbox_clamp(wg);
     sp = wg->strlst; /* index top of stringlist */
-    y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
     sc = 1; /* set first string */
-    while (sp) { /* traverse and paint */
+    while (sp && sc < wg->top) { sp = sp->next; sc++; } /* to the view */
+    y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
+    while (sp && y+ami_chrsizy(wg->wf) <= ami_maxyg(wg->wf)) {
 
         listbox_line(wg, sp, sc, y); /* paint this line */
         y += ami_chrsizy(wg->wf); /* next line */
@@ -2580,7 +2664,35 @@ static void listbox_event(
     ami_strptr sp;
 
     if (ev->etype == ami_etredraw) listbox_draw(wg); /* redraw the window */
-    else if (ev->etype == ami_etmouba && ev->amoubn == 1) {
+    else if (ev->etype == ami_etmouba &&
+             (ev->amoubn == 4 || ev->amoubn == 5)) {
+
+        /* The wheel moves the view. A list longer than its box could not
+           be reached at all before: it drew from its first entry and
+           there it stayed. */
+        long was = wg->top;
+
+        wg->top += ev->amoubn == 4? -3: 3; /* the usual three lines */
+        listbox_clamp(wg);
+        if (wg->top != was) listbox_draw(wg);
+
+    } else if (ev->etype == ami_etscru || ev->etype == ami_etscrd) {
+
+        long was = wg->top; /* the scroll keys, a line at a time */
+
+        wg->top += ev->etype == ami_etscru? -1: 1;
+        listbox_clamp(wg);
+        if (wg->top != was) listbox_draw(wg);
+
+    } else if (ev->etype == ami_etpagu || ev->etype == ami_etpagd) {
+
+        long was = wg->top; /* and by the boxful */
+
+        wg->top += (ev->etype == ami_etpagu? -1: 1)*listbox_vis(wg);
+        listbox_clamp(wg);
+        if (wg->top != was) listbox_draw(wg);
+
+    } else if (ev->etype == ami_etmouba && ev->amoubn == 1) {
 
         /* note that if there is a click in the window, there must have also
            a mouse move */
@@ -2607,12 +2719,14 @@ static void listbox_event(
         wg->mpx = ev->moupxg; /* set present position */
         wg->mpy = ev->moupyg;
 
-        /* find which string the mouse is over */
-        y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
+        /* which string the mouse is over, counting from the entry the
+           view starts at */
         sp = wg->strlst; /* index top of string list */
         sc = 1; /* set first string */
+        while (sp && sc < wg->top) { sp = sp->next; sc++; } /* to the view */
+        y = ami_chrsizy(wg->wf)*0.5; /* space to first string */
         wg->ss = 0; /* set no string selected */
-        while (sp) { /* traverse string list */
+        while (sp && y+ami_chrsizy(wg->wf) <= ami_maxyg(wg->wf)) {
 
             /* if within the string bounding box, select it */
             if (wg->mpy >= y && wg->mpy <= y+ami_chrsizy(wg->wf)) wg->ss = sc;
@@ -6612,9 +6726,11 @@ in the buffer.
     listsp = build_qfl_list(curdir); \
     wp = getwig(); \
     wp->strlst = listsp; \
+    wp->tabs[0] = -chrw*47; \
+    wp->tabs[1] = chrw*49; \
+    wp->ntabs = 2; \
     widget(out, chrw*16, titbot+chrsz*3.4, chrw*78, titbot+chrsz*19.0, \
            "", QFL_ID_LIST, wtlistbox, &wp); \
-    ami_font(fndwig(out, QFL_ID_LIST)->wf, AMI_FONT_TERM); \
 } while (0)
 
 /*
@@ -6686,23 +6802,21 @@ static void qfl_entry(char* d, long dl, const char* name, int isdir,
     char   tms[32];
     long   i;
 
-    /* the name, cut with an ellipsis if it will not fit its column */
+    /* the name, and a directory marked as one */
     for (i = 0; i < QFL_NAMEW && name[i]; i++) d[i] = name[i];
     if (name[i]) { d[QFL_NAMEW-3] = '.'; d[QFL_NAMEW-2] = '.';
                    d[QFL_NAMEW-1] = '.'; i = QFL_NAMEW; }
-    if (isdir && i < QFL_NAMEW) d[i++] = '/';
-    while (i < QFL_NAMEW+1) d[i++] = ' ';
+    if (isdir) d[i++] = '/';
+    d[i++] = '\t'; /* the columns are placed by the list box */
     /* the size, in the units it reads best in; a directory has none */
     if (isdir) strcpy(szs, "");
     else if (size < 1000LL) sprintf(szs, "%lld B", size);
     else if (size < 1000000LL) sprintf(szs, "%.1f kB", size/1000.0);
     else if (size < 1000000000LL) sprintf(szs, "%.1f MB", size/1000000.0);
     else sprintf(szs, "%.1f GB", size/1000000000.0);
-    for (i = 0; i < 10-(long)strlen(szs); i++) d[QFL_NAMEW+1+i] = ' ';
-    strcpy(d+QFL_NAMEW+1+i, szs); /* right aligned, as sizes read */
-    i = strlen(d);
-    d[i++] = ' ';
-    d[i++] = ' ';
+    strcpy(d+i, szs);
+    i += strlen(szs);
+    d[i++] = '\t';
     /* When it was last changed, said the way a file list says it: the
        time alone for today, Yesterday for the day before, the day and
        month within the year, and the year as well for anything older.
@@ -6742,8 +6856,7 @@ static int qfl_name(const char* e, char* d, long dl)
 
     long i = 0, isdir;
 
-    while (i < QFL_NAMEW && e[i] && e[i] != ' ' && i < dl-1) { d[i] = e[i];
-                                                              i++; }
+    while (e[i] && e[i] != '\t' && i < dl-1) { d[i] = e[i]; i++; }
     d[i] = 0;
     isdir = i > 0 && d[i-1] == '/';
     if (isdir) d[i-1] = 0; /* the slash marks it, it is not in the name */
@@ -6803,12 +6916,17 @@ static ami_strptr build_qfl_list(const char* dir) {
         /* in place, after the entries that come before it. The first
            entry is always .., which nothing displaces */
         lp = head;
-        while (lp->next &&
-               !qfl_before(e->str, is_dir, lp->next->str,
-                           strchr(lp->next->str, '/') != NULL &&
-                           strchr(lp->next->str, '/') <
-                               lp->next->str+QFL_NAMEW+1))
+        while (lp->next) {
+
+            char  onam[512];
+            int   odir = qfl_name(lp->next->str, onam, sizeof(onam));
+            char  nnam[512];
+
+            qfl_name(e->str, nnam, sizeof(nnam));
+            if (qfl_before(nnam, is_dir, onam, odir)) break;
             lp = lp->next;
+
+        }
         e->next = lp->next;
         lp->next = e;
         if (tail == lp) tail = e;
@@ -6996,11 +7114,11 @@ static void qfl_dialog(char* s, long sl, const char* title) {
     listsp = build_qfl_list(curdir);
     wp = getwig();
     wp->strlst = listsp;
+    wp->tabs[0] = -chrw*47; /* the size, right aligned as sizes read */
+    wp->tabs[1] = chrw*49;  /* the date */
+    wp->ntabs = 2;
     widget(out, chrw*16, titbot+chrsz*3.4,
                 chrw*78, titbot+chrsz*19.0, "", QFL_ID_LIST, wtlistbox, &wp);
-    /* the list is set in the fixed pitch font, so its columns line up
-       under the headings drawn above it */
-    ami_font(fndwig(out, QFL_ID_LIST)->wf, AMI_FONT_TERM);
 
     /* filename edit box */
     wp = getwig();
@@ -7057,11 +7175,13 @@ static void qfl_dialog(char* s, long sl, const char* title) {
                 ami_bold(out, TRUE);
                 ami_cursorg(out, chrw, titbot+chrsz*2.4);
                 fputs("Places", out);
-                ami_font(out, AMI_FONT_TERM);
                 ami_cursorg(out, chrw*16, titbot+chrsz*2.4);
-                fputs("Name                             "
-                      "      Size  Modified", out);
-                ami_font(out, AMI_FONT_SIGN);
+                fputs("Name", out);
+                ami_cursorg(out, chrw*16+chrw*47-ami_strsiz(out, "Size"),
+                            titbot+chrsz*2.4);
+                fputs("Size", out);
+                ami_cursorg(out, chrw*16+chrw*49, titbot+chrsz*2.4);
+                fputs("Modified", out);
                 ami_bold(out, FALSE);
                 break;
 

--- a/test_gtk.c
+++ b/test_gtk.c
@@ -1,0 +1,330 @@
+/*******************************************************************************
+*                                                                              *
+*                          WIDGET SAMPLER, GTK VERSION                         *
+*                                                                              *
+* The companion to test.c: the same assortment of widgets, in the same layout, *
+* built with GTK instead of Petit-Ami. Run the two side by side to compare the *
+* widget theme against the desktop's own, which is the point of css2theme.     *
+*                                                                              *
+*     bin/css2theme          # convert the desktop theme for Petit-Ami         *
+*     make testg test_gtk                                                      *
+*     ./testg & ./test_gtk &                                                   *
+*                                                                              *
+* Both programs show every widget in the states a theme colors differently:    *
+* enabled and disabled, selected and not, and hovered when the mouse is over   *
+* them. The - and + buttons move the progress bar.                             *
+*                                                                              *
+* There is also a menu bar with one menu, File, holding one item, Open,        *
+* which raises the GTK open file dialog and reports the name it returns.       *
+* That is the reference for the other half of the comparison: putting up a     *
+* menu, raising the file dialog, and getting a file name back out of it.       *
+*                                                                              *
+* This program is not part of Petit-Ami and is not built by "make all": it     *
+* links GTK, which Petit-Ami deliberately does not. It exists only as the      *
+* reference to compare against.                                                *
+*                                                                              *
+* Build:                                                                       *
+*                                                                              *
+*     make test_gtk                                                            *
+*                                                                              *
+* or by hand:                                                                  *
+*                                                                              *
+*     gcc test_gtk.c `pkg-config --cflags --libs gtk+-3.0` -o test_gtk         *
+*                                                                              *
+*******************************************************************************/
+
+#include <gtk/gtk.h>
+
+#define TITLE "GTK widget sampler"
+
+static GtkWidget* progbar; /* progress bar, moved by the - and + buttons */
+static double     prog;    /* progress bar position, 0 to 1 */
+
+/*******************************************************************************
+
+Move the progress bar
+
+Advances or retards the progress bar so its active colors can be seen. The
+button that was pressed carries the direction.
+
+*******************************************************************************/
+
+static void movprog(GtkWidget* w, gpointer data)
+
+{
+
+    prog += GPOINTER_TO_INT(data)*0.1;
+    if (prog > 1.0) prog = 1.0;
+    if (prog < 0.0) prog = 0.0;
+    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(progbar), prog);
+
+}
+
+/*******************************************************************************
+
+Open a file
+
+Raises the GTK open file dialog from the File menu, and reports the name
+it gives back. The dialog runs modally: gtk_dialog_run keeps the
+interface alive while it waits, and returns which button ended it.
+
+*******************************************************************************/
+
+static GtkWidget* filerep; /* where the chosen name is reported */
+
+static void openfile(GtkWidget* w, gpointer data)
+
+{
+
+    GtkWidget* dialog;
+    gint       res;
+
+    dialog = gtk_file_chooser_dialog_new("Open File", GTK_WINDOW(data),
+                                         GTK_FILE_CHOOSER_ACTION_OPEN,
+                                         "_Cancel", GTK_RESPONSE_CANCEL,
+                                         "_Open", GTK_RESPONSE_ACCEPT,
+                                         NULL);
+    res = gtk_dialog_run(GTK_DIALOG(dialog));
+    if (res == GTK_RESPONSE_ACCEPT) {
+
+        char* name = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+        char  line[1024];
+
+        g_snprintf(line, sizeof(line), "Open: %s", name);
+        gtk_label_set_text(GTK_LABEL(filerep), line);
+        g_print("%s\n", line);
+        g_free(name);
+
+    } else {
+
+        gtk_label_set_text(GTK_LABEL(filerep), "Open: cancelled");
+        g_print("Open: cancelled\n");
+
+    }
+    gtk_widget_destroy(dialog);
+
+}
+
+/*******************************************************************************
+
+Quit the program
+
+*******************************************************************************/
+
+static void quit(GtkWidget* w, gpointer data)
+
+{
+
+    gtk_main_quit();
+
+}
+
+/*******************************************************************************
+
+Make a section label
+
+Returns a left aligned label, used as the heading over a group of widgets.
+
+*******************************************************************************/
+
+static GtkWidget* label(const char* s)
+
+{
+
+    GtkWidget* l;
+
+    l = gtk_label_new(s);
+    gtk_widget_set_halign(l, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(l, 10);
+
+    return (l);
+
+}
+
+int main(int argc, char* argv[])
+
+{
+
+    GtkWidget* win;      /* top window */
+    GtkWidget* outer;    /* button row above the columns */
+    GtkWidget* cols;     /* the three columns */
+    GtkWidget* buts;     /* button row */
+    GtkWidget* cola;     /* first column */
+    GtkWidget* colb;     /* second column */
+    GtkWidget* colc;     /* third column */
+    GtkWidget* row;      /* a row within a column */
+    GtkWidget* w;        /* widget being built */
+    GtkWidget* frame;    /* group box */
+    GtkWidget* scroll;   /* list box scroller */
+    GSList*    grp;      /* radio button group */
+
+    gtk_init(&argc, &argv);
+
+    win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(win), TITLE);
+    gtk_window_set_default_size(GTK_WINDOW(win), 1120, 725);
+    gtk_container_set_border_width(GTK_CONTAINER(win), 15);
+    g_signal_connect(win, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+    outer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 15);
+    gtk_container_add(GTK_CONTAINER(win), outer);
+
+    /* the menu: one menu, File, with one item, Open, which raises the
+       file dialog */
+    {
+
+        GtkWidget* menubar = gtk_menu_bar_new();
+        GtkWidget* filemenu = gtk_menu_new();
+        GtkWidget* fileitem = gtk_menu_item_new_with_mnemonic("_File");
+        GtkWidget* openitem = gtk_menu_item_new_with_mnemonic("_Open");
+
+        gtk_menu_item_set_submenu(GTK_MENU_ITEM(fileitem), filemenu);
+        gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), openitem);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menubar), fileitem);
+        g_signal_connect(openitem, "activate", G_CALLBACK(openfile), win);
+        gtk_box_pack_start(GTK_BOX(outer), menubar, FALSE, FALSE, 0);
+        filerep = label("File > Open raises the GTK file dialog");
+        gtk_box_pack_start(GTK_BOX(outer), filerep, FALSE, FALSE, 0);
+
+    }
+
+    /* buttons: normal, held selected, disabled, and the quit button. The
+       selected button is a toggle held down, which is how GTK shows a button
+       with a persistent active state */
+    gtk_box_pack_start(GTK_BOX(outer),
+                       label("Buttons: normal, selected, disabled"),
+                       FALSE, FALSE, 0);
+    buts = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    gtk_box_pack_start(GTK_BOX(outer), buts, FALSE, FALSE, 0);
+
+    w = gtk_button_new_with_label("Normal");
+    gtk_box_pack_start(GTK_BOX(buts), w, FALSE, FALSE, 0);
+
+    w = gtk_toggle_button_new_with_label("Selected");
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), TRUE);
+    gtk_box_pack_start(GTK_BOX(buts), w, FALSE, FALSE, 0);
+
+    w = gtk_button_new_with_label("Disabled");
+    gtk_widget_set_sensitive(w, FALSE);
+    gtk_box_pack_start(GTK_BOX(buts), w, FALSE, FALSE, 0);
+
+    w = gtk_button_new_with_label("Quit");
+    g_signal_connect(w, "clicked", G_CALLBACK(quit), NULL);
+    gtk_box_pack_start(GTK_BOX(buts), w, FALSE, FALSE, 0);
+
+    /* the three columns below the button row */
+    cols = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 25);
+    gtk_box_pack_start(GTK_BOX(outer), cols, TRUE, TRUE, 0);
+    cola = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+    colb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+    colc = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+    gtk_box_pack_start(GTK_BOX(cols), cola, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(cols), colb, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(cols), colc, FALSE, FALSE, 0);
+
+    /* first column: checkboxes, text entry, progress bar */
+    gtk_box_pack_start(GTK_BOX(cola), label("Checkboxes"), FALSE, FALSE, 0);
+    w = gtk_check_button_new_with_label("Checked");
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), TRUE);
+    gtk_box_pack_start(GTK_BOX(cola), w, FALSE, FALSE, 0);
+    w = gtk_check_button_new_with_label("Clear");
+    gtk_box_pack_start(GTK_BOX(cola), w, FALSE, FALSE, 0);
+    w = gtk_check_button_new_with_label("Disabled");
+    gtk_widget_set_sensitive(w, FALSE);
+    gtk_box_pack_start(GTK_BOX(cola), w, FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(cola), label("Edit box, number select box"),
+                       FALSE, FALSE, 0);
+    row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    gtk_box_pack_start(GTK_BOX(cola), row, FALSE, FALSE, 0);
+    w = gtk_entry_new();
+    gtk_entry_set_text(GTK_ENTRY(w), "Editable text");
+    gtk_box_pack_start(GTK_BOX(row), w, FALSE, FALSE, 0);
+    w = gtk_spin_button_new_with_range(1, 100, 1);
+    gtk_box_pack_start(GTK_BOX(row), w, FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(cola), label("Progress bar (- and + move it)"),
+                       FALSE, FALSE, 0);
+    row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    gtk_box_pack_start(GTK_BOX(cola), row, FALSE, FALSE, 0);
+    prog = 0.4; /* start part way along, as the Petit-Ami sampler does */
+    progbar = gtk_progress_bar_new();
+    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(progbar), prog);
+    gtk_widget_set_valign(progbar, GTK_ALIGN_CENTER);
+    gtk_widget_set_size_request(progbar, 200, -1);
+    gtk_box_pack_start(GTK_BOX(row), progbar, FALSE, FALSE, 0);
+    w = gtk_button_new_with_label(" - ");
+    g_signal_connect(w, "clicked", G_CALLBACK(movprog), GINT_TO_POINTER(-1));
+    gtk_box_pack_start(GTK_BOX(row), w, FALSE, FALSE, 0);
+    w = gtk_button_new_with_label(" + ");
+    g_signal_connect(w, "clicked", G_CALLBACK(movprog), GINT_TO_POINTER(1));
+    gtk_box_pack_start(GTK_BOX(row), w, FALSE, FALSE, 0);
+
+    /* second column: scroll bar, slider, drop box, tab bar */
+    gtk_box_pack_start(GTK_BOX(colb), label("Scroll bar and slider"),
+                       FALSE, FALSE, 0);
+    w = gtk_scrollbar_new(GTK_ORIENTATION_HORIZONTAL, NULL);
+    gtk_range_set_range(GTK_RANGE(w), 0, 100);
+    gtk_range_set_value(GTK_RANGE(w), 25);
+    gtk_widget_set_size_request(w, 300, -1);
+    gtk_box_pack_start(GTK_BOX(colb), w, FALSE, FALSE, 0);
+    w = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 0, 100, 1);
+    gtk_scale_set_draw_value(GTK_SCALE(w), FALSE);
+    gtk_range_set_value(GTK_RANGE(w), 10);
+    gtk_widget_set_size_request(w, 300, -1);
+    gtk_box_pack_start(GTK_BOX(colb), w, FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(colb), label("Drop box"), FALSE, FALSE, 0);
+    w = gtk_combo_box_text_new();
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(w), "First");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(w), "Second");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(w), "Third");
+    gtk_combo_box_set_active(GTK_COMBO_BOX(w), 0);
+    gtk_widget_set_halign(w, GTK_ALIGN_START);
+    gtk_box_pack_start(GTK_BOX(colb), w, FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(colb), label("Tab bar"), FALSE, FALSE, 0);
+    w = gtk_notebook_new();
+    gtk_notebook_append_page(GTK_NOTEBOOK(w), gtk_label_new(""),
+                             gtk_label_new("One"));
+    gtk_notebook_append_page(GTK_NOTEBOOK(w), gtk_label_new(""),
+                             gtk_label_new("Two"));
+    gtk_notebook_append_page(GTK_NOTEBOOK(w), gtk_label_new(""),
+                             gtk_label_new("Three"));
+    gtk_widget_set_size_request(w, 300, 100);
+    gtk_box_pack_start(GTK_BOX(colb), w, FALSE, FALSE, 0);
+
+    /* third column: radio buttons, group, list box */
+    gtk_box_pack_start(GTK_BOX(colc), label("Radio buttons"), FALSE, FALSE, 0);
+    w = gtk_radio_button_new_with_label(NULL, "Station 1");
+    grp = gtk_radio_button_get_group(GTK_RADIO_BUTTON(w));
+    gtk_box_pack_start(GTK_BOX(colc), w, FALSE, FALSE, 0);
+    w = gtk_radio_button_new_with_label(grp, "Station 2");
+    grp = gtk_radio_button_get_group(GTK_RADIO_BUTTON(w));
+    gtk_box_pack_start(GTK_BOX(colc), w, FALSE, FALSE, 0);
+    w = gtk_radio_button_new_with_label(grp, "Station 3");
+    gtk_box_pack_start(GTK_BOX(colc), w, FALSE, FALSE, 0);
+
+    frame = gtk_frame_new("Group");
+    gtk_widget_set_size_request(frame, 160, 80);
+    gtk_widget_set_margin_top(frame, 10);
+    gtk_box_pack_start(GTK_BOX(colc), frame, FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(colc), label("List box"), FALSE, FALSE, 0);
+    w = gtk_list_box_new();
+    gtk_list_box_insert(GTK_LIST_BOX(w), gtk_label_new("Red"), -1);
+    gtk_list_box_insert(GTK_LIST_BOX(w), gtk_label_new("Green"), -1);
+    gtk_list_box_insert(GTK_LIST_BOX(w), gtk_label_new("Blue"), -1);
+    scroll = gtk_scrolled_window_new(NULL, NULL);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+    gtk_widget_set_size_request(scroll, 110, 120);
+    gtk_container_add(GTK_CONTAINER(scroll), w);
+    gtk_box_pack_start(GTK_BOX(colc), scroll, FALSE, FALSE, 0);
+
+    gtk_widget_show_all(win);
+    gtk_main();
+
+    return (0);
+
+}


### PR DESCRIPTION
## Summary

A working spreadsheet on the Petit-Ami graphics API, in `graph_programs/spreadsheet.c`, and the library work it turned up along the way.

```
make spreadsheet
bin/spreadsheet [-d] [<file.ods>]
```

## The program

- **Grid** of 78 columns (A through BZ) by 1000 rows, with scroll bars that carry the view over the whole sheet, the cell picked by click or by arrow / page / home / end, and everything reflowing when the window resizes.
- **Formulas**: a recursive descent parser over the cell text -- the four operators with precedence, parentheses, unary minus, cell references, and `SUM`, `AVG`, `MIN`, `MAX`, `COUNT` over a range, nesting freely. A referenced cell evaluates in turn; the depth is bounded, so a reference cycle ends as `ERR` rather than a stack overflow, as do a bad reference and a division by zero.
- **Text runs past its cell** into the empty cells to its right, stopping at the first cell holding anything, and takes the grid lines it crosses with it -- so a title need not fit the column it starts in. A number that will not fit shows as `#` marks rather than a truncated number, which would read as a different number entirely.
- **The standard menu**: File, Edit and Help from `ami_stdmenu` with the entries this program implements (including undo, cut, paste and delete, which it keeps for its own cells), plus a Sheet menu of its own.
- **OpenDocument files** (.ods, ISO/IEC 26300): the format LibreOffice and the rest use. Verified against LibreOffice in both directions and round trip -- a file written here opens there with its formulas computing, a file written there opens here the same way, and a file that makes the whole trip keeps everything.

## Library work it found

- **graphics: a closed menu window left its tracking entry behind.** Window ids return to use as windows close, and a menu opens and closes them freely, so the next window given a recycled id had its events dispatched to a dead menu entry and the program died with "File is invalid". This is what made the file dialogs look broken; they never were.
- **The file dialog is a file browser.** Places down the left, the listing in columns -- name, size, date -- under their headings, sizes in the units they read best in, dates said the way a file list says them (the time for today, Yesterday, the day and month within the year), directories before files, hidden entries hidden, and the buttons in the header bar where a desktop dialog carries them. Two bugs fixed under it: the layout measured widths in character heights, so the dialog came out wider than the screen; and file times are the services module's own, not the C library's, which had every file in another century.
- **List boxes scroll**, by wheel, scroll keys and page keys -- a list longer than its box could not be reached at all before -- **and can lay their entries in columns**, split at tabs and placed at stops the caller sets, a negative stop right aligning its field. Without stops an entry is one string, as it always was.
- **test_gtk** gains a menu and the GTK file dialog, as the reference to compare the above against.

## Verification

Driven under Xvfb throughout, and with a window manager where that mattered: formulas and every error path, text overflow against blocking cells, both scroll bars over their full travel, resize, the menus and their actions, wheel scrolling through a real directory, and the .ods interoperability tests against LibreOffice itself. `widget_test`, `graphics_test`, `management_test` and `test_demo` build and run; regress passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to
