### PR TITLE
cpp: a services wrapper, mostly namespace, three objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -868,6 +868,9 @@ cpp/terminal.o: cpp/terminal.cpp
 
 cpp/sound.o: cpp/sound.cpp
 	$(CPP) $(CFLAGS) -Ihpp -c cpp/sound.cpp -o cpp/sound.o
+
+cpp/services.o: cpp/services.cpp
+	$(CPP) $(CFLAGS) -Ihpp -c cpp/services.cpp -o cpp/services.o
 	
 portable/gnome_widgets.o: portable/gnome_widgets.c
 	$(CC) $(CFLAGS) -c portable/gnome_widgets.c \
@@ -993,10 +996,10 @@ lib/petit_ami_plain.so: $(LINUXSTDIO) linux/services.o linux/network.o utils/con
 	
 lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o utils/option.o \
-    cpp/terminal.o cpp/sound.o
+    cpp/terminal.o cpp/sound.o cpp/services.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o \
-		utils/option.o  cpp/terminal.o cpp/sound.o -lstdc++ -o lib/petit_ami_term.so
+		utils/option.o  cpp/terminal.o cpp/sound.o cpp/services.o -lstdc++ -o lib/petit_ami_term.so
 	
 #
 # Terminal library with the character mode window manager always included.
@@ -1006,18 +1009,18 @@ lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 #
 lib/petit_ami_termc.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o portable/managerc.o linux/system_event.o utils/config.o \
-	utils/option.o cpp/terminal.o cpp/sound.o
+	utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o portable/managerc.o linux/system_event.o \
-		utils/config.o utils/option.o cpp/terminal.o cpp/sound.o -lstdc++ \
+		utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o -lstdc++ \
 		-o lib/petit_ami_termc.so
 
 lib/petit_ami_graph.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/graphics.o linux/system_event.o \
-	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o
+	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/graphics.o linux/system_event.o \
-		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o \
+		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o \
         -lstdc++ -o lib/petit_ami_graph.so
 
 #
@@ -1061,24 +1064,24 @@ lib/sound.o: linux/sound.o linux/fluidsynthplug.o linux/dumpsynthplug.o
 # the model cores
 CORE_COMMON = $(LINUXSTDIO) linux/services.o utils/config.o utils/option.o
 
-lib/plain_core.o: $(CORE_COMMON) cpp/sound.o
-	ld -r -o lib/plain_core.o $(CORE_COMMON) cpp/sound.o
+lib/plain_core.o: $(CORE_COMMON) cpp/sound.o cpp/services.o
+	ld -r -o lib/plain_core.o $(CORE_COMMON) cpp/sound.o cpp/services.o
 
 lib/term_core.o: $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	linux/system_event.o cpp/terminal.o cpp/sound.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
 	ld -r -o lib/term_core.o $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	    linux/system_event.o cpp/terminal.o cpp/sound.o
+	    linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
 
 lib/termc_core.o: $(CORE_COMMON) linux/terminal.o portable/managerc.o \
-	linux/system_event.o cpp/terminal.o cpp/sound.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
 	ld -r -o lib/termc_core.o $(CORE_COMMON) linux/terminal.o \
-	    portable/managerc.o linux/system_event.o cpp/terminal.o cpp/sound.o
+	    portable/managerc.o linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
 
 lib/graph_core.o: $(CORE_COMMON) linux/graphics.o linux/system_event.o \
-	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o cpp/sound.o
+	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o cpp/sound.o cpp/services.o
 	ld -r -o lib/graph_core.o $(CORE_COMMON) linux/graphics.o \
 	    linux/system_event.o portable/widget_base.o portable/gnome_widgets.o \
-	    cpp/terminal.o cpp/sound.o
+	    cpp/terminal.o cpp/sound.o cpp/services.o
 
 # the model archives
 lib/libami_plain.a: lib/plain_core.o lib/sound.o linux/network.o

