### PR TITLE
cpp: a sound wrapper, in the manner of the terminal one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,7 +585,8 @@ else
 	# The archives carry Petit-Ami's code; the system libraries stay
 	# shared. The sound and network tails cost nothing when unused:
 	# with the members not pulled, as-needed linking drops them.
-	PLIBS += -lasound -lfluidsynth -lssl -lcrypto -lm -lpthread
+	# stdc++: the plain core carries the sound C++ wrapper
+	PLIBS += -lasound -lfluidsynth -lssl -lcrypto -lstdc++ -lm -lpthread
 	CLIBS += -lasound -lfluidsynth -lssl -lcrypto -lstdc++ -lm -lpthread
 	GLIBS += -lasound -lfluidsynth -lssl -lcrypto -lstdc++ -lX11 \
 	         -lfreetype -lfontconfig -lm -lpthread

--- a/Makefile
+++ b/Makefile
@@ -863,6 +863,9 @@ stub/keeper.o: stub/keeper.c
 
 cpp/terminal.o: cpp/terminal.cpp
 	$(CPP) $(CFLAGS) -Ihpp -c cpp/terminal.cpp -o cpp/terminal.o
+
+cpp/sound.o: cpp/sound.cpp
+	$(CPP) $(CFLAGS) -Ihpp -c cpp/sound.cpp -o cpp/sound.o
 	
 portable/gnome_widgets.o: portable/gnome_widgets.c
 	$(CC) $(CFLAGS) -c portable/gnome_widgets.c \
@@ -988,10 +991,10 @@ lib/petit_ami_plain.so: $(LINUXSTDIO) linux/services.o linux/network.o utils/con
 	
 lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o utils/option.o \
-    cpp/terminal.o
+    cpp/terminal.o cpp/sound.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o \
-		utils/option.o  cpp/terminal.o -lstdc++ -o lib/petit_ami_term.so
+		utils/option.o  cpp/terminal.o cpp/sound.o -lstdc++ -o lib/petit_ami_term.so
 	
 #
 # Terminal library with the character mode window manager always included.
@@ -1001,18 +1004,18 @@ lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 #
 lib/petit_ami_termc.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o portable/managerc.o linux/system_event.o utils/config.o \
-	utils/option.o cpp/terminal.o
+	utils/option.o cpp/terminal.o cpp/sound.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o portable/managerc.o linux/system_event.o \
-		utils/config.o utils/option.o cpp/terminal.o -lstdc++ \
+		utils/config.o utils/option.o cpp/terminal.o cpp/sound.o -lstdc++ \
 		-o lib/petit_ami_termc.so
 
 lib/petit_ami_graph.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/graphics.o linux/system_event.o \
-	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o
+	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/graphics.o linux/system_event.o \
-		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o \
+		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o \
         -lstdc++ -o lib/petit_ami_graph.so
 
 #
@@ -1056,24 +1059,24 @@ lib/sound.o: linux/sound.o linux/fluidsynthplug.o linux/dumpsynthplug.o
 # the model cores
 CORE_COMMON = $(LINUXSTDIO) linux/services.o utils/config.o utils/option.o
 
-lib/plain_core.o: $(CORE_COMMON)
-	ld -r -o lib/plain_core.o $(CORE_COMMON)
+lib/plain_core.o: $(CORE_COMMON) cpp/sound.o
+	ld -r -o lib/plain_core.o $(CORE_COMMON) cpp/sound.o
 
 lib/term_core.o: $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	linux/system_event.o cpp/terminal.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o
 	ld -r -o lib/term_core.o $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	    linux/system_event.o cpp/terminal.o
+	    linux/system_event.o cpp/terminal.o cpp/sound.o
 
 lib/termc_core.o: $(CORE_COMMON) linux/terminal.o portable/managerc.o \
-	linux/system_event.o cpp/terminal.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o
 	ld -r -o lib/termc_core.o $(CORE_COMMON) linux/terminal.o \
-	    portable/managerc.o linux/system_event.o cpp/terminal.o
+	    portable/managerc.o linux/system_event.o cpp/terminal.o cpp/sound.o
 
 lib/graph_core.o: $(CORE_COMMON) linux/graphics.o linux/system_event.o \
-	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o
+	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o cpp/sound.o
 	ld -r -o lib/graph_core.o $(CORE_COMMON) linux/graphics.o \
 	    linux/system_event.o portable/widget_base.o portable/gnome_widgets.o \
-	    cpp/terminal.o
+	    cpp/terminal.o cpp/sound.o
 
 # the model archives
 lib/libami_plain.a: lib/plain_core.o lib/sound.o linux/network.o

