### PR TITLE
INSTALL: start from getting the source

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,11 +1,34 @@
 Installing Petit-ami
 
-First of all, remember that petit-ami is in development. This means that 
+First of all, remember that petit-ami is in development. This means that
 everything may not work perfectly.
- 
-Second, the configure script does several automated installs of needed
-tools. For each one you will be asked if you want to install the tools.
-If you would prefer to do this manually, see the "make sure used packages are
+
+Getting the source
+
+The project lives on GitHub:
+
+    https://github.com/samiam95124/amitk
+
+Fetch it with git. The tree carries submodules (curses ports of nano,
+htop and the BSD games), so clone with them included:
+
+    git clone --recurse-submodules https://github.com/samiam95124/amitk.git
+    cd amitk
+
+If you cloned without the submodules, fill them in with:
+
+    git submodule update --init
+
+To bring an existing tree up to date later:
+
+    git pull
+    git submodule update
+
+Building
+
+The configure script does several automated installs of needed tools.
+For each one you will be asked if you want to install the tools. If you
+would prefer to do this manually, see the "make sure used packages are
 installed." section in configure.
 
 Steps to install
@@ -22,11 +45,7 @@ setpath [recommended]
 configure
 make
 
-Linux:
-
-. setpath [recommended]
-./configure
-gmake
+BSD and similar systems use gmake in place of make.
 
 If you get something like:
 
@@ -49,5 +68,5 @@ If this gives errors, it means the current glibc has changed enough that it no
 longer can just be automatically patched to find the new version. In this case,
 you will need to get an updated petit_ami or do some serious debug work.
 
-Note that building an override version of glibc is specific to Linux 
+Note that building an override version of glibc is specific to Linux
 distributions.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Web page for Ami !
 
 https://samiam95124.github.io/amitk
 
+To fetch and build it (the tree carries submodules, so take them along):
+
+    git clone --recurse-submodules https://github.com/samiam95124/amitk.git
+    cd amitk
+    . setpath
+    ./configure
+    make
+
+The full procedure, including what to do when the glibc override does
+not match your system, is in [INSTALL](INSTALL).
+
 Please see the following documents to get started in Petit-Ami
 
     doc/petit_ami.docx  The "grand unified" document of what it is, how to


### PR DESCRIPTION
The install instructions began at configure, as though the tree were already on the reader's disk. They begin at git now: the clone with `--recurse-submodules` (the tree carries the curses ports of nano, htop and the BSD games, and a clone without them builds a hole), the repair for a clone taken without them, and how to bring an existing tree up to date.

The doubled Linux block -- one `make`, one `gmake` -- is folded into a single line saying BSD uses gmake.

README.md gets the four-line short form above its pointer to INSTALL, so the repo front page answers the first question a visitor has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEBxbPFe7waARXzYd9e9to