### PR TITLE
cpp: the wrapper objects refuse to be copied

### DIFF
--- a/hpp/graphics.hpp
+++ b/hpp/graphics.hpp
@@ -745,6 +745,10 @@ graph();
 /* destructor */
 ~graph();
 
+/* copying is refused: two objects would free one event hook */
+graph(const graph&) = delete;
+graph& operator=(const graph&) = delete;
+
 /* methods */
 
 /* text */
@@ -1114,6 +1118,10 @@ window(window* parent);
 /* destructor */
 virtual ~window();
 
+/* copying is refused: two objects would free one window */
+window(const window&) = delete;
+window& operator=(const window&) = delete;
+
 /* the window, for the stdio calls and the C interface */
 operator FILE*(void);
 
@@ -1405,6 +1413,10 @@ public:
 
 /* destructor: kills the widget */
 virtual ~widget();
+
+/* copying is refused: two objects would free one widget */
+widget(const widget&) = delete;
+widget& operator=(const widget&) = delete;
 
 /* the widget id */
 long id(void);

--- a/hpp/network.hpp
+++ b/hpp/network.hpp
@@ -88,6 +88,10 @@ net();
 /* destructor */
 ~net();
 
+/* copying is refused: two objects would free one connection */
+net(const net&) = delete;
+net& operator=(const net&) = delete;
+
 /* methods */
 void opennet(unsigned long addr, long port, long secure = 0);
 void opennet(const char* name, long port, long secure = 0);
@@ -116,6 +120,10 @@ msg();
 
 /* destructor */
 ~msg();
+
+/* copying is refused: two objects would free one channel */
+msg(const msg&) = delete;
+msg& operator=(const msg&) = delete;
 
 /* methods */
 void openmsg(unsigned long addr, long port, long secure = 0);

--- a/hpp/services.hpp
+++ b/hpp/services.hpp
@@ -192,6 +192,10 @@ thread(void (*threadmain)(void));
 /* the identifier, as newthread returned it */
 long id(void);
 
+/* copying is refused: two objects would free one identifier */
+thread(const thread&) = delete;
+thread& operator=(const thread&) = delete;
+
 }; /* class thread */
 
 class mutex {
@@ -207,6 +211,10 @@ mutex();
 
 /* destructor */
 ~mutex();
+
+/* copying is refused: two objects would free one lock */
+mutex(const mutex&) = delete;
+mutex& operator=(const mutex&) = delete;
 
 /* methods */
 void lock(void);
@@ -225,6 +233,10 @@ signal();
 
 /* destructor */
 ~signal();
+
+/* copying is refused: two objects would free one signal */
+signal(const signal&) = delete;
+signal& operator=(const signal&) = delete;
 
 /* methods */
 void sendsig(void);

--- a/hpp/sound.hpp
+++ b/hpp/sound.hpp
@@ -448,6 +448,10 @@ synth();
 /* destructor */
 ~synth();
 
+/* copying is refused: two objects would free one port pair */
+synth(const synth&) = delete;
+synth& operator=(const synth&) = delete;
+
 /* methods */
 void opensynthout(long p = synth_out);
 void closesynthout(void);
@@ -503,6 +507,10 @@ wave();
 
 /* destructor */
 ~wave();
+
+/* copying is refused: two objects would free one port pair */
+wave(const wave&) = delete;
+wave& operator=(const wave&) = delete;
 
 /* methods */
 void openwaveout(long p = wave_out);

--- a/hpp/terminal.hpp
+++ b/hpp/terminal.hpp
@@ -269,6 +269,10 @@ term();
 /* destructor */
 ~term();
 
+/* copying is refused: two objects would free one event hook */
+term(const term&) = delete;
+term& operator=(const term&) = delete;
+
 /* methods */
 void cursor(long x, long y);
 long  maxx(void);


### PR DESCRIPTION
Found in discussion of how far the RAII model can be trusted: every
wrapper class had a destructor and none had copy control -- the classic
Rule of Three violation. The default memberwise copy meant:

```cpp
mutex b = a;    /* two objects, one lock id -> deinitlock twice   */
net   d = c;    /* two objects, one FILE*  -> fclose twice        */
term  u = t;    /* the event chain restored twice                 */
```

-- with the second free landing on an identifier the library may
already have reissued.

Copy construction and copy assignment are now `= delete` in all eleven
classes: `term`, `graph`, `window`, `widget` (whose base seals the
sixteen typed widget classes with it), `synth`, `wave`, `thread`,
`mutex`, `signal`, `net`, `msg`. Each carries a one-line comment naming
the resource a copy would double-free.

Verified both directions: eight representative copy attempts each fail
at compile time specifically as "use of deleted function" (the first
test harness had a syntax error that made everything "fail" -- caught
and redone honestly), and plain use of every class compiles unchanged.
Full `make` clean; `snake++` and `winobj` build.

The remaining holes of the model (exit() skipping local destructors,
longjmp skipping scopes, malloc bypassing constructors, cross-thread
lifetime) are the language's price and are documented in discussion --
this was the one that was simply an omission, and the checkable kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)