### PR TITLE
cpp: a network wrapper, namespace plus the net and msg objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,6 +871,9 @@ cpp/sound.o: cpp/sound.cpp
 
 cpp/services.o: cpp/services.cpp
 	$(CPP) $(CFLAGS) -Ihpp -c cpp/services.cpp -o cpp/services.o
+
+cpp/network.o: cpp/network.cpp
+	$(CPP) $(CFLAGS) -Ihpp -c cpp/network.cpp -o cpp/network.o
 	
 portable/gnome_widgets.o: portable/gnome_widgets.c
 	$(CC) $(CFLAGS) -c portable/gnome_widgets.c \
@@ -996,10 +999,10 @@ lib/petit_ami_plain.so: $(LINUXSTDIO) linux/services.o linux/network.o utils/con
 	
 lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o utils/option.o \
-    cpp/terminal.o cpp/sound.o cpp/services.o
+    cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o $(MANAGERC) linux/system_event.o utils/config.o \
-		utils/option.o  cpp/terminal.o cpp/sound.o cpp/services.o -lstdc++ -o lib/petit_ami_term.so
+		utils/option.o  cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o -lstdc++ -o lib/petit_ami_term.so
 	
 #
 # Terminal library with the character mode window manager always included.
@@ -1009,18 +1012,18 @@ lib/petit_ami_term.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 #
 lib/petit_ami_termc.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/terminal.o portable/managerc.o linux/system_event.o utils/config.o \
-	utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o
+	utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/terminal.o portable/managerc.o linux/system_event.o \
-		utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o -lstdc++ \
+		utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o -lstdc++ \
 		-o lib/petit_ami_termc.so
 
 lib/petit_ami_graph.so: $(LINUXSTDIO) linux/services.o linux/network.o \
 	linux/graphics.o linux/system_event.o \
-	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o
+	portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	$(CC) -shared $(LINUXSTDIO) linux/services.o linux/network.o \
 		linux/graphics.o linux/system_event.o \
-		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o \
+		portable/gnome_widgets.o portable/widget_base.o utils/config.o utils/option.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o \
         -lstdc++ -o lib/petit_ami_graph.so
 
 #
@@ -1064,24 +1067,24 @@ lib/sound.o: linux/sound.o linux/fluidsynthplug.o linux/dumpsynthplug.o
 # the model cores
 CORE_COMMON = $(LINUXSTDIO) linux/services.o utils/config.o utils/option.o
 
-lib/plain_core.o: $(CORE_COMMON) cpp/sound.o cpp/services.o
-	ld -r -o lib/plain_core.o $(CORE_COMMON) cpp/sound.o cpp/services.o
+lib/plain_core.o: $(CORE_COMMON) cpp/sound.o cpp/services.o cpp/network.o
+	ld -r -o lib/plain_core.o $(CORE_COMMON) cpp/sound.o cpp/services.o cpp/network.o
 
 lib/term_core.o: $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	ld -r -o lib/term_core.o $(CORE_COMMON) linux/terminal.o $(MANAGERC) \
-	    linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
+	    linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 
 lib/termc_core.o: $(CORE_COMMON) linux/terminal.o portable/managerc.o \
-	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
+	linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	ld -r -o lib/termc_core.o $(CORE_COMMON) linux/terminal.o \
-	    portable/managerc.o linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o
+	    portable/managerc.o linux/system_event.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 
 lib/graph_core.o: $(CORE_COMMON) linux/graphics.o linux/system_event.o \
-	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o cpp/sound.o cpp/services.o
+	portable/widget_base.o portable/gnome_widgets.o cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 	ld -r -o lib/graph_core.o $(CORE_COMMON) linux/graphics.o \
 	    linux/system_event.o portable/widget_base.o portable/gnome_widgets.o \
-	    cpp/terminal.o cpp/sound.o cpp/services.o
+	    cpp/terminal.o cpp/sound.o cpp/services.o cpp/network.o
 
 # the model archives
 lib/libami_plain.a: lib/plain_core.o lib/sound.o linux/network.o