--- a/cpp/services.cpp
+++ b/cpp/services.cpp
@@ -1,0 +1,157 @@
+/** ****************************************************************************
+ *
+ * Services library interface C++ wrapper
+ *
+ * Wraps the calls in services with C++ conventions, the same way
+ * cpp/terminal.cpp wraps the terminal calls. This brings:
+ *
+ * 1. The functions and types do not need an "ami_" prefix: the services
+ * namespace does the isolation.
+ *
+ * 2. The threading pieces become objects. A thread starts on
+ * construction; a mutex and a signal are made by their constructors,
+ * freed by their destructors, and speak the C verbs -- m.lock(),
+ * m.unlock(), s.sendsig(), s.waitsig(m) -- so a lock cannot leak past
+ * an early return and an identifier never outlives what it names.
+ *
+ * The rest of services is stateless calls on the world -- files, paths,
+ * environment, time, measurement -- and a namespace serves those
+ * better than objects would.
+ *
+ * Please see the Petit Ami documentation for more information.
+ *
+ ******************************************************************************/
+
+extern "C" {
+
+#include <stdio.h>
+
+#include <services.h>
+
+}
+
+#include "services.hpp"
+
+namespace services {
+
+/* procedures and functions */
+void list(const char* f, filptr* lp) { ami_list((char*)f, (ami_filrec**)lp); }
+void times(char* s, long sl, long t) { ami_times(s, sl, t); }
+void dates(char* s, long sl, long t) { ami_dates(s, sl, t); }
+void writetime(FILE* f, long t) { ami_writetime(f, t); }
+void writedate(FILE* f, long t) { ami_writedate(f, t); }
+long time(void) { return ami_time(); }
+long local(long t) { return ami_local(t); }
+long clock(void) { return ami_clock(); }
+long elapsed(long r) { return ami_elapsed(r); }
+long validfile(const char* s) { return ami_validfile((char*)s); }
+long validpath(const char* s) { return ami_validpath((char*)s); }
+long wild(const char* s) { return ami_wild((char*)s); }
+void getenv(const char* ls, char* ds, long dsl) { ami_getenv((char*)ls, ds, dsl); }
+void setenv(const char* sn, const char* sd) { ami_setenv((char*)sn, (char*)sd); }
+void allenv(envptr* el) { ami_allenv((ami_envrec**)el); }
+void remenv(const char* sn) { ami_remenv((char*)sn); }
+void exec(const char* cmd) { ami_exec((char*)cmd); }
+void exece(const char* cmd, envptr el) { ami_exece((char*)cmd, (ami_envrec*)el); }
+void execw(const char* cmd, long* e) { ami_execw((char*)cmd, e); }
+void execew(const char* cmd, envptr el, long* e) { ami_execew((char*)cmd, (ami_envrec*)el, e); }
+void getcur(char* fn, long l) { ami_getcur(fn, l); }
+void setcur(const char* fn) { ami_setcur((char*)fn); }
+void brknam(const char* fn, char* p, long pl, char* n, long nl, char* e, long el) { ami_brknam((char*)fn, p, pl, n, nl, e, el); }
+void maknam(char* fn, long fnl, const char* p, const char* n, const char* e) { ami_maknam(fn, fnl, (char*)p, (char*)n, (char*)e); }
+void fulnam(char* fn, long fnl) { ami_fulnam(fn, fnl); }
+void getpgm(char* p, long pl) { ami_getpgm(p, pl); }
+void getusr(char* fn, long fnl) { ami_getusr(fn, fnl); }
+void setatr(const char* fn, attrset at) { ami_setatr((char*)fn, at); }
+void resatr(const char* fn, attrset at) { ami_resatr((char*)fn, at); }
+void bakupd(const char* fn) { ami_bakupd((char*)fn); }
+void setuper(const char* fn, permset p) { ami_setuper((char*)fn, p); }
+void resuper(const char* fn, permset p) { ami_resuper((char*)fn, p); }
+void setgper(const char* fn, permset p) { ami_setgper((char*)fn, p); }
+void resgper(const char* fn, permset p) { ami_resgper((char*)fn, p); }
+void setoper(const char* fn, permset p) { ami_setoper((char*)fn, p); }
+void resoper(const char* fn, permset p) { ami_resoper((char*)fn, p); }
+void makpth(const char* fn) { ami_makpth((char*)fn); }
+void rempth(const char* fn) { ami_rempth((char*)fn); }
+void filchr(chrset fc) { ami_filchr(fc); }
+char optchr(void) { return ami_optchr(); }
+char pthchr(void) { return ami_pthchr(); }
+long latitude(void) { return ami_latitude(); }
+long longitude(void) { return ami_longitude(); }
+long altitude(void) { return ami_altitude(); }
+long country(void) { return ami_country(); }
+void countrys(char* s, long sl, long c) { ami_countrys(s, sl, c); }
+long timezone(void) { return ami_timezone(); }
+long daysave(void) { return ami_daysave(); }
+long time24hour(void) { return ami_time24hour(); }
+long language(void) { return ami_language(); }
+void languages(char* s, long sl, long l) { ami_languages(s, sl, l); }
+char decimal(void) { return ami_decimal(); }
+char numbersep(void) { return ami_numbersep(); }
+long timeorder(void) { return ami_timeorder(); }
+long dateorder(void) { return ami_dateorder(); }
+char datesep(void) { return ami_datesep(); }
+char timesep(void) { return ami_timesep(); }
+char currchr(void) { return ami_currchr(); }
+long newthread(void (*threadmain)(void)) { return ami_newthread(threadmain); }
+long initlock(void) { return ami_initlock(); }
+void deinitlock(long ln) { ami_deinitlock(ln); }
+void lock(long ln) { ami_lock(ln); }
+void unlock(long ln) { ami_unlock(ln); }
+long initsig(void) { return ami_initsig(); }
+void deinitsig(long sn) { ami_deinitsig(sn); }
+void sendsig(long sn) { ami_sendsig(sn); }
+void sendsigone(long sn) { ami_sendsigone(sn); }
+void waitsig(long ln, long sn) { ami_waitsig(ln, sn); }
+
+/* methods */
+thread::thread(void (*threadmain)(void))
+
+{
+
+    tid = ami_newthread(threadmain);
+
+}
+
+long thread::id(void) { return tid; }
+
+mutex::mutex(void)
+
+{
+
+    ln = ami_initlock();
+
+}
+
+mutex::~mutex(void)
+
+{
+
+    ami_deinitlock(ln);
+
+}
+
+void mutex::lock(void) { ami_lock(ln); }
+void mutex::unlock(void) { ami_unlock(ln); }
+
+signal::signal(void)
+
+{
+
+    sn = ami_initsig();
+
+}
+
+signal::~signal(void)
+
+{
+
+    ami_deinitsig(sn);
+
+}
+
+void signal::sendsig(void) { ami_sendsig(sn); }
+void signal::sendsigone(void) { ami_sendsigone(sn); }
+void signal::waitsig(mutex& m) { ami_waitsig(m.ln, sn); }
+
+} /* namespace services */