--- a/cpp/sound.cpp
+++ b/cpp/sound.cpp
@@ -1,0 +1,365 @@
+/** ****************************************************************************
+ *
+ * Sound library interface C++ wrapper
+ *
+ * Wraps the calls in sound with C++ conventions, the same way
+ * cpp/terminal.cpp wraps the terminal calls. This brings:
+ *
+ * 1. The functions, types and constants do not need an "ami_" prefix:
+ * the sound namespace does the isolation. The constants of sound.h
+ * appear in lower case, note_c to inst_gunshot.
+ *
+ * 2. Every call that takes a port has an overload without it, meaning
+ * the default port.
+ *
+ * 3. The synth and wave objects hold ports. Opening sets the port the
+ * object speaks for -- s.opensynthout() or s.opensynthout(2) -- and
+ * every call after that leaves the port off: s.noteon(0, 1, note_c+
+ * octave_6, v). An object holds one port of each direction, so one
+ * synth can serve a keyboard in and a synthesizer out. The destructor
+ * closes whatever is still open.
+ *
+ * Unlike term and graph, sound has no event callbacks to invert, so
+ * these objects hook nothing and any number of them may exist.
+ *
+ * Please see the Petit Ami documentation for more information.
+ *
+ ******************************************************************************/
+
+extern "C" {
+
+#include <stdio.h>
+
+#include <localdefs.h>
+#include <sound.h>
+
+}
+
+#include "sound.hpp"
+
+namespace sound {
+
+/* procedures and functions */
+void starttimeout(void) { ami_starttimeout(); }
+void stoptimeout(void) { ami_stoptimeout(); }
+long curtimeout(void) { return ami_curtimeout(); }
+void starttimein(void) { ami_starttimein(); }
+void stoptimein(void) { ami_stoptimein(); }
+long curtimein(void) { return ami_curtimein(); }
+long synthout(void) { return ami_synthout(); }
+long synthin(void) { return ami_synthin(); }
+long waveout(void) { return ami_waveout(); }
+long wavein(void) { return ami_wavein(); }
+void loadsynth(long s, const char* sf) { ami_loadsynth(s, (char*)sf); }
+void delsynth(long s) { ami_delsynth(s); }
+void loadwave(long w, const char* fn) { ami_loadwave(w, (char*)fn); }
+void delwave(long w) { ami_delwave(w); }
+void opensynthout(long p) { ami_opensynthout(p); }
+void opensynthout(void) { ami_opensynthout(1); }
+void closesynthout(long p) { ami_closesynthout(p); }
+void closesynthout(void) { ami_closesynthout(1); }
+void opensynthin(long p) { ami_opensynthin(p); }
+void opensynthin(void) { ami_opensynthin(1); }
+void closesynthin(long p) { ami_closesynthin(p); }
+void closesynthin(void) { ami_closesynthin(1); }
+void noteon(long p, long t, channel c, note n, long v) { ami_noteon(p, t, c, n, v); }
+void noteon(long t, channel c, note n, long v) { ami_noteon(1, t, c, n, v); }
+void noteoff(long p, long t, channel c, note n, long v) { ami_noteoff(p, t, c, n, v); }
+void noteoff(long t, channel c, note n, long v) { ami_noteoff(1, t, c, n, v); }
+void instchange(long p, long t, channel c, instrument i) { ami_instchange(p, t, c, i); }
+void instchange(long t, channel c, instrument i) { ami_instchange(1, t, c, i); }
+void attack(long p, long t, channel c, long at) { ami_attack(p, t, c, at); }
+void attack(long t, channel c, long at) { ami_attack(1, t, c, at); }
+void release(long p, long t, channel c, long rt) { ami_release(p, t, c, rt); }
+void release(long t, channel c, long rt) { ami_release(1, t, c, rt); }
+void legato(long p, long t, channel c, long b) { ami_legato(p, t, c, b); }
+void legato(long t, channel c, long b) { ami_legato(1, t, c, b); }
+void portamento(long p, long t, channel c, long b) { ami_portamento(p, t, c, b); }
+void portamento(long t, channel c, long b) { ami_portamento(1, t, c, b); }
+void vibrato(long p, long t, channel c, long v) { ami_vibrato(p, t, c, v); }
+void vibrato(long t, channel c, long v) { ami_vibrato(1, t, c, v); }
+void volsynthchan(long p, long t, channel c, long v) { ami_volsynthchan(p, t, c, v); }
+void volsynthchan(long t, channel c, long v) { ami_volsynthchan(1, t, c, v); }
+void porttime(long p, long t, channel c, long v) { ami_porttime(p, t, c, v); }
+void porttime(long t, channel c, long v) { ami_porttime(1, t, c, v); }
+void balance(long p, long t, channel c, long b) { ami_balance(p, t, c, b); }
+void balance(long t, channel c, long b) { ami_balance(1, t, c, b); }
+void pan(long p, long t, channel c, long b) { ami_pan(p, t, c, b); }
+void pan(long t, channel c, long b) { ami_pan(1, t, c, b); }
+void timbre(long p, long t, channel c, long tb) { ami_timbre(p, t, c, tb); }
+void timbre(long t, channel c, long tb) { ami_timbre(1, t, c, tb); }
+void brightness(long p, long t, channel c, long b) { ami_brightness(p, t, c, b); }
+void brightness(long t, channel c, long b) { ami_brightness(1, t, c, b); }
+void reverb(long p, long t, channel c, long r) { ami_reverb(p, t, c, r); }
+void reverb(long t, channel c, long r) { ami_reverb(1, t, c, r); }
+void tremulo(long p, long t, channel c, long tr) { ami_tremulo(p, t, c, tr); }
+void tremulo(long t, channel c, long tr) { ami_tremulo(1, t, c, tr); }
+void chorus(long p, long t, channel c, long cr) { ami_chorus(p, t, c, cr); }
+void chorus(long t, channel c, long cr) { ami_chorus(1, t, c, cr); }
+void celeste(long p, long t, channel c, long ce) { ami_celeste(p, t, c, ce); }
+void celeste(long t, channel c, long ce) { ami_celeste(1, t, c, ce); }
+void phaser(long p, long t, channel c, long ph) { ami_phaser(p, t, c, ph); }
+void phaser(long t, channel c, long ph) { ami_phaser(1, t, c, ph); }
+void aftertouch(long p, long t, channel c, note n, long at) { ami_aftertouch(p, t, c, n, at); }
+void aftertouch(long t, channel c, note n, long at) { ami_aftertouch(1, t, c, n, at); }
+void pressure(long p, long t, channel c, long pr) { ami_pressure(p, t, c, pr); }
+void pressure(long t, channel c, long pr) { ami_pressure(1, t, c, pr); }
+void pitch(long p, long t, channel c, long pt) { ami_pitch(p, t, c, pt); }
+void pitch(long t, channel c, long pt) { ami_pitch(1, t, c, pt); }
+void pitchrange(long p, long t, channel c, long v) { ami_pitchrange(p, t, c, v); }
+void pitchrange(long t, channel c, long v) { ami_pitchrange(1, t, c, v); }
+void mono(long p, long t, channel c, long ch) { ami_mono(p, t, c, ch); }
+void mono(long t, channel c, long ch) { ami_mono(1, t, c, ch); }
+void poly(long p, long t, channel c) { ami_poly(p, t, c); }
+void poly(long t, channel c) { ami_poly(1, t, c); }
+void playsynth(long p, long t, long s) { ami_playsynth(p, t, s); }
+void playsynth(long t, long s) { ami_playsynth(1, t, s); }
+void waitsynth(long p) { ami_waitsynth(p); }
+void waitsynth(void) { ami_waitsynth(1); }
+void wrsynth(long p, seqptr sp) { ami_wrsynth(p, (ami_seqptr)sp); }
+void wrsynth(seqptr sp) { ami_wrsynth(1, (ami_seqptr)sp); }
+void rdsynth(long p, seqptr sp) { ami_rdsynth(p, (ami_seqptr)sp); }
+void rdsynth(seqptr sp) { ami_rdsynth(1, (ami_seqptr)sp); }
+void synthoutname(long p, char* name, long len) { ami_synthoutname(p, name, len); }
+void synthoutname(char* name, long len) { ami_synthoutname(1, name, len); }
+void synthinname(long p, char* name, long len) { ami_synthinname(p, name, len); }
+void synthinname(char* name, long len) { ami_synthinname(1, name, len); }
+long setparamsynthout(long p, const char* name, const char* value) { return ami_setparamsynthout(p, (char*)name, (char*)value); }
+long setparamsynthout(const char* name, const char* value) { return ami_setparamsynthout(1, (char*)name, (char*)value); }
+long setparamsynthin(long p, const char* name, const char* value) { return ami_setparamsynthin(p, (char*)name, (char*)value); }
+long setparamsynthin(const char* name, const char* value) { return ami_setparamsynthin(1, (char*)name, (char*)value); }
+void getparamsynthout(long p, const char* name, char* value, long len) { ami_getparamsynthout(p, (char*)name, value, len); }
+void getparamsynthout(const char* name, char* value, long len) { ami_getparamsynthout(1, (char*)name, value, len); }
+void getparamsynthin(long p, const char* name, char* value, long len) { ami_getparamsynthin(p, (char*)name, value, len); }
+void getparamsynthin(const char* name, char* value, long len) { ami_getparamsynthin(1, (char*)name, value, len); }
+void openwaveout(long p) { ami_openwaveout(p); }
+void openwaveout(void) { ami_openwaveout(1); }
+void closewaveout(long p) { ami_closewaveout(p); }
+void closewaveout(void) { ami_closewaveout(1); }
+void openwavein(long p) { ami_openwavein(p); }
+void openwavein(void) { ami_openwavein(1); }
+void closewavein(long p) { ami_closewavein(p); }
+void closewavein(void) { ami_closewavein(1); }
+void playwave(long p, long t, long w) { ami_playwave(p, t, w); }
+void playwave(long t, long w) { ami_playwave(1, t, w); }
+void volwave(long p, long t, long v) { ami_volwave(p, t, v); }
+void volwave(long t, long v) { ami_volwave(1, t, v); }
+void waitwave(long p) { ami_waitwave(p); }
+void waitwave(void) { ami_waitwave(1); }
+void chanwaveout(long p, long c) { ami_chanwaveout(p, c); }
+void chanwaveout(long c) { ami_chanwaveout(1, c); }
+void ratewaveout(long p, long r) { ami_ratewaveout(p, r); }
+void ratewaveout(long r) { ami_ratewaveout(1, r); }
+void lenwaveout(long p, long l) { ami_lenwaveout(p, l); }
+void lenwaveout(long l) { ami_lenwaveout(1, l); }
+void sgnwaveout(long p, long s) { ami_sgnwaveout(p, s); }
+void sgnwaveout(long s) { ami_sgnwaveout(1, s); }
+void fltwaveout(long p, long f) { ami_fltwaveout(p, f); }
+void fltwaveout(long f) { ami_fltwaveout(1, f); }
+void endwaveout(long p, long e) { ami_endwaveout(p, e); }
+void endwaveout(long e) { ami_endwaveout(1, e); }
+void wrwave(long p, unsigned char* buff, long len) { ami_wrwave(p, (byte*)buff, len); }
+void wrwave(unsigned char* buff, long len) { ami_wrwave(1, (byte*)buff, len); }
+long chanwavein(long p) { return ami_chanwavein(p); }
+long chanwavein(void) { return ami_chanwavein(1); }
+long ratewavein(long p) { return ami_ratewavein(p); }
+long ratewavein(void) { return ami_ratewavein(1); }
+long lenwavein(long p) { return ami_lenwavein(p); }
+long lenwavein(void) { return ami_lenwavein(1); }
+long sgnwavein(long p) { return ami_sgnwavein(p); }
+long sgnwavein(void) { return ami_sgnwavein(1); }
+long endwavein(long p) { return ami_endwavein(p); }
+long endwavein(void) { return ami_endwavein(1); }
+long fltwavein(long p) { return ami_fltwavein(p); }
+long fltwavein(void) { return ami_fltwavein(1); }
+long rdwave(long p, unsigned char* buff, long len) { return ami_rdwave(p, (byte*)buff, len); }
+long rdwave(unsigned char* buff, long len) { return ami_rdwave(1, (byte*)buff, len); }
+void waveoutname(long p, char* name, long len) { ami_waveoutname(p, name, len); }
+void waveoutname(char* name, long len) { ami_waveoutname(1, name, len); }
+void waveinname(long p, char* name, long len) { ami_waveinname(p, name, len); }
+void waveinname(char* name, long len) { ami_waveinname(1, name, len); }
+long setparamwaveout(long p, const char* name, const char* value) { return ami_setparamwaveout(p, (char*)name, (char*)value); }
+long setparamwaveout(const char* name, const char* value) { return ami_setparamwaveout(1, (char*)name, (char*)value); }
+long setparamwavein(long p, const char* name, const char* value) { return ami_setparamwavein(p, (char*)name, (char*)value); }
+long setparamwavein(const char* name, const char* value) { return ami_setparamwavein(1, (char*)name, (char*)value); }
+void getparamwaveout(long p, const char* name, char* value, long len) { ami_getparamwaveout(p, (char*)name, value, len); }
+void getparamwaveout(const char* name, char* value, long len) { ami_getparamwaveout(1, (char*)name, value, len); }
+void getparamwavein(long p, const char* name, char* value, long len) { ami_getparamwavein(p, (char*)name, value, len); }
+void getparamwavein(const char* name, char* value, long len) { ami_getparamwavein(1, (char*)name, value, len); }
+
+/* methods */
+synth::synth(void)
+
+{
+
+    outport = 0; /* nothing held yet */
+    inport = 0;
+
+}
+
+synth::~synth(void)
+
+{
+
+    /* close whatever the object still holds */
+    if (outport) ami_closesynthout(outport);
+    if (inport) ami_closesynthin(inport);
+
+}
+
+void synth::opensynthout(long p)
+
+{
+
+    /* an object holds one port a direction: opening over a held port
+       lets go of the old one first */
+    if (outport) ami_closesynthout(outport);
+    ami_opensynthout(p);
+    outport = p;
+
+}
+
+void synth::closesynthout(void)
+
+{
+
+    if (outport) { ami_closesynthout(outport); outport = 0; }
+
+}
+
+void synth::opensynthin(long p)
+
+{
+
+    if (inport) ami_closesynthin(inport);
+    ami_opensynthin(p);
+    inport = p;
+
+}
+
+void synth::closesynthin(void)
+
+{
+
+    if (inport) { ami_closesynthin(inport); inport = 0; }
+
+}
+
+void synth::noteon(long t, channel c, note n, long v) { ami_noteon(outport, t, c, n, v); }
+void synth::noteoff(long t, channel c, note n, long v) { ami_noteoff(outport, t, c, n, v); }
+void synth::instchange(long t, channel c, instrument i) { ami_instchange(outport, t, c, i); }
+void synth::attack(long t, channel c, long at) { ami_attack(outport, t, c, at); }
+void synth::release(long t, channel c, long rt) { ami_release(outport, t, c, rt); }
+void synth::legato(long t, channel c, long b) { ami_legato(outport, t, c, b); }
+void synth::portamento(long t, channel c, long b) { ami_portamento(outport, t, c, b); }
+void synth::vibrato(long t, channel c, long v) { ami_vibrato(outport, t, c, v); }
+void synth::volsynthchan(long t, channel c, long v) { ami_volsynthchan(outport, t, c, v); }
+void synth::porttime(long t, channel c, long v) { ami_porttime(outport, t, c, v); }
+void synth::balance(long t, channel c, long b) { ami_balance(outport, t, c, b); }
+void synth::pan(long t, channel c, long b) { ami_pan(outport, t, c, b); }
+void synth::timbre(long t, channel c, long tb) { ami_timbre(outport, t, c, tb); }
+void synth::brightness(long t, channel c, long b) { ami_brightness(outport, t, c, b); }
+void synth::reverb(long t, channel c, long r) { ami_reverb(outport, t, c, r); }
+void synth::tremulo(long t, channel c, long tr) { ami_tremulo(outport, t, c, tr); }
+void synth::chorus(long t, channel c, long cr) { ami_chorus(outport, t, c, cr); }
+void synth::celeste(long t, channel c, long ce) { ami_celeste(outport, t, c, ce); }
+void synth::phaser(long t, channel c, long ph) { ami_phaser(outport, t, c, ph); }
+void synth::aftertouch(long t, channel c, note n, long at) { ami_aftertouch(outport, t, c, n, at); }
+void synth::pressure(long t, channel c, long pr) { ami_pressure(outport, t, c, pr); }
+void synth::pitch(long t, channel c, long pt) { ami_pitch(outport, t, c, pt); }
+void synth::pitchrange(long t, channel c, long v) { ami_pitchrange(outport, t, c, v); }
+void synth::mono(long t, channel c, long ch) { ami_mono(outport, t, c, ch); }
+void synth::poly(long t, channel c) { ami_poly(outport, t, c); }
+void synth::playsynth(long t, long s) { ami_playsynth(outport, t, s); }
+void synth::waitsynth(void) { ami_waitsynth(outport); }
+void synth::wrsynth(seqptr sp) { ami_wrsynth(outport, (ami_seqptr)sp); }
+void synth::rdsynth(seqptr sp) { ami_rdsynth(inport, (ami_seqptr)sp); }
+void synth::synthoutname(char* name, long len) { ami_synthoutname(outport, name, len); }
+void synth::synthinname(char* name, long len) { ami_synthinname(inport, name, len); }
+long synth::setparamsynthout(const char* name, const char* value) { return ami_setparamsynthout(outport, (char*)name, (char*)value); }
+long synth::setparamsynthin(const char* name, const char* value) { return ami_setparamsynthin(inport, (char*)name, (char*)value); }
+void synth::getparamsynthout(const char* name, char* value, long len) { ami_getparamsynthout(outport, (char*)name, value, len); }
+void synth::getparamsynthin(const char* name, char* value, long len) { ami_getparamsynthin(inport, (char*)name, value, len); }
+
+wave::wave(void)
+
+{
+
+    outport = 0; /* nothing held yet */
+    inport = 0;
+
+}
+
+wave::~wave(void)
+
+{
+
+    /* close whatever the object still holds */
+    if (outport) ami_closewaveout(outport);
+    if (inport) ami_closewavein(inport);
+
+}
+
+void wave::openwaveout(long p)
+
+{
+
+    /* an object holds one port a direction: opening over a held port
+       lets go of the old one first */
+    if (outport) ami_closewaveout(outport);
+    ami_openwaveout(p);
+    outport = p;
+
+}
+
+void wave::closewaveout(void)
+
+{
+
+    if (outport) { ami_closewaveout(outport); outport = 0; }
+
+}
+
+void wave::openwavein(long p)
+
+{
+
+    if (inport) ami_closewavein(inport);
+    ami_openwavein(p);
+    inport = p;
+
+}
+
+void wave::closewavein(void)
+
+{
+
+    if (inport) { ami_closewavein(inport); inport = 0; }
+
+}
+
+void wave::playwave(long t, long w) { ami_playwave(outport, t, w); }
+void wave::volwave(long t, long v) { ami_volwave(outport, t, v); }
+void wave::waitwave(void) { ami_waitwave(outport); }
+void wave::chanwaveout(long c) { ami_chanwaveout(outport, c); }
+void wave::ratewaveout(long r) { ami_ratewaveout(outport, r); }
+void wave::lenwaveout(long l) { ami_lenwaveout(outport, l); }
+void wave::sgnwaveout(long s) { ami_sgnwaveout(outport, s); }
+void wave::fltwaveout(long f) { ami_fltwaveout(outport, f); }
+void wave::endwaveout(long e) { ami_endwaveout(outport, e); }
+void wave::wrwave(unsigned char* buff, long len) { ami_wrwave(outport, (byte*)buff, len); }
+long wave::chanwavein(void) { return ami_chanwavein(inport); }
+long wave::ratewavein(void) { return ami_ratewavein(inport); }
+long wave::lenwavein(void) { return ami_lenwavein(inport); }
+long wave::sgnwavein(void) { return ami_sgnwavein(inport); }
+long wave::endwavein(void) { return ami_endwavein(inport); }
+long wave::fltwavein(void) { return ami_fltwavein(inport); }
+long wave::rdwave(unsigned char* buff, long len) { return ami_rdwave(inport, (byte*)buff, len); }
+void wave::waveoutname(char* name, long len) { ami_waveoutname(outport, name, len); }
+void wave::waveinname(char* name, long len) { ami_waveinname(inport, name, len); }
+long wave::setparamwaveout(const char* name, const char* value) { return ami_setparamwaveout(outport, (char*)name, (char*)value); }
+long wave::setparamwavein(const char* name, const char* value) { return ami_setparamwavein(inport, (char*)name, (char*)value); }
+void wave::getparamwaveout(const char* name, char* value, long len) { ami_getparamwaveout(outport, (char*)name, value, len); }
+void wave::getparamwavein(const char* name, char* value, long len) { ami_getparamwavein(inport, (char*)name, value, len); }
+
+} /* namespace sound */

