### PR TITLE
hpp: one spelling for the headers

### DIFF
--- a/hpp/network
+++ b/hpp/network
@@ -1,1 +1,0 @@
-network.hpp

--- a/hpp/services
+++ b/hpp/services
@@ -1,1 +1,0 @@
-services.hpp

--- a/hpp/sound
+++ b/hpp/sound
@@ -1,1 +1,0 @@
-sound.hpp

--- a/hpp/terminal
+++ b/hpp/terminal
@@ -1,1 +1,0 @@
-terminal.hpp


### PR DESCRIPTION
The four extensionless header names (`hpp/terminal`, `hpp/sound`,
`hpp/services`, `hpp/network`) were symlinks to the `.hpp` files,
enabling `#include <terminal>` in the standard-library manner. Removed:

- symlinks interfere with copying and archiving;
- worse, a Windows git checkout without symlink privileges materializes
  each as a plain text file *containing the target's name*, which the
  compiler will then include as source -- a baffling failure on a
  platform this tree targets;
- and the compiler does not add extensions, so without them the
  extensionless spelling simply has one honest form: `terminal.hpp`.

Nothing in the tree used the extensionless spelling (verified by grep;
snake++ and the full build confirm). The manual note that suggested it
is withdrawn on the doc branch (#237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)