### PR TITLE
graphics: control-+ and control-- ask for larger and smaller

### DIFF
--- a/graph_programs/mail.c
+++ b/graph_programs/mail.c
@@ -205,6 +205,13 @@ static FILE* readwf;            /* the reader, NULL when closed */
 static FILE* srvwf;             /* the server form, NULL when closed */
 static long  chrh;              /* the height of a line, in pixels */
 static long  rowh;              /* the height of a message line */
+/* The size everything is drawn at. Control-+ and control-- move it a
+   point at a time, and every window takes its size from it, so the whole
+   program grows and shrinks together. The window is not touched: what is
+   in it changes size, and the user sets the window themselves. */
+static float pointsz = 12.0;
+#define MINPOINT 6.0  /* as small and as large as it will go */
+#define MAXPOINT 36.0
 static long  foldw;             /* the width of the folder pane */
 static long  sbw;               /* scroll bar thickness */
 static long  listrows;          /* message lines the list holds */
@@ -453,7 +460,7 @@ static void popopen(long i, long x, long y)
     ami_auto(popwf, FALSE);
     ami_curvis(popwf, FALSE);
     ami_font(popwf, AMI_FONT_SIGN);
-    ami_setpoints(popwf, 12.0);
+    ami_setpoints(popwf, pointsz);
     ami_binvis(popwf);
     ami_setsizg(popwf, w, h);
     ami_setposg(popwf, x, y);
@@ -852,7 +859,7 @@ static void cmpopen(const char* to, const char* cc, const char* subject,
     ami_auto(cmpwf, FALSE);
     ami_curvis(cmpwf, FALSE);
     ami_font(cmpwf, AMI_FONT_SIGN);
-    ami_setpoints(cmpwf, 12.0);
+    ami_setpoints(cmpwf, pointsz);
     ami_binvis(cmpwf);
     ami_winclientg(cmpwf, ami_strsiz(cmpwf, "0")*90, chrh*34, &wx, &wy,
                    BIT(ami_wmframe) | BIT(ami_wmsize) | BIT(ami_wmsysbar));
@@ -2251,7 +2258,7 @@ static void openmsg(long i)
         ami_auto(readwf, FALSE);
         ami_curvis(readwf, FALSE);
         ami_font(readwf, AMI_FONT_TERM);
-        ami_setpoints(readwf, 12.0);
+        ami_setpoints(readwf, pointsz);
         ami_binvis(readwf);
         ami_winclientg(readwf, ami_strsiz(readwf, "0")*84, chrh*40, &wx, &wy,
                        BIT(ami_wmframe) | BIT(ami_wmsize) | BIT(ami_wmsysbar));
@@ -2534,7 +2541,7 @@ static void srvopen(void)
     ami_auto(srvwf, FALSE);
     ami_curvis(srvwf, FALSE);
     ami_font(srvwf, AMI_FONT_SIGN);
-    ami_setpoints(srvwf, 12.0);
+    ami_setpoints(srvwf, pointsz);
     ami_binvis(srvwf);
     ami_editboxsizg(srvwf, "0", &ew, &eh);
     ami_buttonsizg(srvwf, "Cancel", &bw, &bh);
@@ -2737,6 +2744,50 @@ static void layout(void)
     drawlist();
     drawstatus();
     drawbanner();
+
+}
+
+/* Larger and smaller, on control-+ and control--
+
+   The window is left exactly as it is -- that is the user's to set -- and
+   what changes is the size of everything in it. Nearly all of this
+   program is laid out from the point size: the rows of the list, the
+   width of the folder pane, the columns, the wrap of a message. So the
+   size moves a point, the measurements are taken again, and the whole
+   thing is laid out afresh at the new size.
+
+   A window that is open follows along. A window not yet made takes the
+   size when it is made, since it asks for pointsz like everything else. */
+static void setzoom(float d)
+
+{
+
+    float was = pointsz;
+
+    pointsz += d;
+    if (pointsz < MINPOINT) pointsz = MINPOINT;
+    if (pointsz > MAXPOINT) pointsz = MAXPOINT;
+    if (pointsz == was) return; /* it is as far over as it goes */
+    ami_setpoints(stdout, pointsz);
+    ami_setpoints(foldwf, pointsz);
+    ami_setpoints(listwf, pointsz);
+    ami_setpoints(banwf, pointsz*2);
+    /* what everything else is measured from */
+    chrh = ami_chrsizy(stdout);
+    rowh = chrh+8;
+    /* The banner is as tall as the picture wants, or as the name does
+       where there is no picture: the picture does not grow, so a banner
+       with one keeps its height and the name inside it grows. */
+    banh = havepic? pich+16: ami_chrsizy(banwf)+16;
+    layout();
+    /* a message being read is wrapped again at the size it is now */
+    if (readwf) {
+
+        ami_setpoints(readwf, pointsz);
+        wrapread();
+        drawread();
+
+    }
 
 }
 
