### PR TITLE
sound_test: the rest of the API, and what testing it found

### DIFF
--- a/linux/sound.c
+++ b/linux/sound.c
@@ -1750,7 +1750,6 @@ static void closealsapcmin(long p)
 {
 
     snd_pcm_close(alsapcmin[p-1]->pcm); /* close wave device */
-    snd_rawmidi_close(alsamidiout[p-1]->midi); /* close port */
 
 }
 
@@ -4913,7 +4912,7 @@ void ami_closewaveout(long p)
 
     sndinit(); /* devices enumerate on first use */
     if (p < 1 || p > MAXWAVP) error("Invalid wave output port");
-    if (!alsapcmout[p]) error("No wave output device defined at logical number");
+    if (!alsapcmout[p-1]) error("No wave output device defined at logical number");
     if (!alsapcmout[p-1]->devopn) error("Wave port not open");
 
     alsapcmout[p-1]->close(p); /* close device */
@@ -5230,7 +5229,7 @@ void ami_volwave(long p, long t, long v)
 
     sndinit(); /* devices enumerate on first use */
     if (p < 1 || p > MAXWAVP) error("Invalid wave output port");
-    if (!alsapcmout[p]) error("No wave output device defined at logical number");
+    if (!alsapcmout[p-1]) error("No wave output device defined at logical number");
     if (!alsapcmout[p-1]->devopn) error("Wave port not open");
 
 }
@@ -6138,7 +6137,6 @@ long ami_setparamsynthin(long p, string name, string value)
 {
 
     sndinit(); /* devices enumerate on first use */
-printf("pa_setparamsynthin:\n");
     if (p < 1 || p > MAXMIDP) error("Invalid synthesizer port");
     if (!alsamidiin[p-1]) error("No synthsizer defined for logical port");
 

--- a/linux/sound.c
+++ b/linux/sound.c
@@ -1642,7 +1642,7 @@ static void closealsamidiin(long p)
 
 {
 
-    snd_rawmidi_close(alsamidiout[p-1]->midi); /* close port */
+    snd_rawmidi_close(alsamidiin[p-1]->midi); /* close port */
 
 }
 

--- a/tests/sound_test.c
+++ b/tests/sound_test.c
@@ -1109,8 +1109,10 @@ newtests:
 
     printf("\n===== Test 35 =====\n\n");
     printf("Aftertouch and channel pressure. A note is held while each\n");
-    printf("sweeps up; many synthesizers quietly ignore both, so no\n");
-    printf("change heard is not a failure of the call.\n");
+    printf("sweeps up. What is heard depends on the synthesizer: the\n");
+    printf("soundfont default routes channel pressure to vibrato, so on\n");
+    printf("fluidsynth the note should take on a deepening vibrato in\n");
+    printf("the second half; a synth may also ignore both.\n");
     ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
     for (i = 0; i < 10; i++) {
 
@@ -1125,6 +1127,12 @@ newtests:
 
     }
     ami_noteoff(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, 0);
+    /* Put both back, the way every section leaves what it moved. The
+       pressure is not cosmetic: the soundfont default modulator turns
+       standing channel pressure into vibrato, and left at ninety
+       percent it put a wobble on every note of every test after. */
+    ami_aftertouch(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, 0);
+    ami_pressure(dport, 0, 1, 0);
     printf("Complete\n");
     waitret();
 

--- a/tests/sound_test.c
+++ b/tests/sound_test.c
@@ -17,6 +17,13 @@ synthesizer input. The files the file tests need are made on the spot
 and removed. --nomidi starts there; --sin=<port> enables the
 synthesizer input section, which wants a keyboard played.
 
+3. The virtual MIDI loop runs by itself: the output and input sides of
+ALSA's "virtual" port are opened and subscribed together with aconnect,
+which puts the library's encoder on one end of a wire and its decoder
+on the other. One message of each kind is sent and read back, checked
+against what was sent to within a wire step. Where the port or aconnect
+is missing the section says so and stands down.
+
 *******************************************************************************/
 
 #include <limits.h>
@@ -202,6 +209,70 @@ static void makemid(const char* fn)
     if (!f) { printf("could not write %s\n", fn); return; }
     fwrite(smf, 1, sizeof(smf), f);
     fclose(f);
+
+}
+
+/*******************************************************************************
+
+The virtual MIDI loop
+
+ALSA gives a port named "virtual": opening it makes a sequencer client,
+and two of them can be subscribed together with aconnect. Opening the
+output side and the input side and connecting them puts the library's
+own MIDI encoder on one end of a wire and its decoder on the other, so
+what is sent with the API can be read back with rdsynth and compared --
+the round trip through real MIDI bytes, no hardware and no hands.
+
+The clients are found by listing before and after the opens: the ones
+that appear are ours, in the order they were opened.
+
+*******************************************************************************/
+
+/* the library's own stdio header does not carry these */
+extern FILE* popen(const char* cmd, const char* mode);
+extern int   pclose(FILE* f);
+
+static int virtclients(int* cl, int max)
+
+{
+
+    FILE* p;
+    char  ln[300];
+    int   n = 0;
+    int   c = -1;
+
+    p = popen("aconnect -l", "r");
+    if (!p) return (-1);
+    while (fgets(ln, sizeof(ln), p)) {
+
+        if (!strncmp(ln, "client ", 7)) c = atoi(ln+7);
+        else if (strstr(ln, "Virtual RawMIDI") && c >= 0 && n < max)
+            cl[n++] = c;
+
+    }
+    pclose(p);
+
+    return (n);
+
+}
+
+/* one checked result of the loop test */
+static long loopfails;
+
+static void loopchk(const char* what, int ok)
+
+{
+
+    printf("%-40s %s\n", what, ok? "pass": "*** FAIL ***");
+    if (!ok) loopfails++;
+
+}
+
+static int loopnear(long a, long b, long tol)
+
+{
+
+    return (labs(a-b) <= tol);
 
 }
 
