### PR TITLE
cpp: one object, a working destructor, the new events, and snake++ builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ endif
 #
 # No reason at present for CPP to be different than C
 #
-CFLAGSCPP = $(CFLAGS)
+CFLAGSCPP = $(CFLAGS) -Ihpp
 
 #
 # Specify object file for libc
@@ -494,7 +494,8 @@ else
     CLIBS += stub/keeper.o lib/petit_ami_term.so
 endif
 
-CLIBSCPP = $(CLIBS) cpp/terminal.o
+# the C++ wrapper is already packaged inside the library (term_core.o)
+CLIBSCPP = $(CLIBS)
 
 #
 # Graphical model API
@@ -521,7 +522,7 @@ PLIBSD += $(LIBPFX)plain$(LIBEXT)
 CLIBSD += $(LIBPFX)term$(LIBEXT) stub/keeper.o
 GLIBSD += $(LIBPFX)graph$(LIBEXT) stub/keeper.o
 
-CLIBSCPPD = $(CLIBSD) cpp/terminal.o
+CLIBSCPPD = $(CLIBSD)
 #
 # add external packages
 #

--- a/cpp/graphics.cpp
+++ b/cpp/graphics.cpp
@@ -28,6 +28,7 @@
 extern "C" {
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <graphics.h>
 
@@ -498,10 +499,35 @@ graph::graph(void)
 
 {
 
+    /* One graph object at a time. The events come back through one
+       global hook: a second object would not share the events with the
+       first, it would take them all -- and the second hooking of the
+       chain saves the hook itself as the handler to pass unhandled
+       events to, which is a loop with no bottom. Refusing is the only
+       honest answer the wrapper has. */
+    if (graphoCB) {
+
+        fprintf(stderr, "graphics: only one graph object may exist\n");
+        exit(1);
+
+    }
     infile = stdin;
     outfile = stdout;
     graphoCB = this;
     eventsover(graphCB, &graphoeh);
+
+}
+
+graph::~graph(void)
+
+{
+
+    pevthan tmp;
+
+    /* put the chain back the way it was found, so no event is ever
+       delivered to an object that no longer exists */
+    eventsover(graphoeh, &tmp);
+    graphoCB = 0;
 
 }
 
@@ -804,6 +830,8 @@ long graph::evdrpbox(long id, long sel) { return 0; }
 long graph::evdrebox(long id) { return 0; }
 long graph::evsldpos(long id, long pos) { return 0; }
 long graph::evtabbar(long id, long sel) { return 0; }
+long graph::evusize(void) { return 0; }
+long graph::evdsize(void) { return 0; }
 
 void graph::graphCB(evtrec* er)
 
@@ -897,6 +925,8 @@ void graph::graphCB(evtrec* er)
         case etdrebox:  handled = graphoCB->evdrebox(er->drebid); break;
         case etsldpos:  handled = graphoCB->evsldpos(er->sldpid, er->sldpos); break;
         case ettabbar:  handled = graphoCB->evtabbar(er->tabid, er->tabsel); break;
+        case etusize:   handled = graphoCB->evusize(); break;
+        case etdsize:   handled = graphoCB->evdsize(); break;
         default: handled = 0; break;
 
     }