--- a/hpp/sound
+++ b/hpp/sound
@@ -1,0 +1,1 @@
+sound.hpp

--- a/hpp/sound.hpp
+++ b/hpp/sound.hpp
@@ -1,0 +1,540 @@
+/** ****************************************************************************
+ *
+ * Sound library interface C++ wrapper declarations
+ *
+ * See cpp/sound.cpp for the rationale. The types and constants of the C
+ * header appear here with the ami_/AMI_ prefixes stripped, the constants
+ * in lower case as C++ constants rather than macros. The layout of
+ * seqmsg is identical to ami_seqmsg in sound.h, and must stay so: the
+ * wrapper casts between them.
+ *
+ ******************************************************************************/
+
+#ifndef __SOUND_HPP__
+#define __SOUND_HPP__
+
+namespace sound {
+
+/* MIDI note, channel and instrument */
+typedef long note;
+typedef long channel;
+typedef long instrument;
+
+/* sequencer message types */
+typedef enum {
+
+    st_noteon, st_noteoff, st_instchange, st_attack, st_release,
+    st_legato, st_portamento, st_vibrato, st_volsynthchan,
+    st_porttime, st_balance, st_pan, st_timbre, st_brightness,
+    st_reverb, st_tremulo, st_chorus, st_celeste, st_phaser,
+    st_aftertouch, st_pressure, st_pitch, st_pitchrange, st_mono,
+    st_poly, st_playsynth, st_playwave, st_volwave
+
+} seqtyp;
+
+/* sequencer message */
+typedef struct seqmsg {
+
+    struct seqmsg* next; /* next message in list */
+    long           port; /* port to which message applies */
+    long           time; /* time to execute message */
+    seqtyp         st;   /* type of message */
+    union {
+
+        /* st_noteon st_noteoff st_aftertouch st_pressure */
+        struct { channel ntc; note ntn; long ntv; };
+        /* st_instchange */ struct { channel icc; instrument ici; };
+        /* st_attack, st_release, st_vibrato, st_volsynthchan,
+           st_porttime, st_balance, st_pan, st_timbre, st_brightness,
+           st_reverb, st_tremulo, st_chorus, st_celeste, st_phaser,
+           st_pitch, st_pitchrange, st_mono */
+        struct { channel vsc; long vsv; };
+        /* st_poly */ channel pc;
+        /* st_legato, st_portamento */ struct { channel bsc; long bsb; };
+        /* st_playsynth */ long sid;
+        /* st_playwave */ long wt;
+        /* st_volwave */ long wv;
+
+    };
+
+} seqmsg;
+
+/* pointer to message */
+typedef seqmsg* seqptr;
+
+/* the constants of sound.h, prefixes stripped */
+const long chan_drum                    =  10;
+const long synth_out                    =   1;
+const long synth_in                     =   1;
+const long wave_in                      =   1;
+const long wave_out                     =   1;
+const long note_c                       =   1;
+const long note_c_sharp                 =   2;
+const long note_d_flat                  =   2;
+const long note_d                       =   3;
+const long note_d_sharp                 =   4;
+const long note_e_flat                  =   4;
+const long note_e                       =   5;
+const long note_f                       =   6;
+const long note_f_sharp                 =   7;
+const long note_g_flat                  =   7;
+const long note_g                       =   8;
+const long note_g_sharp                 =   9;
+const long note_a_flat                  =   9;
+const long note_a                       =  10;
+const long note_a_sharp                 =  11;
+const long note_b_flat                  =  11;
+const long note_b                       =  12;
+const long octave_1                     =   0;
+const long octave_2                     =  12;
+const long octave_3                     =  24;
+const long octave_4                     =  36;
+const long octave_5                     =  48;
+const long octave_6                     =  60;
+const long octave_7                     =  72;
+const long octave_8                     =  84;
+const long octave_9                     =  96;
+const long octave_10                    = 108;
+const long octave_11                    = 120;
+const long inst_acoustic_grand          =   1;
+const long inst_bright_acoustic         =   2;
+const long inst_electric_grand          =   3;
+const long inst_honky_tonk              =   4;
+const long inst_electric_piano_1        =   5;
+const long inst_electric_piano_2        =   6;
+const long inst_harpsichord             =   7;
+const long inst_clavinet                =   8;
+const long inst_celesta                 =   9;
+const long inst_glockenspiel            =  10;
+const long inst_music_box               =  11;
+const long inst_vibraphone              =  12;
+const long inst_marimba                 =  13;
+const long inst_xylophone               =  14;
+const long inst_tubular_bells           =  15;
+const long inst_dulcimer                =  16;
+const long inst_drawbar_organ           =  17;
+const long inst_percussive_organ        =  18;
+const long inst_rock_organ              =  19;
+const long inst_church_organ            =  20;
+const long inst_reed_organ              =  21;
+const long inst_accoridan               =  22;
+const long inst_harmonica               =  23;
+const long inst_tango_accordian         =  24;
+const long inst_nylon_string_guitar     =  25;
+const long inst_steel_string_guitar     =  26;
+const long inst_electric_jazz_guitar    =  27;
+const long inst_electric_clean_guitar   =  28;
+const long inst_electric_muted_guitar   =  29;
+const long inst_overdriven_guitar       =  30;
+const long inst_distortion_guitar       =  31;
+const long inst_guitar_harmonics        =  32;
+const long inst_acoustic_bass           =  33;
+const long inst_electric_bass_finger    =  34;
+const long inst_electric_bass_pick      =  35;
+const long inst_fretless_bass           =  36;
+const long inst_slap_bass_1             =  37;
+const long inst_slap_bass_2             =  38;
+const long inst_synth_bass_1            =  39;
+const long inst_synth_bass_2            =  40;
+const long inst_violin                  =  41;
+const long inst_viola                   =  42;
+const long inst_cello                   =  43;
+const long inst_contrabass              =  44;
+const long inst_tremolo_strings         =  45;
+const long inst_pizzicato_strings       =  46;
+const long inst_orchestral_strings      =  47;
+const long inst_timpani                 =  48;
+const long inst_string_ensemble_1       =  49;
+const long inst_string_ensemble_2       =  50;
+const long inst_synthstrings_1          =  51;
+const long inst_synthstrings_2          =  52;
+const long inst_choir_aahs              =  53;
+const long inst_voice_oohs              =  54;
+const long inst_synth_voice             =  55;
+const long inst_orchestra_hit           =  56;
+const long inst_trumpet                 =  57;
+const long inst_trombone                =  58;
+const long inst_tuba                    =  59;
+const long inst_muted_trumpet           =  60;
+const long inst_french_horn             =  61;
+const long inst_brass_section           =  62;
+const long inst_synthbrass_1            =  63;
+const long inst_synthbrass_2            =  64;
+const long inst_soprano_sax             =  65;
+const long inst_alto_sax                =  66;
+const long inst_tenor_sax               =  67;
+const long inst_baritone_sax            =  68;
+const long inst_oboe                    =  69;
+const long inst_english_horn            =  70;
+const long inst_bassoon                 =  71;
+const long inst_clarinet                =  72;
+const long inst_piccolo                 =  73;
+const long inst_flute                   =  74;
+const long inst_recorder                =  75;
+const long inst_pan_flute               =  76;
+const long inst_blown_bottle            =  77;
+const long inst_skakuhachi              =  78;
+const long inst_whistle                 =  79;
+const long inst_ocarina                 =  80;
+const long inst_lead_1_square           =  81;
+const long inst_lead_2_sawtooth         =  82;
+const long inst_lead_3_calliope         =  83;
+const long inst_lead_4_chiff            =  84;
+const long inst_lead_5_charang          =  85;
+const long inst_lead_6_voice            =  86;
+const long inst_lead_7_fifths           =  87;
+const long inst_lead_8_bass_lead        =  88;
+const long inst_pad_1_new_age           =  89;
+const long inst_pad_2_warm              =  90;
+const long inst_pad_3_polysynth         =  91;
+const long inst_pad_4_choir             =  92;
+const long inst_pad_5_bowed             =  93;
+const long inst_pad_6_metallic          =  94;
+const long inst_pad_7_halo              =  95;
+const long inst_pad_8_sweep             =  96;
+const long inst_fx_1_rain               =  97;
+const long inst_fx_2_soundtrack         =  98;
+const long inst_fx_3_crystal            =  99;
+const long inst_fx_4_atmosphere         = 100;
+const long inst_fx_5_brightness         = 101;
+const long inst_fx_6_goblins            = 102;
+const long inst_fx_7_echoes             = 103;
+const long inst_fx_8_sci_fi             = 104;
+const long inst_sitar                   = 105;
+const long inst_banjo                   = 106;
+const long inst_shamisen                = 107;
+const long inst_koto                    = 108;
+const long inst_kalimba                 = 109;
+const long inst_bagpipe                 = 110;
+const long inst_fiddle                  = 111;
+const long inst_shanai                  = 112;
+const long inst_tinkle_bell             = 113;
+const long inst_agogo                   = 114;
+const long inst_steel_drums             = 115;
+const long inst_woodblock               = 116;
+const long inst_taiko_drum              = 117;
+const long inst_melodic_tom             = 118;
+const long inst_synth_drum              = 119;
+const long inst_reverse_cymbal          = 120;
+const long inst_guitar_fret_noise       = 121;
+const long inst_breath_noise            = 122;
+const long inst_seashore                = 123;
+const long inst_bird_tweet              = 124;
+const long inst_telephone_ring          = 125;
+const long inst_helicopter              = 126;
+const long inst_applause                = 127;
+const long inst_gunshot                 = 128;
+const long note_acoustic_bass_drum      =  35;
+const long note_bass_drum_1             =  36;
+const long note_side_stick              =  37;
+const long note_acoustic_snare          =  38;
+const long note_hand_clap               =  39;
+const long note_electric_snare          =  40;
+const long note_low_floor_tom           =  41;
+const long note_closed_hi_hat           =  42;
+const long note_high_floor_tom          =  43;
+const long note_pedal_hi_hat            =  44;
+const long note_low_tom                 =  45;
+const long note_open_hi_hat             =  46;
+const long note_low_mid_tom             =  47;
+const long note_hi_mid_tom              =  48;
+const long note_crash_cymbal_1          =  49;
+const long note_high_tom                =  50;
+const long note_ride_cymbal_1           =  51;
+const long note_chinese_cymbal          =  52;
+const long note_ride_bell               =  53;
+const long note_tambourine              =  54;
+const long note_splash_cymbal           =  55;
+const long note_cowbell                 =  56;
+const long note_crash_cymbal_2          =  57;
+const long note_vibraslap               =  58;
+const long note_ride_cymbal_2           =  59;
+const long note_hi_bongo                =  60;
+const long note_low_bongo               =  61;
+const long note_mute_hi_conga           =  62;
+const long note_open_hi_conga           =  63;
+const long note_low_conga               =  64;
+const long note_high_timbale            =  65;
+const long note_low_timbale             =  66;
+const long note_high_agogo              =  67;
+const long note_low_agogo               =  68;
+const long note_cabasa                  =  69;
+const long note_maracas                 =  70;
+const long note_short_whistle           =  71;
+const long note_long_whistle            =  72;
+const long note_short_guiro             =  73;
+const long note_long_guiro              =  74;
+const long note_claves                  =  75;
+const long note_hi_wood_block           =  76;
+const long note_low_wood_block          =  77;
+const long note_mute_cuica              =  78;
+const long note_open_cuica              =  79;
+const long note_mute_triangle           =  80;
+const long note_open_triangle           =  81;
+
+/* procedures and functions */
+void starttimeout(void);
+void stoptimeout(void);
+long curtimeout(void);
+void starttimein(void);
+void stoptimein(void);
+long curtimein(void);
+long synthout(void);
+long synthin(void);
+long waveout(void);
+long wavein(void);
+void loadsynth(long s, const char* sf);
+void delsynth(long s);
+void loadwave(long w, const char* fn);
+void delwave(long w);
+void opensynthout(long p);
+void opensynthout(void);
+void closesynthout(long p);
+void closesynthout(void);
+void opensynthin(long p);
+void opensynthin(void);
+void closesynthin(long p);
+void closesynthin(void);
+void noteon(long p, long t, channel c, note n, long v);
+void noteon(long t, channel c, note n, long v);
+void noteoff(long p, long t, channel c, note n, long v);
+void noteoff(long t, channel c, note n, long v);
+void instchange(long p, long t, channel c, instrument i);
+void instchange(long t, channel c, instrument i);
+void attack(long p, long t, channel c, long at);
+void attack(long t, channel c, long at);
+void release(long p, long t, channel c, long rt);
+void release(long t, channel c, long rt);
+void legato(long p, long t, channel c, long b);
+void legato(long t, channel c, long b);
+void portamento(long p, long t, channel c, long b);
+void portamento(long t, channel c, long b);
+void vibrato(long p, long t, channel c, long v);
+void vibrato(long t, channel c, long v);
+void volsynthchan(long p, long t, channel c, long v);
+void volsynthchan(long t, channel c, long v);
+void porttime(long p, long t, channel c, long v);
+void porttime(long t, channel c, long v);
+void balance(long p, long t, channel c, long b);
+void balance(long t, channel c, long b);
+void pan(long p, long t, channel c, long b);
+void pan(long t, channel c, long b);
+void timbre(long p, long t, channel c, long tb);
+void timbre(long t, channel c, long tb);
+void brightness(long p, long t, channel c, long b);
+void brightness(long t, channel c, long b);
+void reverb(long p, long t, channel c, long r);
+void reverb(long t, channel c, long r);
+void tremulo(long p, long t, channel c, long tr);
+void tremulo(long t, channel c, long tr);
+void chorus(long p, long t, channel c, long cr);
+void chorus(long t, channel c, long cr);
+void celeste(long p, long t, channel c, long ce);
+void celeste(long t, channel c, long ce);
+void phaser(long p, long t, channel c, long ph);
+void phaser(long t, channel c, long ph);
+void aftertouch(long p, long t, channel c, note n, long at);
+void aftertouch(long t, channel c, note n, long at);
+void pressure(long p, long t, channel c, long pr);
+void pressure(long t, channel c, long pr);
+void pitch(long p, long t, channel c, long pt);
+void pitch(long t, channel c, long pt);
+void pitchrange(long p, long t, channel c, long v);
+void pitchrange(long t, channel c, long v);
+void mono(long p, long t, channel c, long ch);
+void mono(long t, channel c, long ch);
+void poly(long p, long t, channel c);
+void poly(long t, channel c);
+void playsynth(long p, long t, long s);
+void playsynth(long t, long s);
+void waitsynth(long p);
+void waitsynth(void);
+void wrsynth(long p, seqptr sp);
+void wrsynth(seqptr sp);
+void rdsynth(long p, seqptr sp);
+void rdsynth(seqptr sp);
+void synthoutname(long p, char* name, long len);
+void synthoutname(char* name, long len);
+void synthinname(long p, char* name, long len);
+void synthinname(char* name, long len);
+long setparamsynthout(long p, const char* name, const char* value);
+long setparamsynthout(const char* name, const char* value);
+long setparamsynthin(long p, const char* name, const char* value);
+long setparamsynthin(const char* name, const char* value);
+void getparamsynthout(long p, const char* name, char* value, long len);
+void getparamsynthout(const char* name, char* value, long len);
+void getparamsynthin(long p, const char* name, char* value, long len);
+void getparamsynthin(const char* name, char* value, long len);
+void openwaveout(long p);
+void openwaveout(void);
+void closewaveout(long p);
+void closewaveout(void);
+void openwavein(long p);
+void openwavein(void);
+void closewavein(long p);
+void closewavein(void);
+void playwave(long p, long t, long w);
+void playwave(long t, long w);
+void volwave(long p, long t, long v);
+void volwave(long t, long v);
+void waitwave(long p);
+void waitwave(void);
+void chanwaveout(long p, long c);
+void chanwaveout(long c);
+void ratewaveout(long p, long r);
+void ratewaveout(long r);
+void lenwaveout(long p, long l);
+void lenwaveout(long l);
+void sgnwaveout(long p, long s);
+void sgnwaveout(long s);
+void fltwaveout(long p, long f);
+void fltwaveout(long f);
+void endwaveout(long p, long e);
+void endwaveout(long e);
+void wrwave(long p, unsigned char* buff, long len);
+void wrwave(unsigned char* buff, long len);
+long chanwavein(long p);
+long chanwavein(void);
+long ratewavein(long p);
+long ratewavein(void);
+long lenwavein(long p);
+long lenwavein(void);
+long sgnwavein(long p);
+long sgnwavein(void);
+long endwavein(long p);
+long endwavein(void);
+long fltwavein(long p);
+long fltwavein(void);
+long rdwave(long p, unsigned char* buff, long len);
+long rdwave(unsigned char* buff, long len);
+void waveoutname(long p, char* name, long len);
+void waveoutname(char* name, long len);
+void waveinname(long p, char* name, long len);
+void waveinname(char* name, long len);
+long setparamwaveout(long p, const char* name, const char* value);
+long setparamwaveout(const char* name, const char* value);
+long setparamwavein(long p, const char* name, const char* value);
+long setparamwavein(const char* name, const char* value);
+void getparamwaveout(long p, const char* name, char* value, long len);
+void getparamwaveout(const char* name, char* value, long len);
+void getparamwavein(long p, const char* name, char* value, long len);
+void getparamwavein(const char* name, char* value, long len);
+
+/*******************************************************************************
+
+The port objects
+
+A synth holds a synthesizer output port and a synthesizer input port; a
+wave holds the same pair of waveform ports. Opening sets the port the
+object speaks for, and every call after that leaves the port off. The
+destructor closes whatever the object still holds open, so a port
+cannot leak by an early return.
+
+Unlike the term and graph objects of the other wrappers, these hook
+nothing: any number of them can exist at once, one per port in use.
+
+*******************************************************************************/
+
+class synth {
+
+long outport; /* the output port held, 0 when closed */
+long inport;  /* the input port held, 0 when closed */
+
+public:
+
+/* constructor */
+synth();
+
+/* destructor */
+~synth();
+
+/* methods */
+void opensynthout(long p = synth_out);
+void closesynthout(void);
+void opensynthin(long p = synth_in);
+void closesynthin(void);
+void noteon(long t, channel c, note n, long v);
+void noteoff(long t, channel c, note n, long v);
+void instchange(long t, channel c, instrument i);
+void attack(long t, channel c, long at);
+void release(long t, channel c, long rt);
+void legato(long t, channel c, long b);
+void portamento(long t, channel c, long b);
+void vibrato(long t, channel c, long v);
+void volsynthchan(long t, channel c, long v);
+void porttime(long t, channel c, long v);
+void balance(long t, channel c, long b);
+void pan(long t, channel c, long b);
+void timbre(long t, channel c, long tb);
+void brightness(long t, channel c, long b);
+void reverb(long t, channel c, long r);
+void tremulo(long t, channel c, long tr);
+void chorus(long t, channel c, long cr);
+void celeste(long t, channel c, long ce);
+void phaser(long t, channel c, long ph);
+void aftertouch(long t, channel c, note n, long at);
+void pressure(long t, channel c, long pr);
+void pitch(long t, channel c, long pt);
+void pitchrange(long t, channel c, long v);
+void mono(long t, channel c, long ch);
+void poly(long t, channel c);
+void playsynth(long t, long s);
+void waitsynth(void);
+void wrsynth(seqptr sp);
+void rdsynth(seqptr sp);
+void synthoutname(char* name, long len);
+void synthinname(char* name, long len);
+long setparamsynthout(const char* name, const char* value);
+long setparamsynthin(const char* name, const char* value);
+void getparamsynthout(const char* name, char* value, long len);
+void getparamsynthin(const char* name, char* value, long len);
+
+}; /* class synth */
+
+class wave {
+
+long outport; /* the output port held, 0 when closed */
+long inport;  /* the input port held, 0 when closed */
+
+public:
+
+/* constructor */
+wave();
+
+/* destructor */
+~wave();
+
+/* methods */
+void openwaveout(long p = wave_out);
+void closewaveout(void);
+void openwavein(long p = wave_in);
+void closewavein(void);
+void playwave(long t, long w);
+void volwave(long t, long v);
+void waitwave(void);
+void chanwaveout(long c);
+void ratewaveout(long r);
+void lenwaveout(long l);
+void sgnwaveout(long s);
+void fltwaveout(long f);
+void endwaveout(long e);
+void wrwave(unsigned char* buff, long len);
+long chanwavein(void);
+long ratewavein(void);
+long lenwavein(void);
+long sgnwavein(void);
+long endwavein(void);
+long fltwavein(void);
+long rdwave(unsigned char* buff, long len);
+void waveoutname(char* name, long len);
+void waveinname(char* name, long len);
+long setparamwaveout(const char* name, const char* value);
+long setparamwavein(const char* name, const char* value);
+void getparamwaveout(const char* name, char* value, long len);
+void getparamwavein(const char* name, char* value, long len);
+
+}; /* class wave */
+
+} /* namespace sound */
+
+#endif /* __SOUND_HPP__ */