@@ -3360,7 +3411,7 @@ static void helpopen(void)
     ami_auto(helpwf, FALSE);
     ami_curvis(helpwf, FALSE);
     ami_font(helpwf, AMI_FONT_SIGN);
-    ami_setpoints(helpwf, 12.0);
+    ami_setpoints(helpwf, pointsz);
     ami_binvis(helpwf);
     ami_winclientg(helpwf, ami_strsiz(helpwf, "0")*86, ami_chrsizy(helpwf)*26,
                    &wx, &wy, BIT(ami_wmframe) | BIT(ami_wmsize) |
@@ -3748,7 +3799,7 @@ int main(int argc, char* argv[])
     ami_curvis(stdout, FALSE);
     ami_auto(stdout, FALSE);
     ami_font(stdout, AMI_FONT_SIGN);
-    ami_setpoints(stdout, 12.0);
+    ami_setpoints(stdout, pointsz);
     ami_binvis(stdout);
     chrh = ami_chrsizy(stdout);
     rowh = chrh+8;
@@ -3797,14 +3848,14 @@ int main(int argc, char* argv[])
     ami_auto(foldwf, FALSE);
     ami_curvis(foldwf, FALSE);
     ami_font(foldwf, AMI_FONT_SIGN);
-    ami_setpoints(foldwf, 12.0);
+    ami_setpoints(foldwf, pointsz);
     ami_binvis(foldwf);
     ami_openwin(&stdin, &listwf, stdout, LISTWIN);
     ami_frame(listwf, FALSE);
     ami_auto(listwf, FALSE);
     ami_curvis(listwf, FALSE);
     ami_font(listwf, AMI_FONT_SIGN);
-    ami_setpoints(listwf, 12.0);
+    ami_setpoints(listwf, pointsz);
     ami_binvis(listwf);
     /* The strip at the foot, and the bar in it. Its natural height is
        what the strip is built around; its width is set here, since a bar
@@ -3816,7 +3867,7 @@ int main(int argc, char* argv[])
     ami_auto(banwf, FALSE);
     ami_curvis(banwf, FALSE);
     ami_font(banwf, AMI_FONT_SIGN);
-    ami_setpoints(banwf, 24.0);
+    ami_setpoints(banwf, pointsz*2);
     {
 
         char path[MAXSTR];
@@ -3887,6 +3938,12 @@ int main(int argc, char* argv[])
             default: break;
 
         }
+        /* Larger and smaller belong to the program and not to any one
+           window of it: whichever window the user had in hand when they
+           asked, it is all of it that changes size. So these are taken
+           before the event is handed to the window it came from. */
+        if (er.etype == ami_etusize) { setzoom(1.0); continue; }
+        if (er.etype == ami_etdsize) { setzoom(-1.0); continue; }
         /* Every event names the window it came from. The reader is a
            window of its own and the panes are windows of their own, so
            this one loop serves them all. */

--- a/graph_programs/mail.c
+++ b/graph_programs/mail.c
@@ -1357,6 +1357,11 @@ static long fitchars(FILE* f, char* s, long w)
     long cap;
     char c;
 
+    /* No room at all, and nothing of it fits. A width arrives negative
+       when a column is squeezed past what there is to give it, and the
+       cap below would then be negative -- s[cap] writes in front of the
+       string, which is a caller's stack. */
+    if (w <= 0) return (0);
     /* Cut it down before measuring it. Measuring costs a walk of the
        whole string, so the four hundred characters of a snippet are
        walked by every measurement even though sixty of them will fit.
@@ -2707,6 +2712,7 @@ static void layout(void)
        eating the subject whole. The date is never squeezed: a date that
        does not fit is not a date. */
     datex = ami_maxxg(listwf)-sbw-ami_strsiz(listwf, "Sep 30, 2025 ");
+    if (datex < 0) datex = 0; /* a pane too narrow for even the date */
     {
 
         long unit = ami_strsiz(listwf, "0");
@@ -2724,6 +2730,15 @@ static void layout(void)
 
         }
         catx = fromx+catw;
+        /* The minimums above are what a column would like, not what
+           there is: at a large point size in a narrow window they ask
+           for more than the whole width. The columns are kept in order
+           and inside it, and the subject takes what is left, which may
+           be nothing. Left alone, a column past the date column gave the
+           drawing a negative width to cut a string to. */
+        if (fromx > datex) fromx = datex;
+        if (catx > datex) catx = datex;
+        if (catx < fromx) catx = fromx;
 
     }
     /* The bar down the right of the message list is moved and sized, not

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -143,6 +143,13 @@ typedef enum {
     ami_etdrebox,   /* drop edit box signals done */
     ami_etsldpos,   /* slider position */
     ami_ettabbar,   /* tab bar select */