--- a/cpp/network.cpp
+++ b/cpp/network.cpp
@@ -1,0 +1,250 @@
+/** ****************************************************************************
+ *
+ * Network library interface C++ wrapper
+ *
+ * Wraps the calls in network with C++ conventions, the same way
+ * cpp/terminal.cpp wraps the terminal calls. This brings:
+ *
+ * 1. The functions and types do not need an "ami_" prefix: the network
+ * namespace does the isolation. The secure flag defaults off.
+ *
+ * 2. The net and msg objects hold connections. A net is one stream
+ * connection, opened as a client -- by address, or by name with the
+ * lookup made on the way -- or as a server with waitnet; it converts
+ * to FILE* so the stdio calls read and write it directly. A msg is one
+ * message channel, the same way. The destructor closes whatever is
+ * still held, so a connection cannot leak past an early return.
+ *
+ * These hold handles, not hooks, so any number of them may exist: a
+ * mail program holds one net for IMAP and another for SMTP.
+ *
+ * Please see the Petit Ami documentation for more information.
+ *
+ ******************************************************************************/
+
+extern "C" {
+
+#include <stdio.h>
+
+#include <localdefs.h>
+#include <network.h>
+
+}
+
+#include "network.hpp"
+
+namespace network {
+
+/* procedures and functions */
+void  addrnet(const char* name, unsigned long* addr)
+    { ami_addrnet((char*)name, addr); }
+void  addrnetv6(const char* name, unsigned long long* addrh,
+                unsigned long long* addrl)
+    { ami_addrnetv6((char*)name, addrh, addrl); }
+FILE* opennet(unsigned long addr, long port, long secure)
+    { return ami_opennet(addr, port, secure); }
+FILE* opennetv6(unsigned long long addrh, unsigned long long addrl,
+                long port, long secure)
+    { return ami_opennetv6(addrh, addrl, port, secure); }
+long  maxmsg(unsigned long addr) { return ami_maxmsg(addr); }
+long  maxmsgv6(unsigned long long addrh, unsigned long long addrl)
+    { return ami_maxmsgv6(addrh, addrl); }
+long  relymsg(unsigned long addr) { return ami_relymsg(addr); }
+long  relymsgv6(unsigned long long addrh, unsigned long long addrl)
+    { return ami_relymsgv6(addrh, addrl); }
+long  openmsg(unsigned long addr, long port, long secure)
+    { return ami_openmsg(addr, port, secure); }
+long  openmsgv6(unsigned long long addrh, unsigned long long addrl,
+                long port, long secure)
+    { return ami_openmsgv6(addrh, addrl, port, secure); }
+void  wrmsg(long fn, void* msg, unsigned long len) { ami_wrmsg(fn, msg, len); }
+long  rdmsg(long fn, void* msg, unsigned long len)
+    { return ami_rdmsg(fn, msg, len); }
+void  clsmsg(long fn) { ami_clsmsg(fn); }
+FILE* waitnet(long port, long secure) { return ami_waitnet(port, secure); }
+long  waitmsg(long port, long secure) { return ami_waitmsg(port, secure); }
+long  certnet(FILE* f, long which, char* cert, long len)
+    { return ami_certnet(f, which, cert, len); }
+long  certmsg(long fn, long which, char* cert, long len)
+    { return ami_certmsg(fn, which, cert, len); }
+void  certlistnet(FILE* f, long which, certptr* list)
+    { ami_certlistnet(f, which, (ami_certptr*)list); }
+void  certlistmsg(long fn, long which, certptr* list)
+    { ami_certlistmsg(fn, which, (ami_certptr*)list); }
+void  certlistfree(certptr* list) { ami_certlistfree((ami_certptr*)list); }
+
+/* methods */
+net::net(void)
+
+{
+
+    f = NULL; /* nothing held yet */
+
+}
+
+net::~net(void)
+
+{
+
+    /* close what the object still holds */
+    if (f) fclose(f);
+
+}
+
+/* An object holds one connection: opening over a held one lets go of
+   the old one first. The same rule as the sound port objects. */
+void net::opennet(unsigned long addr, long port, long secure)
+
+{
+
+    if (f) fclose(f);
+    f = ami_opennet(addr, port, secure);
+
+}
+
+/* as a convenience, the name form makes the lookup on the way */
+void net::opennet(const char* name, long port, long secure)
+
+{
+
+    unsigned long addr;
+
+    ami_addrnet((char*)name, &addr);
+    opennet(addr, port, secure);
+
+}
+
+void net::opennetv6(unsigned long long addrh, unsigned long long addrl,
+                    long port, long secure)
+
+{
+
+    if (f) fclose(f);
+    f = ami_opennetv6(addrh, addrl, port, secure);
+
+}
+
+void net::opennetv6(const char* name, long port, long secure)
+
+{
+
+    unsigned long long addrh, addrl;
+
+    ami_addrnetv6((char*)name, &addrh, &addrl);
+    opennetv6(addrh, addrl, port, secure);
+
+}
+
+void net::waitnet(long port, long secure)
+
+{
+
+    if (f) fclose(f);
+    f = ami_waitnet(port, secure);
+
+}
+
+void net::close(void)
+
+{
+
+    if (f) { fclose(f); f = NULL; }
+
+}
+
+long net::certnet(long which, char* cert, long len)
+    { return ami_certnet(f, which, cert, len); }
+void net::certlistnet(long which, certptr* list)
+    { ami_certlistnet(f, which, (ami_certptr*)list); }
+
+net::operator FILE*(void) { return f; }
+
+msg::msg(void)
+
+{
+
+    fn = -1; /* nothing held yet */
+    open = 0;
+
+}
+
+msg::~msg(void)
+
+{
+
+    /* close what the object still holds */
+    if (open) ami_clsmsg(fn);
+
+}
+
+void msg::openmsg(unsigned long addr, long port, long secure)
+
+{
+
+    if (open) ami_clsmsg(fn);
+    fn = ami_openmsg(addr, port, secure);
+    open = 1;
+
+}
+
+void msg::openmsg(const char* name, long port, long secure)
+
+{
+
+    unsigned long addr;
+
+    ami_addrnet((char*)name, &addr);
+    openmsg(addr, port, secure);
+
+}
+
+void msg::openmsgv6(unsigned long long addrh, unsigned long long addrl,
+                    long port, long secure)
+
+{
+
+    if (open) ami_clsmsg(fn);
+    fn = ami_openmsgv6(addrh, addrl, port, secure);
+    open = 1;
+
+}
+
+void msg::openmsgv6(const char* name, long port, long secure)
+
+{
+
+    unsigned long long addrh, addrl;
+
+    ami_addrnetv6((char*)name, &addrh, &addrl);
+    openmsgv6(addrh, addrl, port, secure);
+
+}
+
+void msg::waitmsg(long port, long secure)
+
+{
+
+    if (open) ami_clsmsg(fn);
+    fn = ami_waitmsg(port, secure);
+    open = 1;
+
+}
+
+void msg::wrmsg(void* buff, unsigned long len) { ami_wrmsg(fn, buff, len); }
+long msg::rdmsg(void* buff, unsigned long len)
+    { return ami_rdmsg(fn, buff, len); }
+
+void msg::clsmsg(void)
+
+{
+
+    if (open) { ami_clsmsg(fn); open = 0; }
+
+}
+
+long msg::certmsg(long which, char* cert, long len)
+    { return ami_certmsg(fn, which, cert, len); }
+void msg::certlistmsg(long which, certptr* list)
+    { ami_certlistmsg(fn, which, (ami_certptr*)list); }
+
+} /* namespace network */