### PR DESCRIPTION
`cpp/sound.cpp` and `hpp/sound.hpp`, following the pattern of the
terminal and graphics wrappers, with the two ideas asked of it:

## 1. The sound namespace

The whole of `sound.h` with the prefixes stripped: every function, the
sequencer types (`seqmsg` layout-identical to `ami_seqmsg`, as the other
wrappers keep their records), and all 208 constants of the header as
lower-case C++ constants rather than macros -- `note_c`, `octave_6`,
`inst_acoustic_grand`, `chan_drum`. Every call that takes a port also
has an overload without one, meaning the default port, the way the
terminal wrapper defaults stdout.

## 2. The port objects

```cpp
synth s;
s.opensynthout();                    /* or opensynthout(2) */
s.instchange(0, 1, inst_acoustic_grand);
s.noteon(0, 1, note_c+octave_6, v); /* no port anywhere after the open */
```

`synth` and `wave` each hold one port of each direction, so a single
synth serves a keyboard in and a synthesizer out, and a single wave a
recording and its playback. The destructor closes whatever is still
held -- a port cannot leak past an early return -- and opening over a
held port lets go of the old one first. A method on a direction that
was never opened passes port 0, which the library's own error
discipline stops loudly.

Unlike `term` and `graph`, these hook nothing, so any number may exist:
the test plays **two synthesizers at once from two objects**, which the
one-hook wrappers cannot express.

## Packaging

Compiled into the cores beside `cpp/terminal.o` -- term, termc, graph,
and the shared libraries -- and into the **plain** core as well, since
sound does not need a terminal. `PLIBS` gains `-lstdc++` accordingly
(the other profiles already carried it). Nothing was added to
`CLIBSCPP`: the library carries the object, and naming it twice is the
double link snake++ just taught (#230).

## Verified live

Counts and names through the namespace; a C-major scale through a
`synth` object on Fluidsynth; a second of A 440 written through a
`wave` object; wave input opened and queried on the same object (8 ch /
44100 through Pulse); two synth objects sounding on two ports at once;
destructors closing everything -- exit 0. One note: the wave-input
close runs into the stray rawmidi close that **#228** fixes; with that
one line applied the run is clean end to end, so #228 should land
before or with this. Full `make` clean, and the 43-check network test
still passes from the rebuilt plain library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)