+    /* The user asks for what is displayed to be made larger or smaller,
+       with control-+ and control--. The window is not touched -- the user
+       sets that themselves -- it is the material in it that changes, which
+       for most programs means taking the point size a point up or down and
+       laying out again. */
+    ami_etusize,    /* enlarge what is displayed */
+    ami_etdsize,    /* reduce what is displayed */
 
     /* Reserved extra code areas, these are module defined. */
     ami_etsys    = 0x1000, /* start of base system reserved codes */

--- a/linux/graphics.c
+++ b/linux/graphics.c
@@ -1220,7 +1220,7 @@ static int        numjoy;         /* number of joysticks found */
 static joyptr     joytab[MAXJOY]; /* joystick control table */
 static int        frmfid;         /* framing timer fid */
 static int        cfgcap;         /* "configuration" caps */
-static ami_pevthan evthan[ami_ettabbar+1]; /* array of event handler routines */
+static ami_pevthan evthan[ami_etdsize+1]; /* array of event handler routines */
 static ami_pevthan evtshan;        /* single master event handler routine */
 static xevtque*   freque;         /* free XEvent queue entries list */
 static xevtque*   evtque;         /* XEvent input save queue */
@@ -1938,6 +1938,8 @@ void prtevtt(ami_evtcod e)
         case ami_etdrebox:  fprintf(stderr, "etdrebox "); break;
         case ami_etsldpos:  fprintf(stderr, "etsldpos "); break;
         case ami_ettabbar:  fprintf(stderr, "ettabbar "); break;
+        case ami_etusize:   fprintf(stderr, "etusize "); break;
+        case ami_etdsize:   fprintf(stderr, "etdsize "); break;
 
         default: fprintf(stderr, "???");
 
@@ -13182,6 +13184,23 @@ static void xwinevt(winptr win, ami_evtrec* er, XEvent* e, int* keep)
                                        er->etype = ami_etinsert;
                                    break;
 
+                /* Larger and smaller, the way the browsers do it. There
+                   are two of each key on a PC keyboard, the "=+" and "-_"
+                   of the main pad and the "+" and "-" of the numeric one,
+                   and both are taken. The main pad key gives "=" plain and
+                   "+" shifted, and control-= is as common a way to ask for
+                   this as control-+, so both arrive here. */
+                case XK_equal:
+                case XK_plus:
+                case XK_KP_Add:      if (ctrll || ctrlr)
+                                         er->etype = ami_etusize;
+                                     break;
+                case XK_minus:
+                case XK_underscore:
+                case XK_KP_Subtract: if (ctrll || ctrlr)
+                                         er->etype = ami_etdsize;
+                                     break;
+
                 case XK_Shift_L:   shiftl = TRUE; break; /* Left shift */
                 case XK_Shift_R:   shiftr = TRUE; break; /* Right shift */
                 case XK_Control_L: ctrll = TRUE; break;  /* Left control */
