### PR TITLE
managerc: a terminal resize gives the client its own size

### DIFF
--- a/portable/managerc.c
+++ b/portable/managerc.c
@@ -5385,14 +5385,20 @@ static void intevent(FILE* f)
 
                 win->pmaxx = dimx; /* the root window is the surface */
                 win->pmaxy = dimy;
-                win->cmaxx = dimx; /* frameless, client is the whole */
-                win->cmaxy = dimy;
+                /* The client is what the decorations leave. The root
+                   window is frameless, but a menu bar still takes its
+                   first row, and a client told it has that row draws its
+                   last line where nothing is shown: a program with a
+                   strip along its foot lost the strip on every terminal
+                   resize, and did not get it back by resizing again. */
+                win->cmaxx = dimx-decorx(win);
+                win->cmaxy = dimy-decory(win);
                 /* In follow mode the buffer is the window, so it tracks
                    the new surface. In buffered mode the program chose the
                    buffer size and it keeps it: the window simply shows
                    more or less of it. Growing it here regardless threw
                    away the size a program had asked for. */
-                if (!win->bufmod) growwinbuf(win, dimx, dimy);
+                if (!win->bufmod) growwinbuf(win, win->cmaxx, win->cmaxy);
                 /* The layer below keeps its own screen buffers, sized when
                    it started, and clips writes to them. Grow those through
                    the standard call rather than by reaching into that
@@ -5410,8 +5416,8 @@ static void intevent(FILE* f)
                 /* Before the repaint: the repaint announces redraws, and
                    the client draws on those to the size it last heard. */
                 er.etype = ami_etresize;
-                er.rszx = dimx;
-                er.rszy = dimy;
+                er.rszx = win->cmaxx; /* the client's size, as everywhere */
+                er.rszy = win->cmaxy;
                 er.winid = win->wid;
                 intsendevent(win, &er);
 


### PR DESCRIPTION
Found while checking that resizing a terminal is enough to get what zoom
would give in `mailc`.

**Symptom.** The strip of key help along the foot of `mailc` disappeared
after any terminal resize, and did not come back by resizing again -- not
even on returning to the original size.

**Cause.** On a terminal resize the root window was handed the whole
surface as its client area:

```c
win->cmaxx = dimx; /* frameless, client is the whole */
win->cmaxy = dimy;
```

It is frameless, but a menu bar still takes its first row, so the client
is one row shorter. `mailc` believed the number and drew its strip on a
row that is not shown. This is the same assumption already corrected for
the startup path; the terminal-resize path kept it. The other resize path
in this same file has always sent `win->cmaxx/cmaxy`.

Instrumenting `drawstatus()` showed it drawing correctly onto the row
that isn't there -- `y 42 maxx 140` on a client that is 41 rows:

    drawstatus: y 23 maxx 90  said 'Tab/f folder  arrows list  Ent'   <- 24 row terminal, correct
    drawstatus: y 42 maxx 140 said 'Tab/f folder  arrows list  Ent'   <- 42 row terminal, one too far

**Fix.** The client is what the decorations leave, via the existing
`decorx()`/`decory()`; the follow-mode buffer grows to the client rather
than the surface; and the event reports the client size.

**Verified.** The foot strip is present at 90x24, then across a grow to
140x42, a shrink to 100x30, and back to 90x24. Confirmed beforehand that
an idle program holds its strip for 48 seconds untouched, so the resize
was the cause and not a timer. Full `make` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)