--- a/hpp/network
+++ b/hpp/network
@@ -1,0 +1,1 @@
+network.hpp

--- a/hpp/network.hpp
+++ b/hpp/network.hpp
@@ -1,0 +1,137 @@
+/** ****************************************************************************
+ *
+ * Network library interface C++ wrapper declarations
+ *
+ * See cpp/network.cpp for the rationale. The certificate field record
+ * appears here with the ami_ prefix stripped, laid out identically to
+ * its C form: the wrapper casts between them.
+ *
+ ******************************************************************************/
+
+#ifndef __NETWORK_HPP__
+#define __NETWORK_HPP__
+
+extern "C" {
+
+#include <stdio.h>
+
+}
+
+namespace network {
+
+/* name - value pair list */
+typedef struct certfield {
+
+    char*             name;     /* name of field */
+    char*             data;     /* content of field */
+    long              critical; /* is a critical X509 field */
+    struct certfield* fork;     /* sublist */
+    struct certfield* next;     /* next entry in list */
+
+} certfield, *certptr;
+
+/* procedures and functions */
+void  addrnet(const char* name, unsigned long* addr);
+void  addrnetv6(const char* name, unsigned long long* addrh,
+                unsigned long long* addrl);
+FILE* opennet(unsigned long addr, long port, long secure = 0);
+FILE* opennetv6(unsigned long long addrh, unsigned long long addrl,
+                long port, long secure = 0);
+long  maxmsg(unsigned long addr);
+long  maxmsgv6(unsigned long long addrh, unsigned long long addrl);
+long  relymsg(unsigned long addr);
+long  relymsgv6(unsigned long long addrh, unsigned long long addrl);
+long  openmsg(unsigned long addr, long port, long secure = 0);
+long  openmsgv6(unsigned long long addrh, unsigned long long addrl,
+                long port, long secure = 0);
+void  wrmsg(long fn, void* msg, unsigned long len);
+long  rdmsg(long fn, void* msg, unsigned long len);
+void  clsmsg(long fn);
+FILE* waitnet(long port, long secure = 0);
+long  waitmsg(long port, long secure = 0);
+long  certnet(FILE* f, long which, char* cert, long len);
+long  certmsg(long fn, long which, char* cert, long len);
+void  certlistnet(FILE* f, long which, certptr* list);
+void  certlistmsg(long fn, long which, certptr* list);
+void  certlistfree(certptr* list);
+
+/*******************************************************************************
+
+The net and msg objects
+
+A net holds one stream connection, a msg one message channel. Opening
+sets what the object holds -- as a client by address or, for a net, by
+name, with the lookup made on the way -- or as a server with the wait
+call. Every call after that leaves the connection off, and the
+destructor closes whatever is still held, so a connection cannot leak
+past an early return.
+
+A net converts to FILE* wherever one is wanted, so the stdio calls
+read and write it directly: fgets(buff, len, n) reads from the
+connection n holds. Close it with the object -- close() or the
+destructor -- never with fclose through the converted pointer, or the
+destructor would close it a second time.
+
+These hold handles, not hooks: any number of them may exist.
+
+*******************************************************************************/
+
+class net {
+
+FILE* f; /* the connection held, NULL when closed */
+
+public:
+
+/* constructor */
+net();
+
+/* destructor */
+~net();
+
+/* methods */
+void opennet(unsigned long addr, long port, long secure = 0);
+void opennet(const char* name, long port, long secure = 0);
+void opennetv6(unsigned long long addrh, unsigned long long addrl,
+               long port, long secure = 0);
+void opennetv6(const char* name, long port, long secure = 0);
+void waitnet(long port, long secure = 0);
+void close(void);
+long certnet(long which, char* cert, long len);
+void certlistnet(long which, certptr* list);
+
+/* the connection, for the stdio calls */
+operator FILE*(void);
+
+}; /* class net */
+
+class msg {
+
+long fn;   /* the channel held */
+long open; /* it is held */
+
+public:
+
+/* constructor */
+msg();
+
+/* destructor */
+~msg();
+
+/* methods */
+void openmsg(unsigned long addr, long port, long secure = 0);
+void openmsg(const char* name, long port, long secure = 0);
+void openmsgv6(unsigned long long addrh, unsigned long long addrl,
+               long port, long secure = 0);
+void openmsgv6(const char* name, long port, long secure = 0);
+void waitmsg(long port, long secure = 0);
+void wrmsg(void* buff, unsigned long len);
+long rdmsg(void* buff, unsigned long len);
+void clsmsg(void);
+long certmsg(long which, char* cert, long len);
+void certlistmsg(long which, certptr* list);
+
+}; /* class msg */
+
+} /* namespace network */
+
+#endif /* __NETWORK_HPP__ */


