### PR TITLE
mail: open a message clear of the list it came from

### DIFF
--- a/graph_programs/mail.c
+++ b/graph_programs/mail.c
@@ -2256,9 +2256,28 @@ static void openmsg(long i)
         ami_winclientg(readwf, ami_strsiz(readwf, "0")*84, chrh*40, &wx, &wy,
                        BIT(ami_wmframe) | BIT(ami_wmsize) | BIT(ami_wmsysbar));
         ami_setsizg(readwf, wx, wy);
-        /* down and to the right, so it does not sit on top of the list
-           it was opened from */
-        ami_setposg(readwf, 80, 80);
+        /* Clear of the list it was opened from, which has to stay
+           clickable: beside the main window, as far right as the screen
+           allows. A fixed position will not do, since it is measured from
+           the screen and the list is not -- the reader used to open at
+           80,80 and land on top of the very list it came from, where it
+           took the clicks meant for the next message, and every one after
+           the first appeared to open the same mail. */
+        {
+
+            long sx, sy; /* the screen */
+            long mx, my; /* and what the main window takes of it */
+            long rx;
+
+            ami_scnsizg(stdout, &sx, &sy);
+            ami_getsizg(stdout, &mx, &my);
+            rx = sx-wx-20;
+            if (rx < mx+20) rx = mx+20; /* beside the list at the least */
+            if (rx+wx > sx) rx = sx-wx; /* but still on the screen */
+            if (rx < 0) rx = 0;
+            ami_setposg(readwf, rx, 60);
+
+        }
         ami_scrollvertsizg(readwf, &sbw, &wy);
         ami_scrollvertg(readwf, ami_maxxg(readwf)-sbw, 1, sbw,
                         ami_maxyg(readwf), SBREAD);


### PR DESCRIPTION
Reported: *"selecting any email turns up this same one"* -- in the
graphical mail, clicking message after message kept showing the first one
opened.

The message list itself was innocent. With the reader moved out of the
way, every click resolves correctly, scrolled or not: rows 0/2/4/6 open
Shruti Jogi, the July 2026 newsletter, "this job is a match!" and Scott
Franco's untitled note, and after six wheel notches rows 6/8/10 open the
right three. The index was checked too -- all 9,457 records of the gmail
INBOX start on real header bytes.

The reader was opened at a fixed `80,80`. That position is measured from
the screen while the list is not, so on a main window near the top left
the reader -- 84 columns by 40 rows, about 840x920 -- came down squarely
on the list. X then gave the clicks to the reader, which is what the
event trace showed: `ev 38 win 4` (READWIN) for every click after the
first, and no list click at all. The list never moved and the reader kept
the message it already held.

It is now placed beside the main window, as far right as the screen
allows.

Before, four clicks on four different rows:

    click y=200 -> reader 'Shruti Jogi posted: Five years ago...'
    click y=260 -> reader 'Shruti Jogi posted: Five years ago...'
    click y=320 -> reader 'Shruti Jogi posted: Five years ago...'
    click y=380 -> reader 'Shruti Jogi posted: Five years ago...'

After, the same four clicks:

    click y=200 -> reader 'Shruti Jogi posted: Five years ago...'
    click y=260 -> reader 'July 2026 Newsletter'
    click y=320 -> reader 'Scott, this job is a match!'
    click y=380 -> reader '(no subject)'

🤖 Generated with [Claude Code](https://claude.com/claude-code)