@@ -13821,7 +13840,7 @@ static void event_ivf(FILE* f, ami_evtrec* er)
         }
         er->handled = 1; /* set event is handled by default */
         (evtshan)(er); /* call master event handler */
-        if (!er->handled && er->etype <= ami_ettabbar) { /* send it to fanout */
+        if (!er->handled && er->etype <= ami_etdsize) { /* send it to fanout */
 
             er->handled = 1; /* set event is handled by default */
             (*evthan[er->etype])(er); /* call event handler first */
@@ -13887,7 +13906,7 @@ static void eventover_ivf(ami_evtcod e, ami_pevthan eh,  ami_pevthan* oeh)
 
 {
 
-    if (e > ami_ettabbar) error(evecaxe); /* cannot vector auxillary event */
+    if (e > ami_etdsize) error(evecaxe); /* cannot vector auxillary event */
     *oeh = evthan[e]; /* save existing event handler */
     evthan[e] = eh; /* place new event handler */
 
@@ -17273,7 +17292,7 @@ static void ami_init_graphics(int argc, char *argv[])
 
     /* clear event vector table */
     evtshan = defaultevent;
-    for (e = ami_etchar; e <= ami_ettabbar; e++) evthan[e] = defaultevent;
+    for (e = ami_etchar; e <= ami_etdsize; e++) evthan[e] = defaultevent;
 
     /* get setup configuration */
     config_root = NULL;
@@ -17510,7 +17529,7 @@ static void ami_deinit_graphics()
        that are no longer safe to call now that main() has returned — the
        stack frame they longjmp into is gone. */
     evtshan = defaultevent;
-    for (e = ami_etchar; e <= ami_ettabbar; e++) evthan[e] = defaultevent;
+    for (e = ami_etchar; e <= ami_etdsize; e++) evthan[e] = defaultevent;
 
     /* try to get window from stdout */
     win = NULL; /* set no window */

--- a/tests/sizekeys.c
+++ b/tests/sizekeys.c
@@ -1,0 +1,81 @@
+/*******************************************************************************
+
+Control-plus and control-minus make what is shown larger and smaller
+
+The two events ami_etusize and ami_etdsize say that the user wants the
+material on the screen bigger or smaller, the way control-+ and control--
+work in a browser. The window is not touched -- that is the user's to set
+-- so this program keeps its window exactly where it is and moves the
+point size a point at a time, laying the text out again at whatever size
+it has reached.
+
+There are two of each key on a PC keyboard: the "=+" and "-_" of the main
+pad, and the "+" and "-" of the numeric pad. All four are taken, and so is
+control-= unshifted, since that is the one most people actually press.
+
+Build as a graphical program:
+
+    gcc $(CFLAGS) tests/sizekeys.c $(GLIBS) -o bin/sizekeys
+
+Press control-+ and control--, and the sample text changes size while the
+window stays put. Escape twice, or the close box, ends it.
+
+*******************************************************************************/
+
+#include <stdio.h>
+
+#include <localdefs.h>
+#include <graphics.h>
+
+#define STARTPT 12.0 /* where the point size starts */
+#define MINPT   4.0  /* and how far it goes each way */
+#define MAXPT   72.0
+
+static void layout(float pt)
+
+{
+
+    long y;
+    long i;
+
+    ami_setpoints(stdout, pt);
+    fprintf(stdout, "\f");
+    y = ami_chrsizy(stdout);
+    ami_cursorg(stdout, 10, 10);
+    fprintf(stdout, "Point size %.0f -- control-+ and control-- change it",
+            pt);
+    for (i = 1; i <= 6; i++) {
+
+        ami_cursorg(stdout, 10, 10+(i+1)*y);
+        fprintf(stdout, "The material is laid out again at the new size, and "
+                        "the window is not touched.");
+
+    }
+
+}
+
+int main(void)
+
+{
+
+    ami_evtrec er;
+    float      pt = STARTPT;
+
+    ami_title(stdout, "Control-plus and control-minus");
+    ami_auto(stdout, FALSE);
+    ami_curvis(stdout, FALSE);
+    ami_font(stdout, AMI_FONT_TERM);
+    layout(pt);
+    do {
+
+        ami_event(stdin, &er);
+        if (er.etype == ami_etusize && pt < MAXPT) layout(++pt);
+        else if (er.etype == ami_etdsize && pt > MINPT) layout(--pt);
+        else if (er.etype == ami_etredraw || er.etype == ami_etresize)
+            layout(pt);
+
+    } while (er.etype != ami_etterm && er.etype != ami_etcan);
+
+    return (0);
+
+}

--- a/windows/graphics.c
+++ b/windows/graphics.c
@@ -698,7 +698,7 @@ static int       stdwinj2c;    /* joystick 1 capture */
 /* lock for all global structures */
 CRITICAL_SECTION mainlock;     /* main task lock */
 static imptr     freitm;       /* intratask message free list */
-static ami_pevthan evthan[ami_ettabbar+1]; /* array of event handler routines */
+static ami_pevthan evthan[ami_etdsize+1]; /* array of event handler routines */
 static ami_pevthan evtshan;     /* single master event handler routine */
 
 /* The double fault flag is set when exiting, so if we exit again, it
@@ -16889,7 +16889,7 @@ static void ami_init_graph()
 
     /* clear event vector table */
     evtshan = defaultevent;
-    for (e = ami_etchar; e <= ami_ettabbar; e++) evthan[e] = defaultevent;
+    for (e = ami_etchar; e <= ami_etdsize; e++) evthan[e] = defaultevent;
 
     /* clear open files table */
     for (fi = 0; fi < MAXFIL; fi++) {


### PR DESCRIPTION
Two new events at the end of the list in `graphics.h`:

    ami_etusize,    /* enlarge what is displayed */
    ami_etdsize,    /* reduce what is displayed */

They say the user wants what is shown made bigger or smaller. Following
the browsers, **the window is not touched** -- that is the user's to set
-- it is the material inside it that changes. Ami sizes nearly everything
off the point size, so a program answers these by taking its points a
step up or down and laying out again.

## The keys

All the spellings a PC keyboard has, since there are two of each key:

| key | keysym | event |
|---|---|---|
| main pad `=+`, unshifted | `XK_equal` | usize |
| main pad `=+`, shifted | `XK_plus` | usize |
| numeric pad `+` | `XK_KP_Add` | usize |
| main pad `-_`, unshifted | `XK_minus` | dsize |
| main pad `-_`, shifted | `XK_underscore` | dsize |
| numeric pad `-` | `XK_KP_Subtract` | dsize |

`control-=` is included deliberately: shifting for `+` is what the key is
labelled for, but unshifted is what most people press. Without control
they all remain characters.

## The fanout bounds

`ami_ettabbar` was the last event code, and was used as that bound in five
places in the Linux port -- the `evthan` array, its two initializers, the
dispatch test and the `eventover` guard. They move to the new last code so
the new events vector like any other. The Windows port's copy of the array
is widened to match: it does not generate these yet, but it indexes
`evthan[er->etype]` with no bound test, so leaving it short would be a
loaded gun.

## Verified

`tests/sizekeys.c` changes point size on the keys and never touches its
window. Driven under Xvfb, starting at 12 points:

- 6 x `ctrl+plus`, then 3 x `ctrl+equal` -> **21 points**
- 12 x `ctrl+KP_Subtract` -> **9 points**
- 2 x `ctrl+KP_Add`, 3 x `ctrl+minus`, 1 x `ctrl+underscore` -> 12 to **10 points**
- a plain `+` with no control -> size unchanged, still a character
- window geometry `1200x800` before and after every one of them

Full `make` is clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)