### PR DESCRIPTION
`cpp/network.cpp` and `hpp/network.hpp` -- the fifth wrapper, with the
shape asked: the namespace, a network object, and a message object.

## The namespace

All of `network.h` unprefixed, `certfield`/`certptr` laid out
identically to the C record, and `secure` defaulted off everywhere, so
the common case reads `opennet(addr, 80)`.

## The net object

```cpp
net c;

c.opennet("google.com", 443, 1);   /* by name: the lookup on the way */
fputs("GET / HTTP/1.0\r\n\r\n", c);
fflush(c);
while (fgets(buff, sizeof(buff), c)) ...
```

One stream connection: client by address or by name (an overload makes
the `addrnet` lookup on the way), or server by `waitnet`. **It converts
to `FILE*`**, so the stdio calls speak to it directly -- the file
paradigm of the C interface kept whole. Certificate queries are
methods. Close by `close()` or the destructor, never `fclose` through
the converted pointer, so it closes once.

## The msg object

The same idea for a message channel: `openmsg`/`waitmsg`, `wrmsg`,
`rdmsg`, `clsmsg`, and the message-side certificate queries. The
destructor closes what is held; opening over a held channel lets the
old one go.

Both hold handles, not hooks -- any number may exist. A mail program
holds one net for IMAP and another for SMTP.

## Packaged and verified

Beside the other wrappers in every core and the shared libraries; full
`make` clean. Verified live over the loopback with the server on a
**services thread object** (the wrappers composing): clear stream
exchange with the client opened by name; TLS exchange with the
certificate fetched raw and decoded through the object, the committed
test CA found in the chain; message exchange through a msg pair; every
connection closed by its destructor. All pass, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)