@@ -1164,6 +1235,110 @@ newtests:
         waitret();
 
     } else printf("No wave input device: recording not tested.\n");
+
+    /***************************************************************************
+
+    SYNTHESIZER INPUT, AUTOMATED: THE VIRTUAL LOOP
+
+    ***************************************************************************/
+
+    printf("The virtual MIDI loop: the encoder sent down a wire to the\n");
+    printf("decoder, and every message checked against what was sent.\n");
+    {
+
+        long vout = 0, vin = 0;
+        char nm[200];
+
+        for (i = 1; i <= ami_synthout() && !vout; i++) {
+
+            ami_synthoutname(i, nm, sizeof(nm));
+            if (!strcmp(nm, "virtual")) vout = i;
+
+        }
+        for (i = 1; i <= ami_synthin() && !vin; i++) {
+
+            ami_synthinname(i, nm, sizeof(nm));
+            if (!strcmp(nm, "virtual")) vin = i;
+
+        }
+        if (vout && vin) {
+
+            int before[20], after[20];
+            int nb, na;
+            int co = -1, ci = -1;
+            int j, k, found;
+
+            nb = virtclients(before, 20);
+            ami_opensynthout(vout);
+            ami_opensynthin(vin);
+            na = virtclients(after, 20);
+            /* ours are the clients that were not there before, in the
+               order they were opened: the output first */
+            for (j = 0; j < na; j++) {
+
+                found = FALSE;
+                for (k = 0; k < nb; k++) if (after[j] == before[k]) found = TRUE;
+                if (!found) {
+
+                    if (co < 0) co = after[j];
+                    else if (ci < 0) ci = after[j];
+
+                }
+
+            }
+            if (nb >= 0 && co >= 0 && ci >= 0) {
+
+                char cmd[100];
+
+                sprintf(cmd, "aconnect %d:0 %d:0", co, ci);
+                if (!system(cmd)) {
+
+                    ami_seqmsg sm;
+
+                    loopfails = 0;
+                    /* one of each kind down the wire ... */
+                    ami_noteon(vout, 0, 1, 61, LONG_MAX);
+                    ami_noteoff(vout, 0, 1, 61, 0);
+                    ami_instchange(vout, 0, 2, 42);
+                    ami_pressure(vout, 0, 3, LONG_MAX/2);
+                    ami_pitch(vout, 0, 4, LONG_MAX/2);
+                    /* ... and back, in order. The values scale to seven
+                       (or for pitch, fourteen) bits on the wire, so what
+                       returns is what was sent to within one wire step. */
+                    ami_rdsynth(vin, &sm);
+                    loopchk("loop note on", sm.st == st_noteon &&
+                            sm.ntc == 1 && sm.ntn == 61 &&
+                            loopnear(sm.ntv, LONG_MAX, LONG_MAX/64));
+                    ami_rdsynth(vin, &sm);
+                    loopchk("loop note off", sm.st == st_noteoff &&
+                            sm.ntc == 1 && sm.ntn == 61 && sm.ntv == 0);
+                    ami_rdsynth(vin, &sm);
+                    loopchk("loop instrument change", sm.st == st_instchange &&
+                            sm.icc == 2 && sm.ici == 42);
+                    ami_rdsynth(vin, &sm);
+                    loopchk("loop pressure", sm.st == st_pressure &&
+                            sm.ntc == 3 &&
+                            loopnear(sm.ntv, LONG_MAX/2, LONG_MAX/64));
+                    ami_rdsynth(vin, &sm);
+                    loopchk("loop pitch bend", sm.st == st_pitch &&
+                            sm.vsc == 4 &&
+                            loopnear(sm.vsv, LONG_MAX/2, LONG_MAX/4096));
+                    printf("Loop test: %s\n", loopfails?
+                           "*** FAILS ***": "all pass");
+
+                } else printf("aconnect would not connect the pair: "
+                              "not tested\n");
+
+            } else printf("could not tell the virtual clients apart: "
+                          "not tested\n");
+            ami_closesynthin(vin);
+            ami_closesynthout(vout);
+
+        } else printf("no virtual MIDI port: not tested\n");
+
+    }
+    printf("Complete\n");
+    waitret();
 
     /***************************************************************************
 

--- a/tests/sound_test.c
+++ b/tests/sound_test.c
@@ -426,6 +426,7 @@ int main(int argc, char *argv[])
 
     if (nomidi) goto newtests; /* asked to go straight to the later sections */
 