--- a/cpp/terminal.cpp
+++ b/cpp/terminal.cpp
@@ -33,6 +33,7 @@
 extern "C" {
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <terminal.h>
 
@@ -144,10 +145,35 @@ term::term(void)
 
 {
 
+    /* One term object at a time. The events come back through one
+       global hook: a second object would not share the events with the
+       first, it would take them all -- and the second hooking of the
+       chain saves the hook itself as the handler to pass unhandled
+       events to, which is a loop with no bottom. Refusing is the only
+       honest answer the wrapper has. */
+    if (termoCB) {
+
+        fprintf(stderr, "terminal: only one term object may exist\n");
+        exit(1);
+
+    }
     infile = stdin;
     outfile = stdout;
     termoCB = this;
     eventsover(termCB, &termoeh);
+
+}
+
+term::~term(void)
+
+{
+
+    pevthan tmp;
+
+    /* put the chain back the way it was found, so no event is ever
+       delivered to an object that no longer exists */
+    eventsover(termoeh, &tmp);
+    termoCB = 0;
 
 }
 

--- a/hpp/graphics.hpp
+++ b/hpp/graphics.hpp
@@ -130,6 +130,8 @@ typedef enum {
     /** drop edit box signals done */   etdrebox,
     /** slider position */              etsldpos,
     /** tab bar select */               ettabbar,
+    /** enlarge what is displayed */    etusize,
+    /** reduce what is displayed */     etdsize,
 
     /* Reserved extra code areas, these are module defined. */
     etsys    = 0x1000, /**< start of base system reserved codes */
@@ -804,6 +806,9 @@ public:
 /* constructor */
 graph();
 
+/* destructor */
+~graph();
+
 /* methods */
 
 /* text */
@@ -1107,6 +1112,8 @@ virtual long evdrpbox(long id, long sel);
 virtual long evdrebox(long id);
 virtual long evsldpos(long id, long pos);
 virtual long evtabbar(long id, long sel);
+virtual long evusize(void);
+virtual long evdsize(void);
 
 }; /* class graph */
 

--- a/hpp/terminal.hpp
+++ b/hpp/terminal.hpp
@@ -266,6 +266,9 @@ public:
 /* constructor */
 term();
 
+/* destructor */
+~term();
+
 /* methods */
 void cursor(long x, long y);
 long  maxx(void);

--- a/terminal_games/snake.cpp
+++ b/terminal_games/snake.cpp
@@ -54,12 +54,9 @@ Translated to C++, 2022/08/19.
 #include <limits.h>
 #include <stdlib.h>
 
-#include <iostream>
-
 #include <localdefs.h>
 #include <terminal.hpp>
 
-using namespace std;
 using namespace terminal;
 
 #define MAXSN  1000  /* total snake positions */
@@ -108,7 +105,7 @@ class gameterm: public term
     char   image[MAXSCN][MAXSCN]; /* screen image */
 
     /* methods */
-    int evterm(void);
+    long evterm(void);
     void event(void);
     void writeimage(int x, int y, char c);
     char readimage(int x, int y);
@@ -142,7 +139,7 @@ screen back to 1, then exits the program with no error.
 
 *******************************************************************************/
 
-int gameterm::evterm(void)
+long gameterm::evterm(void)
 
 {
 
@@ -205,7 +202,7 @@ void gameterm::writescreen(int x, int y, /* position to place character */
     cursor(x, y); /* position to the given location */
     if (c != image[x][y]) { /* filter redundant placements */
 
-        cout << c; /* write the character */
+        putchar(c); /* write the character */
         image[x][y] = c; /* place character in image */
 
     }
@@ -263,12 +260,12 @@ class game: public gameterm
     ~game();                       /* destuctor */
 
     /* event callbacks */
-    int evleft(void);              /* left arrow */
-    int evright(void);             /* right arrow */
-    int evup(void);                /* up arrow */
-    int evdown(void);              /* down arrow */
-    int evjoymov(int j, int x, int y, int z); /* joystick move */
-    int evtim(int t);              /* timer fires */
+    long evleft(void);             /* left arrow */
+    long evright(void);            /* right arrow */
+    long evup(void);               /* up arrow */
+    long evdown(void);             /* down arrow */
+    long evjoymov(long j, long x, long y, long z); /* joystick move */
+    long evtim(long t);            /* timer fires */
 
     /* additional methods */
     void clrscn(void);             /* clear and format game screen */
@@ -290,10 +287,10 @@ Called on arrow keys, moves the snake in the direction indicated.
 
 *******************************************************************************/
 
-int game::evleft(void) { movesnake(etleft); return (1); }
-int game::evright(void) { movesnake(etright); return (1); }
-int game::evup(void) { movesnake(etup); return (1); }
-int game::evdown(void) { movesnake(etdown); return (1); }
+long game::evleft(void) { movesnake(etleft); return (1); }
+long game::evright(void) { movesnake(etright); return (1); }
+long game::evup(void) { movesnake(etup); return (1); }
+long game::evdown(void) { movesnake(etdown); return (1); }
 
 /*******************************************************************************
 
@@ -304,7 +301,7 @@ goes in the joystick indicated direction.
 
 *******************************************************************************/
 
-int game::evjoymov(int j, int x, int y, int z)
+long game::evjoymov(long j, long x, long y, long z)
 
 {
 
@@ -326,7 +323,7 @@ Called on timer events. We handle only timer 1 here, the automatic move timer.
 
 *******************************************************************************/
 
-int game::evtim(int t)
+long game::evtim(long t)
 
 {
 
@@ -378,7 +375,7 @@ void game::clrscn(void)
     int y; /* index y */
     int x; /* index x */
 
-    cout << '\f'; /* clear display screen */
+    putchar('\f'); /* clear display screen */
     for (x = 1; x <= maxx(); x++) /* clear image */
         for (y = 1; y <= maxy(); y++) writeimage(x, y, ' ');
     /* place top */
@@ -677,7 +674,7 @@ game::game()
 
     if (maxx() > MAXSCN || maxy() > MAXSCN) {
 
-        clog << "*** Error: Screen exceeds maximum size" << endl;
+        fprintf(stderr, "*** Error: Screen exceeds maximum size\n");
         exit(1);
 
     }


### PR DESCRIPTION
Follows from a review of the C++ wrappers (`cpp/terminal.cpp`,
`cpp/graphics.cpp`) and a check of `terminal_games/snake.cpp` against
them.

## The wrappers

**A second object was a crash, not a refusal.** Both wrappers hook the
library's master event chain through a single global (`termoCB` /
`graphoCB`). A second `term` or `graph` object would take *all* events
from the first -- and worse, the second hooking saves the hook itself as
the handler for unhandled events, so the first unhandled event recurses
until the stack dies. The constructor now refuses a second object with a
plain message. A destructor unhooks the chain and clears the global, so
a destroyed object can never receive an event.

**The graphics wrapper missed #224's events.** The hpp keeps a parallel
copy of the event enum, and it still ended at `ettabbar`. Added
`etusize`/`etdsize`, the `evusize`/`evdsize` virtuals, and their arms of
the dispatch switch.

## snake++

Had not built in some time -- the reasons were stacked three deep, each
hiding the next:

1. `CFLAGSCPP` never carried `-Ihpp`, so `terminal.hpp` was not found.
2. Behind that: the game's event overrides still said `int` from before
   the long conversion, so they no longer overrode the `long` virtuals
   -- hard compile errors, exactly the parallel-declaration hazard.
3. Behind that: the link carried `cpp/terminal.o` twice, by name in
   `CLIBSCPP` and inside `libami_term.a`, from when the wrapper moved
   into `term_core.o` -- multiple definition of every method.

Also: the game wrote through `cout`, which bypasses the library's stdio
(`cpp.not` note 3 records that breaking on Windows). Three uses, all
single characters or an error line -- now `putchar`/`fprintf`, and
`<iostream>` is out of the program, which also removes a PA-FILE/glibc-
FILE typedef collision in that translation unit.

## Verified

`make snake++` builds; the game plays under tmux (border, score, snake
moves on arrow keys through the `evleft`/`evright`/`evup`/`evdown`
virtuals, timer moves through `evtim`); control-c lands in the `evterm`
override, which restores the screen and exits 0. Full `make` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)