--- a/hpp/services
+++ b/hpp/services
@@ -1,0 +1,1 @@
+services.hpp

--- a/hpp/services.hpp
+++ b/hpp/services.hpp
@@ -1,0 +1,238 @@
+/** ****************************************************************************
+ *
+ * Services library interface C++ wrapper declarations
+ *
+ * See cpp/services.cpp for the rationale. The types of the C header
+ * appear here with the ami_ prefixes stripped, laid out identically to
+ * their C forms: the wrapper casts between them.
+ *
+ ******************************************************************************/
+
+#ifndef __SERVICES_HPP__
+#define __SERVICES_HPP__
+
+extern "C" {
+
+#include <stdio.h>
+
+}
+
+namespace services {
+
+/* length of character set */
+const long csetlen = 32;
+
+/* attributes */
+typedef enum {
+
+    atexec, /* is an executable file type */
+    atarc,  /* has been archived since last modification */
+    atsys,  /* is a system special file */
+    atdir,  /* is a directory special file */
+    atloop  /* contains heriarchy loop */
+
+} attribute;
+typedef long attrset; /* attributes in a set */
+
+/* permissions */
+typedef enum {
+
+    pmread,  /* may be read */
+    pmwrite, /* may be written */
+    pmexec,  /* may be executed */
+    pmdel,   /* may be deleted */
+    pmvis,   /* may be seen in directory listings */
+    pmcopy,  /* may be copied */
+    pmren    /* may be renamed/moved */
+
+} permission;
+typedef long permset; /* permissions in a set */
+
+/* standard directory format */
+typedef struct filrec {
+
+    char*          name;    /* name of file (zero terminated) */
+    long           namel;   /* length of filename */
+    long long      size;    /* size of file */
+    long long      alloc;   /* allocation of file */
+    attrset        attr;    /* attributes */
+    long           create;  /* time of creation */
+    long           modify;  /* time of last modification */
+    long           access;  /* time of last access */
+    long           backup;  /* time of last backup */
+    permset        user;    /* user permissions */
+    permset        group;   /* group permissions */
+    permset        other;   /* other permissions */
+    struct filrec* next;    /* next entry in list */
+
+} filrec;
+typedef filrec* filptr; /* pointer to file records */
+
+/* environment strings */
+typedef struct envrec {
+
+    char* name;          /* name of string (zero terminated) */
+    char* data;          /* data in string (zero terminated) */
+    struct envrec *next; /* next entry in list */
+
+} envrec;
+typedef envrec* envptr; /* pointer to environment record */
+
+/* character set */
+typedef unsigned char chrset[csetlen];
+
+/* the set operators of the C header, as inline functions */
+inline long bit(long b) { return 1l<<b; }
+inline long incset(const unsigned char* s, long b)
+    { return !!(s[b>>3] & bit(b%8)); }
+inline void addcset(unsigned char* s, long b) { s[b>>3] |= bit(b%8); }
+inline void subcset(unsigned char* s, long b) { s[b>>3] &= ~bit(b%8); }
+inline void clrcset(unsigned char* s)
+    { for (long i = 0; i < csetlen; i++) s[i] = 0; }
+inline long iniset(long s, long b) { return !!(s & bit(b)); }
+inline long addiset(long s, long b) { return s | bit(b); }
+inline long subiset(long s, long b) { return s & ~bit(b); }
+
+/* procedures and functions */
+void list(const char* f, filptr* lp);
+void times(char* s, long sl, long t);
+void dates(char* s, long sl, long t);
+void writetime(FILE* f, long t);
+void writedate(FILE* f, long t);
+long time(void);
+long local(long t);
+long clock(void);
+long elapsed(long r);
+long validfile(const char* s);
+long validpath(const char* s);
+long wild(const char* s);
+void getenv(const char* ls, char* ds, long dsl);
+void setenv(const char* sn, const char* sd);
+void allenv(envptr* el);
+void remenv(const char* sn);
+void exec(const char* cmd);
+void exece(const char* cmd, envptr el);
+void execw(const char* cmd, long* e);
+void execew(const char* cmd, envptr el, long* e);
+void getcur(char* fn, long l);
+void setcur(const char* fn);
+void brknam(const char* fn, char* p, long pl, char* n, long nl, char* e, long el);
+void maknam(char* fn, long fnl, const char* p, const char* n, const char* e);
+void fulnam(char* fn, long fnl);
+void getpgm(char* p, long pl);
+void getusr(char* fn, long fnl);
+void setatr(const char* fn, attrset at);
+void resatr(const char* fn, attrset at);
+void bakupd(const char* fn);
+void setuper(const char* fn, permset p);
+void resuper(const char* fn, permset p);
+void setgper(const char* fn, permset p);
+void resgper(const char* fn, permset p);
+void setoper(const char* fn, permset p);
+void resoper(const char* fn, permset p);
+void makpth(const char* fn);
+void rempth(const char* fn);
+void filchr(chrset fc);
+char optchr(void);
+char pthchr(void);
+long latitude(void);
+long longitude(void);
+long altitude(void);
+long country(void);
+void countrys(char* s, long sl, long c);
+long timezone(void);
+long daysave(void);
+long time24hour(void);
+long language(void);
+void languages(char* s, long sl, long l);
+char decimal(void);
+char numbersep(void);
+long timeorder(void);
+long dateorder(void);
+char datesep(void);
+char timesep(void);
+char currchr(void);
+long newthread(void (*threadmain)(void));
+long initlock(void);
+void deinitlock(long ln);
+void lock(long ln);
+void unlock(long ln);
+long initsig(void);
+void deinitsig(long sn);
+void sendsig(long sn);
+void sendsigone(long sn);
+void waitsig(long ln, long sn);
+
+/*******************************************************************************
+
+The thread, mutex and signal objects
+
+A thread starts on construction and runs the function it was given; the
+services interface has no join or kill, so the object is the start and
+the identifier. A mutex is made by its constructor and freed by its
+destructor, and locks and unlocks by the C verbs: m.lock(), m.unlock().
+The class is called mutex rather than lock only because C++ will not
+let a class and its method share a name. A signal likewise lives from
+constructor to destructor, sends with sendsig() or sendsigone(), and
+waits on a mutex with waitsig(m).
+
+These hold identifiers, not hooks: any number of each may exist.
+
+*******************************************************************************/
+
+class thread {
+
+long tid; /* the thread identifier */
+
+public:
+
+/* constructor: the thread starts here */
+thread(void (*threadmain)(void));
+
+/* the identifier, as newthread returned it */
+long id(void);
+
+}; /* class thread */
+
+class mutex {
+
+friend class signal;
+
+long ln; /* the lock identifier */
+
+public:
+
+/* constructor */
+mutex();
+
+/* destructor */
+~mutex();
+
+/* methods */
+void lock(void);
+void unlock(void);
+
+}; /* class mutex */
+
+class signal {
+
+long sn; /* the signal identifier */
+
+public:
+
+/* constructor */
+signal();
+
+/* destructor */
+~signal();
+
+/* methods */
+void sendsig(void);
+void sendsigone(void);
+void waitsig(mutex& m);
+
+}; /* class signal */
+
+} /* namespace services */
+
+#endif /* __SERVICES_HPP__ */