+    printf("\n===== Test 1 =====\n\n");
     printf("Run through the entire scale of notes available\n");
     for (n = AMI_NOTE_C+AMI_OCTAVE_1; n <= AMI_NOTE_G+AMI_OCTAVE_11; n++) {
 
@@ -439,6 +440,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 2 =====\n\n");
     printf("Run through all instruments with middle C\n");
     printf("Note that not all syths implement all instruments\n");
     printf("Instruments: ");
@@ -457,6 +459,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 3 =====\n\n");
     printf("Run though all percussive instruments\n");
     printf("Note that not all syths implement all instruments\n");
     printf("Instruments: ");
@@ -473,6 +476,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 4 =====\n\n");
     printf("Chop test, play note series and repeat with the envelope time\n");
     printf("limited by noteoff\n");
     printf("First piano, then organ\n");
@@ -484,6 +488,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 5 =====\n\n");
     printf("Note volume test\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     for (i = 0; i < 20; i++) {
@@ -497,12 +502,14 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 6 =====\n\n");
     printf("Random note programming piano:\n");
     waitret();
     playrand(dport, 100);
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 7 =====\n\n");
     printf("Random note programming harpsichord:\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_HARPSICHORD);
@@ -510,6 +517,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 8 =====\n\n");
     printf("Random note programming organ:\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -517,6 +525,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 9 =====\n\n");
     printf("Random note programming soprando sax:\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_SOPRANO_SAX);
@@ -524,6 +533,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 10 =====\n\n");
     printf("Random note programming telephone:\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_TELEPHONE_RING);
@@ -535,6 +545,7 @@ int main(int argc, char *argv[])
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
 
     /* set attack times */
+    printf("\n===== Test 11 =====\n\n");
     printf("Set step attack times on piano\n");
     waitret();
     for (i = 0; i <= 10; i++) {
@@ -548,6 +559,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 12 =====\n\n");
     printf("Set step attack times on organ\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -563,6 +575,7 @@ int main(int argc, char *argv[])
     waitret();
 
     /* set release times */
+    printf("\n===== Test 13 =====\n\n");
     printf("Set step release times on piano\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
@@ -577,6 +590,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 14 =====\n\n");
     printf("Set step release times on organ\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -592,6 +606,7 @@ int main(int argc, char *argv[])
     waitret();
 
     /* set legato */
+    printf("\n===== Test 15 =====\n\n");
     printf("Set legato on piano, first normal, then legato\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
@@ -616,6 +631,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 16 =====\n\n");
     printf("Set legato on organ, first normal, then legato\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -641,6 +657,7 @@ int main(int argc, char *argv[])
     waitret();
 
     /* set portamento */
+    printf("\n===== Test 17 =====\n\n");
     printf("Set portamento on piano, first normal, then portamento, through\n");
     printf("various portamento times\n");
     waitret();
@@ -672,6 +689,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 18 =====\n\n");
     printf("Set portamento on organ, first normal, then portamento\n");
     waitret();
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -701,6 +719,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 19 =====\n\n");
     printf("Channel volume test. Play note continuously while advancing volume\n");
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
     ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
@@ -718,6 +737,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 20 =====\n\n");
     printf("Channel balance test. Play note continuously while changing\n");
     printf("from to right\n");
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -736,6 +756,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 21 =====\n\n");
     printf("Channel vibrato test. Play note continuously while advancing vibrato\n");
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
     ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
@@ -753,6 +774,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 22 =====\n\n");
     printf("Channel pan test. Play note continuously while changing\n");
     printf("pan from to right\n");
     ami_instchange(dport, 0, 1, AMI_INST_DRAWBAR_ORGAN);
@@ -771,6 +793,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 23 =====\n\n");
     printf("Channel timbre test. Play notes while advancing timbre\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     /* advance timbre sets on channel while playing */
@@ -789,6 +812,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 24 =====\n\n");
     printf("Channel brightness test. Play notes while advancing brightness\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     /* advance brightness sets on channel while playing */
@@ -807,6 +831,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 25 =====\n\n");
     printf("Channel reverb test. Play notes while advancing reverb\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     /* advance reverb sets on channel while playing */
@@ -825,6 +850,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 26 =====\n\n");
     printf("Channel tremulo test. Play notes while advancing tremulo\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
 
@@ -844,6 +870,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 27 =====\n\n");
     printf("Channel chorus test. Play notes while advancing chorus\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
 
@@ -863,6 +890,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 28 =====\n\n");
     printf("Channel celeste test. Play notes while advancing celeste\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     /* advance celeste sets on channel while playing */
@@ -881,6 +909,7 @@ int main(int argc, char *argv[])
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 29 =====\n\n");
     printf("Channel phaser test. Play notes while advancing phaser\n");
     ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
     /* advance phaser sets on channel while playing */
@@ -901,6 +930,7 @@ int main(int argc, char *argv[])
 
     /* don't know about this test, it seems to limit the total pitch wheel range,
        which is not right */
+    printf("\n===== Test 30 =====\n\n");
     printf("pitch wheel. Vary pitch wheel while playing continuously\n");
     ami_instchange(dport, 0, 1, AMI_INST_LEAD_1_SQUARE);
     ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
@@ -931,6 +961,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 31 =====\n\n");
     printf("Device inventory. Every port of every kind, by name.\n");
     {
 
@@ -969,6 +1000,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 32 =====\n\n");
     printf("Parameters, get and set, all four directions. ALSA devices\n");
     printf("carry none, so empty values and a declined set are correct\n");
     printf("here; a plug-in with parameters would show them.\n");
@@ -1011,6 +1043,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 33 =====\n\n");
     printf("Sequenced playback. Every test so far played at time zero;\n");
     printf("this queues a scale with future timestamps in one burst, and\n");
     printf("the sequencer plays it in tempo. The queueing returns at\n");
@@ -1045,6 +1078,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 34 =====\n\n");
     printf("wrsynth: the same notes as sequencer records, through the\n");
     printf("record interface the plug-ins speak. Three notes.\n");
     {
@@ -1073,6 +1107,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 35 =====\n\n");
     printf("Aftertouch and channel pressure. A note is held while each\n");
     printf("sweeps up; many synthesizers quietly ignore both, so no\n");
     printf("change heard is not a failure of the call.\n");
@@ -1093,6 +1128,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 36 =====\n\n");
     printf("Mono and poly. In mono a second note silences the first; in\n");
     printf("poly they sound together. The same pair is played each way.\n");
     ami_mono(dport, 0, 1, 1);
@@ -1113,6 +1149,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 37 =====\n\n");
     printf("A MIDI file: made here, loaded, played, deleted. You should\n");
     printf("hear C, E, G on the piano, a quarter note each.\n");
     makemid("sound_test.mid");
@@ -1130,6 +1167,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 38 =====\n\n");
     printf("Wave output, synthesized: two seconds of A 440 written\n");
     printf("straight to the device, the way genwave does.\n");
     ami_openwaveout(wport);
@@ -1159,6 +1197,7 @@ newtests:
     printf("Complete\n");
     waitret();
 
+    printf("\n===== Test 39 =====\n\n");
     printf("A wave file: made here, loaded, played, deleted. You should\n");
     printf("hear a C, a bit above the tone before, for a second and a\n");
     printf("half. volwave is exercised on the way; it is a stub in this\n");
@@ -1180,6 +1219,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 40 =====\n\n");
     if (ami_wavein() > 0) {
 
         long ch, ra, lb, sg, en, fl;
@@ -1242,6 +1282,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 41 =====\n\n");
     printf("The virtual MIDI loop: the encoder sent down a wire to the\n");
     printf("decoder, and every message checked against what was sent.\n");
     {
@@ -1346,6 +1387,7 @@ newtests:
 
     ***************************************************************************/
 
+    printf("\n===== Test 42 =====\n\n");
     if (sport > 0) {
 
         ami_seqmsg sm;

--- a/tests/sound_test.c
+++ b/tests/sound_test.c
@@ -1089,7 +1089,7 @@ newtests:
     waitret();
 
     printf("A wave file: made here, loaded, played, deleted. You should\n");
-    printf("hear a C, a fifth above the tone before, for a second and a\n");
+    printf("hear a C, a bit above the tone before, for a second and a\n");
     printf("half. volwave is exercised on the way; it is a stub in this\n");
     printf("implementation, so it changes nothing audible yet.\n");
     makewav("sound_test.wav", 523.25, 1.5);

--- a/tests/sound_test.c
+++ b/tests/sound_test.c
@@ -9,11 +9,21 @@ Notes:
 1. The MIDI tests not only test sound.c, but also the synthesizer
 implementation.
 
+2. The sections after the synthesizer listening tests cover the rest of
+the API: devices and their names, parameters, the sequencer proper
+(timed playback), wrsynth, aftertouch/pressure/mono/poly, MIDI file
+playback, wave output synthesized and from a file, wave input, and
+synthesizer input. The files the file tests need are made on the spot
+and removed. --nomidi starts there; --sin=<port> enables the
+synthesizer input section, which wants a keyboard played.
+
 *******************************************************************************/
 
 #include <limits.h>
 #include <setjmp.h>
 #include <stdlib.h>
+#include <string.h>
+#include <math.h>
 
 #include <terminal.h> /* terminal level functions */
 #include <sound.h>    /* sound library */
@@ -23,11 +33,25 @@ implementation.
 
 
 long dport = AMI_SYNTH_OUT; /* set default synth out */
+long wport = AMI_WAVE_OUT;  /* wave output port */
+long iport = AMI_WAVE_IN;   /* wave input port */
+long sport = 0;             /* synth input port; 0 skips the section, since
+                               reading a keyboard nobody plays blocks */
+long nomidi = FALSE;        /* skip the synthesizer listening tests and go
+                               straight to the sections after them */
 
 ami_optrec opttbl[] = {
 
     { "port",   NULL,    &dport, NULL, NULL },
     { "p",      NULL,    &dport, NULL, NULL },
+    { "wport",  NULL,    &wport, NULL, NULL },
+    { "w",      NULL,    &wport, NULL, NULL },
+    { "iport",  NULL,    &iport, NULL, NULL },
+    { "i",      NULL,    &iport, NULL, NULL },
+    { "sin",    NULL,    &sport, NULL, NULL },
+    { "si",     NULL,    &sport, NULL, NULL },
+    { "nomidi", &nomidi, NULL,   NULL, NULL },
+    { "nm",     &nomidi, NULL,   NULL, NULL },
     { NULL,     NULL,    NULL,    NULL, NULL }
 
 };
@@ -90,6 +114,94 @@ static void waitret(void)
 
     printf("Hit return to continue\n");
     waitnext();
+
+}
+
+/*******************************************************************************
+
+Test files, made on the spot
+
+The wave and MIDI file tests need a file to load, and none is committed:
+a small one of each is written here, played, and removed. The wave is a
+sine at the given pitch, mono, sixteen bits, the standard rate. The MIDI
+file is the smallest thing that is a song: format 0, one track, three
+quarter notes of a C major chord walked up, on the piano.
+
+*******************************************************************************/
+
+#define TESTRATE 44100
+
+static void makewav(const char* fn, double freq, double secs)
+
+{
+
+    FILE* f;
+    long  n = (long)(TESTRATE*secs);
+    long  dlen = n*2;
+    long  i;
+
+    f = fopen(fn, "wb");
+    if (!f) { printf("could not write %s\n", fn); return; }
+    /* the RIFF/fmt/data framing, all little endian */
+    fprintf(f, "RIFF");
+    fputc((36+dlen)&0xff, f); fputc((36+dlen)>>8&0xff, f);
+    fputc((36+dlen)>>16&0xff, f); fputc((36+dlen)>>24&0xff, f);
+    fprintf(f, "WAVEfmt ");
+    fputc(16, f); fputc(0, f); fputc(0, f); fputc(0, f); /* fmt length */
+    fputc(1, f); fputc(0, f);                            /* PCM */
+    fputc(1, f); fputc(0, f);                            /* mono */
+    fputc(TESTRATE&0xff, f); fputc(TESTRATE>>8&0xff, f); /* rate */
+    fputc(TESTRATE>>16&0xff, f); fputc(0, f);
+    fputc((TESTRATE*2)&0xff, f); fputc((TESTRATE*2)>>8&0xff, f); /* byte rate */
+    fputc((TESTRATE*2)>>16&0xff, f); fputc(0, f);
+    fputc(2, f); fputc(0, f);                            /* block align */
+    fputc(16, f); fputc(0, f);                           /* bits */
+    fprintf(f, "data");
+    fputc(dlen&0xff, f); fputc(dlen>>8&0xff, f);
+    fputc(dlen>>16&0xff, f); fputc(dlen>>24&0xff, f);
+    for (i = 0; i < n; i++) {
+
+        /* the tone, eased in and out so it does not click */
+        double a = sin(2.0*3.14159265*freq*i/TESTRATE)*20000.0;
+        long   e = n/50;
+        short  s;
+
+        if (i < e) a = a*i/e;
+        if (n-i < e) a = a*(n-i)/e;
+        s = (short)a;
+        fputc(s&0xff, f); fputc(s>>8&0xff, f);
+
+    }
+    fclose(f);
+
+}
+
+static void makemid(const char* fn)
+
+{
+
+    FILE* f;
+    /* MThd: format 0, one track, 96 per quarter; MTrk: piano, C then E
+       then G, a quarter note each, end of track */
+    static const unsigned char smf[] = {
+
+        'M','T','h','d', 0,0,0,6, 0,0, 0,1, 0,96,
+        'M','T','r','k', 0,0,0,32,
+        0x00, 0xc0, 0x00,       /* program change, piano */
+        0x00, 0x90, 60, 0x60,   /* C on */
+        0x60, 0x80, 60, 0x40,   /* a quarter later, off */
+        0x00, 0x90, 64, 0x60,   /* E */
+        0x60, 0x80, 64, 0x40,
+        0x00, 0x90, 67, 0x60,   /* G */
+        0x60, 0x80, 67, 0x40,
+        0x00, 0xff, 0x2f, 0x00  /* end of track */
+
+    };
+
+    f = fopen(fn, "wb");
+    if (!f) { printf("could not write %s\n", fn); return; }
+    fwrite(smf, 1, sizeof(smf), f);
+    fclose(f);
 
 }
 
@@ -209,6 +321,13 @@ int main(int argc, char *argv[])
     if (argcl != 1) {
 
         fprintf(stderr, "Usage: sndtst [--port=<port>|--p=<port>]\n");
+        fprintf(stderr, "              [--wport=<port>] wave output port\n");
+        fprintf(stderr, "              [--iport=<port>] wave input port\n");
+        fprintf(stderr, "              [--sin=<port>]   synth input port; the\n");
+        fprintf(stderr, "                  section runs only when given, and\n");
+        fprintf(stderr, "                  wants keys played on the device\n");
+        fprintf(stderr, "              [--nomidi]       skip the synthesizer\n");
+        fprintf(stderr, "                  listening tests, straight to the rest\n");
         exit(1);
 
     }
@@ -233,6 +352,8 @@ int main(int argc, char *argv[])
     printf("Not all synths implement all modes or instruments. In fact, it is common\n");
     printf("to leave many features unimplemented.\n");
     waitret();
+
+    if (nomidi) goto newtests; /* asked to go straight to the later sections */
 
     printf("Run through the entire scale of notes available\n");
     for (n = AMI_NOTE_C+AMI_OCTAVE_1; n <= AMI_NOTE_G+AMI_OCTAVE_11; n++) {
@@ -730,6 +851,363 @@ int main(int argc, char *argv[])
     ami_pitch(dport, 0, 1, 0);
     printf("Complete\n");
     waitret();
+
+newtests:
+
+    /***************************************************************************
+
+    DEVICES AND PARAMETERS
+
+    ***************************************************************************/
+
+    printf("Device inventory. Every port of every kind, by name.\n");
+    {
+
+        char nm[200];
+
+        printf("Output synthesizers: %ld\n", ami_synthout());
+        for (i = 1; i <= ami_synthout(); i++) {
+
+            ami_synthoutname(i, nm, sizeof(nm));
+            printf("    %2ld: %s\n", (long)i, nm);
+
+        }
+        printf("Input synthesizers: %ld\n", ami_synthin());
+        for (i = 1; i <= ami_synthin(); i++) {
+
+            ami_synthinname(i, nm, sizeof(nm));
+            printf("    %2ld: %s\n", (long)i, nm);
+
+        }
+        printf("Output wave devices: %ld\n", ami_waveout());
+        for (i = 1; i <= ami_waveout(); i++) {
+
+            ami_waveoutname(i, nm, sizeof(nm));
+            printf("    %2ld: %s\n", (long)i, nm);
+
+        }
+        printf("Input wave devices: %ld\n", ami_wavein());
+        for (i = 1; i <= ami_wavein(); i++) {
+
+            ami_waveinname(i, nm, sizeof(nm));
+            printf("    %2ld: %s\n", (long)i, nm);
+
+        }
+
+    }
+    printf("Complete\n");
+    waitret();
+
+    printf("Parameters, get and set, all four directions. ALSA devices\n");
+    printf("carry none, so empty values and a declined set are correct\n");
+    printf("here; a plug-in with parameters would show them.\n");
+    {
+
+        char val[200];
+
+        ami_getparamsynthout(dport, "name", val, sizeof(val));
+        printf("getparamsynthout(name): \"%s\"\n", val);
+        printf("setparamsynthout(name): %ld\n",
+               ami_setparamsynthout(dport, "name", "value"));
+        if (ami_synthin() > 0) {
+
+            ami_getparamsynthin(1, "name", val, sizeof(val));
+            printf("getparamsynthin(name):  \"%s\"\n", val);
+            printf("setparamsynthin(name):  %ld\n",
+                   ami_setparamsynthin(1, "name", "value"));
+
+        }
+        ami_getparamwaveout(wport, "name", val, sizeof(val));
+        printf("getparamwaveout(name):  \"%s\"\n", val);
+        printf("setparamwaveout(name):  %ld\n",
+               ami_setparamwaveout(wport, "name", "value"));
+        if (ami_wavein() > 0) {
+
+            ami_getparamwavein(iport, "name", val, sizeof(val));
+            printf("getparamwavein(name):   \"%s\"\n", val);
+            printf("setparamwavein(name):   %ld\n",
+                   ami_setparamwavein(iport, "name", "value"));
+
+        }
+
+    }
+    printf("Complete\n");
+    waitret();
+
+    /***************************************************************************
+
+    THE SEQUENCER PROPER
+
+    ***************************************************************************/
+
+    printf("Sequenced playback. Every test so far played at time zero;\n");
+    printf("this queues a scale with future timestamps in one burst, and\n");
+    printf("the sequencer plays it in tempo. The queueing returns at\n");
+    printf("once, which the elapsed times printed show.\n");
+    ami_instchange(dport, 0, 1, AMI_INST_ACOUSTIC_GRAND);
+    ami_starttimeout();
+    printf("time before queueing: %ld\n", ami_curtimeout());
+    {
+
+        static const ami_note sc[8] = {
+
+            AMI_NOTE_C+AMI_OCTAVE_6, AMI_NOTE_D+AMI_OCTAVE_6,
+            AMI_NOTE_E+AMI_OCTAVE_6, AMI_NOTE_F+AMI_OCTAVE_6,
+            AMI_NOTE_G+AMI_OCTAVE_6, AMI_NOTE_A+AMI_OCTAVE_6,
+            AMI_NOTE_B+AMI_OCTAVE_6, AMI_NOTE_C+AMI_OCTAVE_7
+
+        };
+
+        for (i = 0; i < 8; i++) {
+
+            ami_noteon(dport, (i+1)*(SECOND/3), 1, sc[i], LONG_MAX);
+            ami_noteoff(dport, (i+1)*(SECOND/3)+SECOND/4, 1, sc[i], 0);
+
+        }
+
+    }
+    printf("time after queueing:  %ld (all eight notes are queued)\n",
+           ami_curtimeout());
+    waittime(SECOND*3+SECOND/2);
+    printf("time after playing:   %ld\n", ami_curtimeout());
+    ami_stoptimeout();
+    printf("Complete\n");
+    waitret();
+
+    printf("wrsynth: the same notes as sequencer records, through the\n");
+    printf("record interface the plug-ins speak. Three notes.\n");
+    {
+
+        ami_seqmsg sm;
+
+        for (i = 0; i < 3; i++) {
+
+            memset(&sm, 0, sizeof(sm));
+            sm.port = dport;
+            sm.time = 0;
+            sm.st = st_noteon;
+            sm.ntc = 1;
+            sm.ntn = AMI_NOTE_C+AMI_OCTAVE_6+i*4;
+            sm.ntv = LONG_MAX;
+            ami_wrsynth(dport, &sm);
+            waittime(SECOND/3);
+            sm.st = st_noteoff;
+            sm.ntv = 0;
+            ami_wrsynth(dport, &sm);
+            waittime(SECOND/6);
+
+        }
+
+    }
+    printf("Complete\n");
+    waitret();
+
+    printf("Aftertouch and channel pressure. A note is held while each\n");
+    printf("sweeps up; many synthesizers quietly ignore both, so no\n");
+    printf("change heard is not a failure of the call.\n");
+    ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
+    for (i = 0; i < 10; i++) {
+
+        ami_aftertouch(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, i*(LONG_MAX/10));
+        waittime(SECOND/10);
+
+    }
+    for (i = 0; i < 10; i++) {
+
+        ami_pressure(dport, 0, 1, i*(LONG_MAX/10));
+        waittime(SECOND/10);
+
+    }
+    ami_noteoff(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, 0);
+    printf("Complete\n");
+    waitret();
+
+    printf("Mono and poly. In mono a second note silences the first; in\n");
+    printf("poly they sound together. The same pair is played each way.\n");
+    ami_mono(dport, 0, 1, 1);
+    ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
+    waittime(SECOND/2);
+    ami_noteon(dport, 0, 1, AMI_NOTE_G+AMI_OCTAVE_6, LONG_MAX);
+    waittime(SECOND/2);
+    ami_noteoff(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, 0);
+    ami_noteoff(dport, 0, 1, AMI_NOTE_G+AMI_OCTAVE_6, 0);
+    ami_poly(dport, 0, 1);
+    waittime(SECOND/2);
+    ami_noteon(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, LONG_MAX);
+    waittime(SECOND/2);
+    ami_noteon(dport, 0, 1, AMI_NOTE_G+AMI_OCTAVE_6, LONG_MAX);
+    waittime(SECOND/2);
+    ami_noteoff(dport, 0, 1, AMI_NOTE_C+AMI_OCTAVE_6, 0);
+    ami_noteoff(dport, 0, 1, AMI_NOTE_G+AMI_OCTAVE_6, 0);
+    printf("Complete\n");
+    waitret();
+
+    printf("A MIDI file: made here, loaded, played, deleted. You should\n");
+    printf("hear C, E, G on the piano, a quarter note each.\n");
+    makemid("sound_test.mid");
+    ami_loadsynth(1, "sound_test.mid");
+    ami_playsynth(dport, 0, 1);
+    ami_waitsynth(dport);
+    ami_delsynth(1);
+    remove("sound_test.mid");
+    printf("Complete\n");
+    waitret();
+
+    /***************************************************************************
+
+    WAVE OUTPUT
+
+    ***************************************************************************/
+
+    printf("Wave output, synthesized: two seconds of A 440 written\n");
+    printf("straight to the device, the way genwave does.\n");
+    ami_openwaveout(wport);
+    ami_chanwaveout(wport, 1);
+    ami_ratewaveout(wport, TESTRATE);
+    ami_lenwaveout(wport, 16);
+    ami_sgnwaveout(wport, TRUE);
+    ami_endwaveout(wport, FALSE);
+    ami_fltwaveout(wport, FALSE);
+    {
+
+        static short buf[TESTRATE/10]; /* a tenth of a second a write */
+        long j;
+
+        for (i = 0; i < 20; i++) {
+
+            for (j = 0; j < TESTRATE/10; j++)
+                buf[j] = (short)(sin(2.0*3.14159265*440.0*
+                                     (i*(TESTRATE/10)+j)/TESTRATE)*20000.0);
+            /* the length is in samples, as genwave and connectwave pass
+               it, not in bytes */
+            ami_wrwave(wport, (byte*)buf, TESTRATE/10);
+
+        }
+
+    }
+    printf("Complete\n");
+    waitret();
+
+    printf("A wave file: made here, loaded, played, deleted. You should\n");
+    printf("hear a C, a fifth above the tone before, for a second and a\n");
+    printf("half. volwave is exercised on the way; it is a stub in this\n");
+    printf("implementation, so it changes nothing audible yet.\n");
+    makewav("sound_test.wav", 523.25, 1.5);
+    ami_loadwave(1, "sound_test.wav");
+    ami_volwave(wport, 0, LONG_MAX/2);
+    ami_playwave(wport, 0, 1);
+    ami_waitwave(wport);
+    ami_delwave(1);
+    remove("sound_test.wav");
+    ami_closewaveout(wport);
+    printf("Complete\n");
+    waitret();
+
+    /***************************************************************************
+
+    WAVE INPUT
+
+    ***************************************************************************/
+
+    if (ami_wavein() > 0) {
+
+        long ch, ra, lb, sg, en, fl;
+        long bps, total, got;
+        byte* rec;
+
+        printf("Wave input. Three seconds are recorded from input port %ld\n",
+               iport);
+        printf("-- make some noise -- and played back to you.\n");
+        waitret();
+        ami_openwavein(iport);
+        ch = ami_chanwavein(iport);
+        ra = ami_ratewavein(iport);
+        lb = ami_lenwavein(iport);
+        sg = ami_sgnwavein(iport);
+        en = ami_endwavein(iport);
+        fl = ami_fltwavein(iport);
+        printf("The device delivers: %ld channels at %ld hertz, %ld bits,\n",
+               ch, ra, lb);
+        printf("%s, %s endian, %s\n", sg? "signed": "unsigned",
+               en? "big": "little", fl? "float": "integer");
+        /* lengths to rdwave and wrwave are in samples -- one frame of
+           every channel -- as connectwave passes them, not in bytes */
+        bps = ch*(lb/8);
+        total = ra*3;
+        rec = malloc(total*bps);
+        if (rec) {
+
+            printf("Recording...\n");
+            got = 0;
+            while (got < total)
+                got += ami_rdwave(iport, rec+got*bps, total-got);
+            ami_closewavein(iport);
+            printf("Playing back...\n");
+            ami_openwaveout(wport);
+            ami_chanwaveout(wport, ch);
+            ami_ratewaveout(wport, ra);
+            ami_lenwaveout(wport, lb);
+            ami_sgnwaveout(wport, sg);
+            ami_endwaveout(wport, en);
+            ami_fltwaveout(wport, fl);
+            ami_wrwave(wport, rec, total);
+            ami_closewaveout(wport);
+            free(rec);
+
+        } else {
+
+            printf("no memory for the recording\n");
+            ami_closewavein(iport);
+
+        }
+        printf("Complete\n");
+        waitret();
+
+    } else printf("No wave input device: recording not tested.\n");
+
+    /***************************************************************************
+
+    SYNTHESIZER INPUT
+
+    ***************************************************************************/
+
+    if (sport > 0) {
+
+        ami_seqmsg sm;
+
+        printf("Synthesizer input from port %ld. Play eight notes on the\n",
+               sport);
+        printf("keyboard; each is echoed to the output synthesizer and\n");
+        printf("printed with the time it arrived.\n");
+        ami_opensynthin(sport);
+        ami_starttimein();
+        for (i = 0; i < 8; ) {
+
+            ami_rdsynth(sport, &sm);
+            if (sm.st == st_noteon) {
+
+                printf("note on:  note %3ld velocity %ld time %ld\n",
+                       (long)sm.ntn, sm.ntv, ami_curtimein());
+                ami_noteon(dport, 0, 1, sm.ntn, sm.ntv);
+                i++;
+
+            } else if (sm.st == st_noteoff) {
+
+                printf("note off: note %3ld time %ld\n", (long)sm.ntn,
+                       ami_curtimein());
+                ami_noteoff(dport, 0, 1, sm.ntn, sm.ntv);
+
+            } else printf("other message: type %d time %ld\n", sm.st,
+                          ami_curtimein());
+
+        }
+        ami_stoptimein();
+        ami_closesynthin(sport);
+        printf("Complete\n");
+        waitret();
+
+    } else printf("Synthesizer input not tested: give --sin=<port> and play "
+                  "the keys.\n");
 
 terminate: /* terminate */
     ami_closesynthout(dport);


### PR DESCRIPTION
`sound_test` covered synthesizer output alone -- and not all of that.
New sections after the listening tests cover the rest of `sound.h`:

- **Devices**: every port of every kind, by name (`synthout/synthin/waveout/wavein` counts and the four `*name` calls)
- **Parameters**: get and set in all four directions (ALSA carries none, so empty and declined are the correct answers; a plug-in with parameters would show them)
- **The sequencer proper** -- nothing had tested it: every note the old test played went at time zero. A scale is queued with future timestamps in one burst; the printed elapsed times show queueing return at 0 and playback take its 3.5 seconds (`time after playing: 35004`)
- **wrsynth**: notes as sequencer records through the record interface
- **aftertouch, pressure, mono, poly**
- **A MIDI file**: `loadsynth/playsynth/waitsynth/delsynth` -- the file (three quarter notes, C-E-G) is generated on the spot and removed, since no .mid is committed
- **Wave output**, both ways: synthesized 440 Hz through `wrwave` the way genwave does, and a generated .wav through `loadwave/playwave/volwave/waitwave/delwave`
- **Wave input**: three seconds recorded through `rdwave` and played back, format copied the way connectwave does
- **Synthesizer input**: `opensynthin/rdsynth/closesynthin` plus `starttimein/curtimein/stoptimein`, echoing a played keyboard -- behind `--sin=<port>`, since reading a keyboard nobody plays blocks

`--nomidi` skips the listening tests and starts at the new sections.

## Library defects the test found, fixed here

1. **`closealsapcmin` closed a MIDI handle from the wave input close.** A
   stray `snd_rawmidi_close(alsamidiout[p-1]->midi)` left over from
   another close routine. Where that slot is a plug-in synth (Fluidsynth,
   here) there is no rawmidi handle, and closing wave input aborted the
   program inside ALSA: `snd_rawmidi_close: Assertion 'rawmidi' failed`.

2. **`ami_closewaveout` checked `alsapcmout[p]` instead of `[p-1]`** --
   the wrong device's existence vouching for the right one.

3. **`ami_volwave`**, same off-by-one (it is otherwise a stub, noted as
   such in the test's narration).

4. **`ami_setparamsynthin` printed a debug line** on every call.

## Notes

The length `wrwave`/`rdwave` take is in **samples** (one frame of every
channel), as genwave and connectwave pass it -- the header comment says
bytes, which is stale. The new sections say so where it matters; my first
draft of the recording test believed the header and scribbled 32x past
its buffer.

Verified end to end on real hardware: full `--nomidi` run exits 0, wave
input records and plays back (8 ch / 44100 / 32 bit float through Pulse),
generated files removed, full `make` clean. The listening judgments are
yours to make -- that part is what the test is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)