### PR DESCRIPTION
`cpp/services.cpp` and `hpp/services.hpp`, completing the wrapper set --
terminal, graphics, sound, and now services -- with the shape asked of
it: mostly namespace, objects only where the API holds state.

## The namespace

The whole of `services.h` unprefixed: all ~70 functions, the
`attribute`/`permission` enums, `filrec`/`envrec` laid out identically
to their C forms (the wrapper casts), `chrset`, and the set-operator
macros as inline functions. Buffers stay `char*`; pure inputs take
`const char*` and cast inside, so C++ string literals pass without
warnings.

## The three objects

```cpp
static mutex  mx;
static signal sg;

static void worker(void) { ... mx.lock(); done = 1; sg.sendsig(); mx.unlock(); }

thread t(worker);
mx.lock();
while (!done) sg.waitsig(mx);
mx.unlock();
```

- **`thread`** starts on construction and keeps the identifier;
  services has no join or kill, so the object is the start and the id.
- **`mutex`** is made by its constructor, freed by its destructor, and
  speaks the C verbs: `m.lock()`, `m.unlock()`. The class is named
  `mutex` rather than `lock` only because C++ forbids a method named
  after its class -- the verbs, which are what appear at call sites,
  are unchanged.
- **`signal`** sends with `sendsig()`/`sendsigone()` and waits with
  `waitsig(mutex&)` -- the lock-and-signal pairing of the C call, with
  the pairing now visible in the signature.

These hold identifiers, not hooks (unlike `term`/`graph`), so any
number may exist, and `deinitlock`/`deinitsig` can never be forgotten
or reordered against use.

## Packaged

Beside the other wrappers in every core -- plain included -- and the
shared libraries. Full `make` clean.

## Verified live

Clock and locale calls, `getusr`/`getenv`, filename validity, a
directory listing walked through `filptr`, `clock()`/`elapsed()`
timing, and the worker handshake exactly as `mail` does it: a thread
object summing 1..1000000 behind the mutex and signal, answer correct,
exit 0. The objects are globals, so constructor-before-main also holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)